### PR TITLE
Tweak register to avoid error

### DIFF
--- a/src/extra_functions.jl
+++ b/src/extra_functions.jl
@@ -42,6 +42,11 @@ derivative(::typeof(IfElse.ifelse), args::NTuple{3,Any}, ::Val{3}) = IfElse.ifel
 @register ∈(x::Num, y::AbstractArray)
 @register ∪(x, y)
 @register ∩(x, y)
+
+function ∨ end
+function ∧ end
+function ⊆ end
+
 @register ∨(x, y)
 @register ∧(x, y)
 @register ⊆(x, y)

--- a/src/register.jl
+++ b/src/register.jl
@@ -39,7 +39,7 @@ macro register(expr, define_promotion = true, Ts = [Num, Symbolic, Real])
     ex = Expr(:block)
     for ts in types
         push!(ex.args, quote
-            function (::$typeof($f))($(setinds(args, symbolic_args, ts)...))
+            function (::$(Core.Typeof)($f))($(setinds(args, symbolic_args, ts)...))
                 wrap =  any(x->typeof(x) <: Num, tuple($(setinds(args, symbolic_args, ts)...),)) ? Num : identity
                 wrap($Term{$ret_type}($f, [$(map(name, args)...)]))
             end

--- a/src/register.jl
+++ b/src/register.jl
@@ -39,7 +39,7 @@ macro register(expr, define_promotion = true, Ts = [Num, Symbolic, Real])
     ex = Expr(:block)
     for ts in types
         push!(ex.args, quote
-            function $f($(setinds(args, symbolic_args, ts)...))
+            function (::$typeof($f))($(setinds(args, symbolic_args, ts)...))
                 wrap =  any(x->typeof(x) <: Num, tuple($(setinds(args, symbolic_args, ts)...),)) ? Num : identity
                 wrap($Term{$ret_type}($f, [$(map(name, args)...)]))
             end

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -142,7 +142,7 @@ canonequal(a, b) = isequal(simplify(a), simplify(b))
                  Symbolics.derivative(sin(cos(x)), x),
                  -sin(x) * cos(cos(x))
                 )
-
+function no_der end
 Symbolics.@register no_der(x)
 @test canonequal(
                  Symbolics.derivative([sin(cos(x)), hypot(x, no_der(x))], x),
@@ -152,6 +152,7 @@ Symbolics.@register no_der(x)
                  ]
                 )
 
+function intfun end
 Symbolics.@register intfun(x)::Int
 @test Symbolics.symtype(intfun(x)) === Int
 


### PR DESCRIPTION
(very sorry I accidentally committed to master when I was originally making this tweak)

I think this is a better way to define `@register` because it'll work more gracefully with a wider class of user provided functions. For instance, before this change:


```julia
julia> using ModelingToolkit

julia> f = (x) -> x + 1
#4 (generic function with 1 method)

julia> @register f(x)
ERROR: cannot define function f; it already has a value
Stacktrace:
 [1] top-level scope
   @ none:0
 [2] top-level scope
   @ ~/.julia/packages/Symbolics/HUlQv/src/register.jl:42
```

and after:


```julia
julia> f = x -> x + 1
#6 (generic function with 1 method)

julia> @register f(x)

julia> @syms x;

julia> f(x)
var"#6#7"()(x)
```

Not exactly nice printing, but at least it works.

One potential danger is that it makes accidental piracy easy:


```julia
julia> module Foo

       bar(x) = x + 1
       export bar

       end

julia> using .Foo

julia> @register bar(x)

julia> bar(x)
Main.Foo.bar(x)
```



┆Issue is synchronized with this [Trello card](https://trello.com/c/QyJJyVsY) by [Unito](https://www.unito.io)
