### PR TITLE
Support complex equations

### DIFF
--- a/src/equations.jl
+++ b/src/equations.jl
@@ -50,10 +50,19 @@ Base.:~(lhs::Symbolic, rhs::Any    ) = Equation(value(lhs), value(rhs))
 Base.:~(lhs::Any, rhs::Symbolic    ) = Equation(value(lhs), value(rhs))
 for T in [:Num, :Complex, :Number], S in [:Num, :Complex, :Number]
     (T != :Complex && S != :Complex) && continue
-    @eval Base.:~(a::$T, b::$S) = [
-      (isa(value(real(a)), Number) && isa(value(real(b)), Number)) ? [] : value(real(a)) ~ value(real(b));
-      (isa(value(imag(a)), Number) && isa(value(imag(b)), Number)) ? [] : value(imag(a)) ~ value(imag(b))
-    ]
+    @eval Base.:~(a::$T, b::$S) = let ar = value(real(a)), br = value(real(b)),
+                                      ai = value(imag(a)), bi = value(imag(b))
+        if ar isa Number && br isa Number && ai isa number && bi isa Number
+          error("Equation $a ~ $b does not contain any symbols")
+        elseif ar isa Number && br isa Number
+            ai ~ bi
+        elseif ai isa Number && bi isa Number
+            ar ~ br
+        else
+            [ar ~ br
+            ai ~ bi]
+        end
+    end
 end
 
 struct ConstrainedEquation

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -53,7 +53,7 @@ for T in [:Num, :Complex, :Number], S in [:Num, :Complex, :Number]
     @eval Base.:~(a::$T, b::$S) = let ar = value(real(a)), br = value(real(b)),
                                       ai = value(imag(a)), bi = value(imag(b))
         if ar isa Number && br isa Number && ai isa number && bi isa Number
-          error("Equation $a ~ $b does not contain any symbols")
+            error("Equation $a ~ $b does not contain any symbols")
         elseif ar isa Number && br isa Number
             ai ~ bi
         elseif ai isa Number && bi isa Number

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -48,6 +48,13 @@ Base.:~(lhs::Number    , rhs::Num) = Equation(value(lhs), value(rhs))
 Base.:~(lhs::Symbolic, rhs::Symbolic) = Equation(value(lhs), value(rhs))
 Base.:~(lhs::Symbolic, rhs::Any    ) = Equation(value(lhs), value(rhs))
 Base.:~(lhs::Any, rhs::Symbolic    ) = Equation(value(lhs), value(rhs))
+for T in [:Num, :Complex, :Number], S in [:Num, :Complex, :Number]
+    (T != :Complex && S != :Complex) && continue
+    @eval Base.:~(a::$T, b::$S) = [
+      (isa(value(real(a)), Number) && isa(value(real(b)), Number)) ? [] : value(real(a)) ~ value(real(b));
+      (isa(value(imag(a)), Number) && isa(value(imag(b)), Number)) ? [] : value(imag(a)) ~ value(imag(b))
+    ]
+end
 
 struct ConstrainedEquation
   constraints

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -127,6 +127,11 @@ z2 = c + d * im
 @test isequal(2 - z1, Complex(2 - a, -b))
 @test isequal(z1 ^ 2, a^2 - b^2 + 2a*b*im)
 
+@test isequal((0 ~ a+0*im), [0 ~ a])
+@test isequal((im ~ b+c*im), [0 ~ b; 1 ~ c])
+@test isequal((0 ~ z1), [0 ~ a, 0 ~ b])
+@test isequal((z1 ~ z2), [a ~ c, b ~ d])
+
 @test a + im === Complex(a, Num(true))
 @test real(a) === a
 @test conj(a) === a

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -127,7 +127,7 @@ z2 = c + d * im
 @test isequal(2 - z1, Complex(2 - a, -b))
 @test isequal(z1 ^ 2, a^2 - b^2 + 2a*b*im)
 
-@test isequal((0 ~ a+0*im), [0 ~ a])
+@test isequal((0 ~ a+0*im), 0 ~ a)
 @test isequal((im ~ b+c*im), [0 ~ b; 1 ~ c])
 @test isequal((0 ~ z1), [0 ~ a, 0 ~ b])
 @test isequal((z1 ~ z2), [a ~ c, b ~ d])


### PR DESCRIPTION
This is a retake of https://github.com/SciML/ModelingToolkit.jl/pull/795 based on an idea by @YingboMa that an equation of complex numbers should return a list of two equations for the real and imaginary part.

I've added some code such that if the concrete type inside the `Num` on neither side is symbolic, no equation is generated for that. This prevents code like `im*a ~ im*b` from generating `0 ~ 0` for the real part. Currently there is no safeguard against writing `1*im ~ 2*im` which will simply generate no equations at all.

On my end `@test real(a) === a` is broken, but this is not due to anything I did.