### PR TITLE
CTarget inputs defined as const

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -535,7 +535,7 @@ function _build_function(target::CTarget, ex::AbstractArray, args...;
         end
     end
 
-    argstrs = join(vcat("double* $(lhsname)",[typeof(args[i])<:Array ? "double* $(rhsnames[i])" : "double $(rhsnames[i])" for i in 1:length(args)]),", ")
+    argstrs = join(vcat("double* $(lhsname)",[typeof(args[i])<:Array ? "const double* $(rhsnames[i])" : "const double $(rhsnames[i])" for i in 1:length(args)]),", ")
 
     ccode = """
     #include <math.h>

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -128,7 +128,7 @@ let # Symbolics.jl#123
     str = build_function(output_eq, x, target=Symbolics.CTarget())
     @test str == """
     #include <math.h>
-    void diffeqf(double* du, double* RHS1) {
+    void diffeqf(double* du, const double* RHS1) {
       du[0] = qd₁ * u * (M₁ * qd₁ + M₁ * qd₃ + M₁ * qd₄ + M₂₅ * qd₅ + M₃₁ * qd₆ + M₇ * qd₂);
     }
     """

--- a/test/build_targets.jl
+++ b/test/build_targets.jl
@@ -17,7 +17,7 @@ expr = [a*x - x*y,-3y + x*y]
                                      rhsnames=[:internal_var___u,:internal_var___p,:t]) ==
   """
   #include <math.h>
-  void diffeqf(double* internal_var___du, double* internal_var___u, double* internal_var___p, double t) {
+  void diffeqf(double* internal_var___du, const double* internal_var___u, const double* internal_var___p, const double t) {
     internal_var___du[0] = internal_var___p[0] * internal_var___u[0] + -1 * internal_var___u[0] * internal_var___u[1];
     internal_var___du[1] = internal_var___u[0] * internal_var___u[1] + -3 * internal_var___u[1];
   }
@@ -66,7 +66,7 @@ let
     cfunc      = build_function(expression, variables; target = Symbolics.CTarget(), expression = Val{true})
 
     # Generated function should be out[0] = in[0], out[1] = in[1], out[2] = in[2], etc.
-    @test cfunc == "#include <math.h>\nvoid diffeqf(double* du, double* RHS1) {\n  du[0] = RHS1[0];\n  du[1] = RHS1[1];\n  du[2] = RHS1[2];\n  du[3] = RHS1[3];\n  du[4] = RHS1[4];\n  du[5] = RHS1[5];\n  du[6] = RHS1[6];\n  du[7] = RHS1[7];\n  du[8] = RHS1[8];\n  du[9] = RHS1[9];\n  du[10] = RHS1[10];\n  du[11] = RHS1[11];\n}\n"
+    @test cfunc == "#include <math.h>\nvoid diffeqf(double* du, const double* RHS1) {\n  du[0] = RHS1[0];\n  du[1] = RHS1[1];\n  du[2] = RHS1[2];\n  du[3] = RHS1[3];\n  du[4] = RHS1[4];\n  du[5] = RHS1[5];\n  du[6] = RHS1[6];\n  du[7] = RHS1[7];\n  du[8] = RHS1[8];\n  du[9] = RHS1[9];\n  du[10] = RHS1[10];\n  du[11] = RHS1[11];\n}\n"
 end
 
 # Scalar CTarget test
@@ -76,7 +76,7 @@ let
     cfunc = build_function(expression, [x], [y], t; target = Symbolics.CTarget(), expression = Val{true})
 
     # Generated function should be out[0] = in1[0] + in2[0] + in3
-    @test cfunc == "#include <math.h>\nvoid diffeqf(double* du, double* RHS1, double* RHS2, double RHS3) {\n  du[0] = RHS3 + RHS1[0] + RHS2[0];\n}\n"
+    @test cfunc == "#include <math.h>\nvoid diffeqf(double* du, const double* RHS1, const double* RHS2, const double RHS3) {\n  du[0] = RHS3 + RHS1[0] + RHS2[0];\n}\n"
 end
 
 # Scalar CTarget test with scalar multiplication and powers
@@ -86,7 +86,7 @@ let
   cfunc = build_function(expression, [x, y], [a], t; target = Symbolics.CTarget(), expression = Val{true})
 
   # Generated function should avoid scalar multiplication of the form "4t" (currently done by adding another "* 1") and other invalid C syntax
-  @test cfunc == "#include <math.h>\nvoid diffeqf(double* du, double* RHS1, double* RHS2, double RHS3) {\n  du[0] = 2 * RHS3 * 1 + pow(RHS1[0], 2) + 1.0 / RHS1[1] + pow(sin(RHS2[0]), 3.5);\n}\n"
+  @test cfunc == "#include <math.h>\nvoid diffeqf(double* du, const double* RHS1, const double* RHS2, const double RHS3) {\n  du[0] = 2 * RHS3 * 1 + pow(RHS1[0], 2) + 1.0 / RHS1[1] + pow(sin(RHS2[0]), 3.5);\n}\n"
 end
 
 


### PR DESCRIPTION
Closes #119 

Feel free to close / not merge. This behavior makes sense to me, but I'm not sure what behavior y'all want for `build_function(...; target=CTarget())` calls. 

This PR designates all function inputs (every function argument that is __not__ the first "output" argument) as `const` in generated C functions. To my knowledge, this already matches `build_function` behavior, since function inputs are not modified in any generated `build_function` code. 

Tests should pass. I just rebased this over the latest `master` branch.