### PR TITLE
WIP: low-overhead batched threading

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -53,6 +53,8 @@ include("diff.jl")
 
 include("linear_algebra.jl")
 
+include("thread_utils.jl")
+
 import Libdl
 include("build_function.jl")
 export build_function

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -1,5 +1,6 @@
 using SymbolicUtils.Code
 using Base.Threads
+using ThreadingUtilities
 
 abstract type BuildTargets end
 struct JuliaTarget <: BuildTargets end

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -293,6 +293,8 @@ function set_array(s::SerialForm, closed_vars, args...)
     _set_array(args...)
 end
 
+@inline noop(args...) = nothing
+
 function set_array(s::MultithreadedForm, closed_args, out, outputidxs, rhss, checkbounds, skipzeros)
     if rhss isa AbstractSparseArray
         return set_array(LiteralExpr(:($out.nzval)),
@@ -312,10 +314,8 @@ function set_array(s::MultithreadedForm, closed_args, out, outputidxs, rhss, che
         Func([out, closed_args...], [],
              _set_array(out, idxs, vals, checkbounds, skipzeros)), [out, closed_args...]
     end
-    SpawnFetch{MultithreadedForm}(ClosureExpr.(first.(arrays), last.(arrays), (Nothing,)), noop)
+    SpawnFetch{MultithreadedForm}(ClosureExpr.(first.(arrays), last.(arrays), Nothing), noop)
 end
-
-@inline noop(args...) = nothing
 
 function _set_array(out, outputidxs, rhss::AbstractArray, checkbounds, skipzeros)
     if outputidxs === nothing

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -255,9 +255,9 @@ function toexpr(p::SpawnFetch{MultithreadedForm}, st)
     end
 
     quote
-        $spawn_fetch(($(ex...),),
-                     Val{$(Threads.nthreads())}(),
-                     $(toexpr(p.combine, st)))
+        $spawn_fetch_serial(($(ex...),),
+                            Val{$(Threads.nthreads())}(),
+                            $(toexpr(p.combine, st)))
     end
 end
 

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -312,8 +312,10 @@ function set_array(s::MultithreadedForm, closed_args, out, outputidxs, rhss, che
         Func([out, closed_args...], [],
              _set_array(out, idxs, vals, checkbounds, skipzeros)), [out, closed_args...]
     end
-    SpawnFetch{MultithreadedForm}(ClosureExpr.(first.(arrays), last.(arrays)), @inline noop(args...) = nothing)
+    SpawnFetch{MultithreadedForm}(ClosureExpr.(first.(arrays), last.(arrays), (Nothing,)), noop)
 end
+
+@inline noop(args...) = nothing
 
 function _set_array(out, outputidxs, rhss::AbstractArray, checkbounds, skipzeros)
     if outputidxs === nothing

--- a/src/thread_utils.jl
+++ b/src/thread_utils.jl
@@ -34,7 +34,7 @@ function setup_call!(p, f, args, resref)
     resptr = Base.unsafe_convert(Ptr{eltype(resref)}, resref)
     argptr = Base.unsafe_convert(Ptr{args_type(f)}, args)
     offset = ThreadingUtilities.store!(p, fp, sizeof(UInt))
-    offset = ThreadingUtilities.store!(p, (argptr, resptr), offset)
+    ThreadingUtilities.store!(p, (argptr, resptr), offset)
 end
 
 @inline function launch_call!(tid, f::RGFWrap, args, resref)
@@ -94,7 +94,7 @@ end
     quote
         rs = Base.@ntuple $N i->Ref{output_type(fs[i])}()
         argrefs = Base.@ntuple $N i->Ref(fs[i].args)
-        GC.@preserve fs rs argrefs begin
+        GC.@preserve rs argrefs begin
             $(batches...)
         end
         return Base.@ntuple $N i->rs[i][]
@@ -107,7 +107,7 @@ function spawn_fetch_nonstatic(fs, g=tuple)
 
     nt = Threads.nthreads()
     ts = 1:nt-1
-    GC.@preserve fs rs argrefs begin
+    GC.@preserve rs argrefs begin
         for batch in Iterators.partition(1:length(fs),
                                          length(ts))
             for (t, i) in enumerate(batch)
@@ -120,3 +120,67 @@ function spawn_fetch_nonstatic(fs, g=tuple)
     end
     return g(map(r->r[], rs)...)
 end
+
+
+const DEBUGBUF = zeros(UInt, 64)
+@generated function spawn_fetch_debug(fs::NTuple{N,Any}, ::Val{nt}, g=tuple) where {nt, N}
+
+    ts = 1:nt
+    batches = map(Iterators.partition(1:N, nt)) do batch
+         # one batch of spawns
+         launches = map(ts) do t
+             if t > length(batch)
+                 return
+             end
+             i = batch[t]
+             if t == nt
+                 :(rs[$i][] = fs[$i]())
+             else
+                 quote
+                    setup_call!(p,
+                                fs[$i].f,
+                                argrefs[$i],
+                                rs[$i])
+                    fs[$i].f(p)
+                end
+             end
+         end
+
+         quote
+             $(launches...)
+         end
+     end
+
+    quote
+        rs = Base.@ntuple $N i->Ref{output_type(fs[i])}()
+        argrefs = Base.@ntuple $N i->Ref(fs[i].args)
+        p = Base.unsafe_convert(Ptr{UInt}, DEBUGBUF)
+        GC.@preserve rs argrefs begin
+            $(batches...)
+        end
+        return Base.@ntuple $N i->rs[i][]
+    end
+end
+
+#=
+function spawn_fetch_debug(fs, g=tuple)
+    rs = map(f->Ref{output_type(f)}(), fs)
+    argrefs = map(f->Ref(f.args), fs)
+
+    nt = Threads.nthreads()
+    ts = 1:nt-1
+    arr = zeros(UInt, 64)
+    GC.@preserve arr fs rs argrefs begin
+        for batch in Iterators.partition(1:length(fs),
+                                         length(ts))
+            for (t, i) in enumerate(batch)
+                fill!(arr, 0)
+                p = Base.unsafe_convert(Ptr{UInt}, arr)
+                setup_call!(p, fs[i].f, argrefs[i], rs[i])
+                fs[i].f(p)
+            end
+        end
+    end
+    return g(map(r->r[], rs)...)
+end
+=#

--- a/src/thread_utils.jl
+++ b/src/thread_utils.jl
@@ -13,8 +13,20 @@ function (f::RGFWrap{F, Args, T})(p::Ptr{UInt}) where {Args, F, T}
     nothing
 end
 
-@inline function fptr(f::RGFWrap)
-    @cfunction($f, Cvoid, (Ptr{UInt},))
+const Cf = @cfunction($sin, Float64, (Float64,))
+
+@generated function fptr(f::RGFWrap{F}) where {F}
+    if F <: RuntimeGeneratedFunction
+        instance = f(F(Expr(:block))) # HACK
+        cf = @cfunction($instance, Cvoid, (Ptr{UInt},))
+        quote
+            $(Expr(:meta, :inline))
+            $cf
+        end
+    else
+        instance = f(F.instance)
+        @cfunction($instance, Cvoid, (Ptr{UInt},))
+    end
 end
 
 struct Funcall{F, Args, outT}
@@ -27,13 +39,13 @@ end
 
 output_type(f::Funcall{F, Args, outT}) where {F, Args, outT} = outT
 
-@inline function Funcall(f::F, args::Args, outT=Base.return_types(f, Args)[1]) where {F,Args}
+@inline function Funcall(f::F, args::Args, outT) where {F,Args}
     g = RGFWrap{F, Args, outT}(f)
     Funcall{F, Args, outT}(g, args, fptr(g))
 end
 
-function setup_call!(p, f, cfunc, args, resref)
-    fp = Base.unsafe_convert(Ptr{Cvoid}, cfunc)
+@inline function setup_call!(p, f, cfunc, args, resref)
+    fp = Base.unsafe_convert(Ptr{Nothing}, cfunc)
     resptr = Base.unsafe_convert(Ptr{eltype(resref)}, resref)
     argptr = Base.unsafe_convert(Ptr{args_type(f)}, args)
     offset = ThreadingUtilities.store!(p, fp, sizeof(UInt))
@@ -113,7 +125,7 @@ end
 end
 
 function spawn_fetch_serial(fs::NTuple{N,Any}, ::Val, g=tuple) where {N}
-    ntuple(i->fs[i](), Val{N}())
+    ntuple(i->fs[i].f.f(fs[i].args...), Val{N}())
 end
 
 function spawn_fetch_nonstatic(fs, g=tuple)
@@ -154,6 +166,7 @@ const DEBUGBUF = zeros(UInt, 64)
                  quote
                     setup_call!(p,
                                 fs[$i].f,
+                                fs[$i].cfunc,
                                 argrefs[$i],
                                 rs[$i])
                     fs[$i].f(p)

--- a/src/thread_utils.jl
+++ b/src/thread_utils.jl
@@ -58,6 +58,7 @@ end
         end
     end
 end
+
 @inline @generated function spawn_fetch(fs::NTuple{N,Any}, ::Val{nt}, g=tuple) where {nt, N}
 
     ts = 1:nt
@@ -109,6 +110,10 @@ end
         end
         return Base.@ntuple $N i->res_i[]
     end
+end
+
+function spawn_fetch_serial(fs::NTuple{N,Any}, ::Val, g=tuple) where {N}
+    ntuple(i->fs[i](), Val{N}())
 end
 
 function spawn_fetch_nonstatic(fs, g=tuple)

--- a/src/thread_utils.jl
+++ b/src/thread_utils.jl
@@ -1,0 +1,100 @@
+using ThreadingUtilities
+
+struct RGFWrap{F, Args, T}
+    f::F
+end
+@inline args_type(f::RGFWrap{F,Args}) where {F, Args} = Args
+
+function (f::RGFWrap{F, Args, T})(p::Ptr{UInt}) where {Args, F, T}
+    _, (argsptr, resptr) = ThreadingUtilities.load(p, Tuple{Ptr{Args}, Ptr{T}}, 2*sizeof(UInt))
+    res = f.f(unsafe_load(argsptr)...)
+    unsafe_store!(resptr, res)
+    nothing
+end
+
+@inline function fptr(f::RGFWrap)
+    @cfunction($f, Cvoid, (Ptr{UInt},))
+end
+
+struct Funcall{F, Args, outT}
+    f::RGFWrap{F, Args, outT}
+    args::Args
+end
+
+(f::Funcall)() = f.f.f(f.args...)
+
+output_type(f::Funcall{F, Args, outT}) where {F, Args, outT} = outT
+
+@inline function Funcall(f::F, args::Args, outT=Base.return_types(f, Args)[1]) where {F,Args}
+    Funcall{F, Args, outT}(RGFWrap{F, Args, outT}(f), args)
+end
+
+function setup_call!(p, f, args, resref)
+    fp = Base.unsafe_convert(Ptr{Cvoid}, fptr(f))
+    resptr = Base.unsafe_convert(Ptr{eltype(resref)}, resref)
+    argptr = Base.unsafe_convert(Ptr{args_type(f)}, args)
+    offset = ThreadingUtilities.store!(p, fp, sizeof(UInt))
+    offset = ThreadingUtilities.store!(p, (argptr, resptr), offset)
+end
+
+@inline function launch_call!(tid, f::RGFWrap, args, resref)
+    p = ThreadingUtilities.taskpointer(tid)
+    while true
+        if ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.SPIN, ThreadingUtilities.STUP)
+            setup_call!(p, f, args, resref)
+            @assert ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.STUP, ThreadingUtilities.TASK)
+            return
+        elseif ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.WAIT, ThreadingUtilities.STUP)
+            setup_call!(p, f, args, resref)
+            @assert ThreadingUtilities._atomic_cas_cmp!(p, ThreadingUtilities.STUP, ThreadingUtilities.LOCK)
+            ThreadingUtilities.wake_thread!(tid % UInt)
+            return
+        end
+        ThreadingUtilities.pause()
+    end
+end
+@generated function spawn_fetch(fs::NTuple{N,Any}, ::Val{nt}, g=tuple) where {nt, N}
+
+    ts = 1:nt-1
+    batches = map(Iterators.partition(1:N, nt-1)) do batch
+         # one batch of spawns
+         quote
+             $([:(launch_call!($(ts[t]),
+                               fs[$i].f,
+                               argrefs[$i],
+                               rs[$i]))
+                for (t, i) in enumerate(batch)]...)
+             $([:(ThreadingUtilities.__wait($(ts[t])))
+                for (t, i) in enumerate(batch)]...)
+         end
+     end
+
+    quote
+        rs = Base.@ntuple $N i->Ref{output_type(fs[i])}()
+        argrefs = Base.@ntuple $N i->Ref(fs[i].args)
+        GC.@preserve rs argrefs begin
+            $(batches...)
+        end
+        return Base.@ntuple $N i->rs[i][]
+    end
+end
+
+function spawn_fetch_nonstatic(fs, g=tuple)
+    rs = map(f->Ref{output_type(f)}(), fs)
+    argrefs = map(f->Ref(f.args), fs)
+
+    nt = Threads.nthreads()
+    ts = 1:nt-1
+    GC.@preserve rs argrefs begin
+        for batch in Iterators.partition(1:length(fs),
+                                         length(ts))
+            for (t, i) in enumerate(batch)
+                launch_call!(ts[t], fs[i].f, argrefs[i], rs[i])
+            end
+            for (t, i) in enumerate(batch)
+                ThreadingUtilities.__wait(t)
+            end
+        end
+    end
+    return g(map(r->r[], rs)...)
+end


### PR DESCRIPTION
This reduces the overhead for each task to nanoseconds from a few micro seconds, but we don't have a work-stealing scheduler. We just wait for nthreads() number of work items at a time.  So it's a tradeoff.

Thanks to ChrisElrod for ThreadingUtilities and helping us to start using it!



┆Issue is synchronized with this [Trello card](https://trello.com/c/VhFjNosx) by [Unito](https://www.unito.io)
