### PR TITLE
Automatically latexify AbstractArray{Num}

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -28,6 +28,7 @@ end
 Base.show(io::IO, ::MIME"text/latex", x::Num) = print(io, latexify(x))
 Base.show(io::IO, ::MIME"text/latex", x::Symbolic) = print(io, latexify(x))
 Base.show(io::IO, ::MIME"text/latex", x::Vector{Equation}) = print(io, latexify(x))
+Base.show(io::IO, ::MIME"text/latex", x::AbstractArray{Num}) = print(io, latexify(x))
 
 # `_toexpr` is only used for latexify
 function _toexpr(O; canonicalize=true)


### PR DESCRIPTION
Extension of https://github.com/SciML/ModelingToolkit.jl/pull/726. Ref: https://github.com/JuliaSymbolics/Symbolics.jl/issues/41

With this PR, any `AbstractArray{Num}` will automatically latexified (if possible).
<img width="271" alt="Screenshot 2021-03-04 at 22 51 10" src="https://user-images.githubusercontent.com/187980/110035599-2cea6280-7d3c-11eb-980b-0a54a6c4bdf5.png">

(This is the default for SymPy as well.)