### PR TITLE
Handle norm(::Num)

### DIFF
--- a/src/extra_functions.jl
+++ b/src/extra_functions.jl
@@ -45,3 +45,5 @@ derivative(::typeof(IfElse.ifelse), args::NTuple{3,Any}, ::Val{3}) = IfElse.ifel
 @register ∨(x, y)
 @register ∧(x, y)
 @register ⊆(x, y)
+
+LinearAlgebra.norm(x::Num, p::Real) = abs(x)


### PR DESCRIPTION
Specializes on Num <: Number so it will be something to make note of with array symbolics