### PR TITLE
Unwrap `Num` values in substitute

### DIFF
--- a/src/num.jl
+++ b/src/num.jl
@@ -60,7 +60,14 @@ function Base.show(io::IO, z::Complex{<:Num})
 end
 
 SymbolicUtils.simplify(n::Num; kw...) = Num(SymbolicUtils.simplify(value(n); kw...))
-substitute(x::Num, rule; kw...) = Num(substitute(value(x), rule; kw...))
+function substitute(x::Num, rule::Dict; kw...)
+    rule′ = if any(v -> v isa Num, values(rule))
+        Dict((k => v isa Num ? value(v) : v for (k, v) in rule))
+    else
+        rule
+    end
+    Num(substitute(value(x), rule′; kw...))
+end
 
 SymbolicUtils.symtype(n::Num) = symtype(n.val)
 

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -198,3 +198,9 @@ reference_hes = Symbolics.hessian(rr, X)
 sp_hess = Symbolics.sparsehessian(rr, X)
 @test findnz(sparse(reference_hes))[1:2] == findnz(sp_hess)[1:2]
 @test isequal(map(spoly, findnz(sparse(reference_hes))[3]), map(spoly, findnz(sp_hess)[3]))
+
+#96
+@variables t x[1:4](t) ẋ[1:4](t)
+expression = sin(x[1] + x[2] + x[3] + x[4]) |> Differential(t) |> expand_derivatives
+expression2 = substitute(expression, Dict(Differential(t).(x) .=> ẋ))
+@test isequal(expression2, (ẋ[1] + ẋ[2] + ẋ[3] + ẋ[4])*cos(x[1] + x[2] + x[3] + x[4]))


### PR DESCRIPTION
Fixes https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/223

We were accidentally rewriting stuff into `Num`s which was causing all sorts of mayhem because `Num <: Number`. 