### PR TITLE
Add complex overloads for division

### DIFF
--- a/src/num.jl
+++ b/src/num.jl
@@ -36,6 +36,10 @@ for C in [Complex, Complex{Bool}]
     @eval begin
         Base.:*(x::Num, z::$C) = Complex(x * real(z), x * imag(z))
         Base.:*(z::$C, x::Num) = Complex(real(z) * x, imag(z) * x)
+        Base.:/(x::Num, z::$C) = let (a, b) = reim(z), den = a^2 + b^2
+            Complex(x * a / den, x * b / den)
+        end
+        Base.:/(z::$C, x::Num) = Complex(real(z) / x, imag(z) / x)
         Base.:+(x::Num, z::$C) = Complex(x + real(z), imag(z))
         Base.:+(z::$C, x::Num) = Complex(real(z) + x, imag(z))
         Base.:-(x::Num, z::$C) = Complex(x - real(z), -imag(z))

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -124,6 +124,8 @@ z2 = c + d * im
 @test isequal(z1 / z1, 1)
 @test isequal(z1 / z2, Complex((a*c + b*d)/(c^2 + d^2), (b*c - a*d)/(c^2 + d^2)))
 @test isequal(1 / z2, Complex(c/(c^2 + d^2), -d/(c^2 + d^2)))
+@test isequal(z1 / c, Complex(a/c, b/c))
+@test isequal(a / z2, Complex(a*c/(c^2 + d^2), a*d/(c^2 + d^2)))
 @test isequal(z1 * z2, Complex(a*c - b*d, a*d + b*c))
 @test isequal(z1 - z2, Complex(a - c, b - d))
 @test isequal(z1 + z2, Complex(a + c, b + d))


### PR DESCRIPTION
There were overloads for dividing two complex numbers, but not for a number and a complex.
Now there are.