### PR TITLE
call unflatten_long_ops in _set_array

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -321,7 +321,7 @@ function _set_array(out, outputidxs, rhss::AbstractArray, checkbounds, skipzeros
     ii = findall(i->!(rhss[i] isa AbstractArray) && !(skipzeros && _iszero(rhss[i])), eachindex(outputidxs))
     jj = findall(i->rhss[i] isa AbstractArray, eachindex(outputidxs))
     exprs = []
-    push!(exprs, SetArray(!checkbounds, out, AtIndex.(vec(collect(outputidxs[ii])), vec(rhss[ii]))))
+    push!(exprs, SetArray(!checkbounds, out, AtIndex.(vec(collect(outputidxs[ii])), unflatten_long_ops.(vec(rhss[ii])))))
     for j in jj
         push!(exprs, _set_array(LiteralExpr(:($out[$j])), nothing, rhss[j], checkbounds, skipzeros))
     end

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -321,7 +321,12 @@ function _set_array(out, outputidxs, rhss::AbstractArray, checkbounds, skipzeros
     ii = findall(i->!(rhss[i] isa AbstractArray) && !(skipzeros && _iszero(rhss[i])), eachindex(outputidxs))
     jj = findall(i->rhss[i] isa AbstractArray, eachindex(outputidxs))
     exprs = []
-    push!(exprs, SetArray(!checkbounds, out, AtIndex.(vec(collect(outputidxs[ii])), unflatten_long_ops.(vec(rhss[ii])))))
+    rhss_scalar = unflatten_long_ops.(vec(rhss[ii]))
+    setterexpr = SetArray(!checkbounds,
+                          out,
+                          AtIndex.(vec(collect(outputidxs[ii])),
+                                   rhss_scalar))
+    push!(exprs, setterexpr)
     for j in jj
         push!(exprs, _set_array(LiteralExpr(:($out[$j])), nothing, rhss[j], checkbounds, skipzeros))
     end


### PR DESCRIPTION
Restores the BCR benchmark in https://github.com/SciML/ModelingToolkit.jl/issues/553