### PR TITLE
Implement the simplify interface for Complex{Num}

### DIFF
--- a/src/num.jl
+++ b/src/num.jl
@@ -47,6 +47,10 @@ for C in [Complex, Complex{Bool}]
     end
 end
 
+istree(c::Complex{Num}) = true
+operation(::Complex{Num}) = Complex{Num}
+arguments(c::Complex{Num}) = [real(c), imag(c)]
+
 function Base.inv(z::Complex{Num})
     a, b = reim(z)
     den = a^2 + b^2

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -9,6 +9,7 @@ using Test
 @test isequal(sincos(a), (sin(a), cos(a)))
 
 @test substitute(a ~ b, Dict(a=>1, b=>c)) == (1 ~ c)
+@test substitute(im * a, Dict(a=>1)) == Complex{Num}(Num(false), Num(1))
 
 # test hashing
 aa = a; # old a


### PR DESCRIPTION
Fixes #137.

This solves the problem, but maybe not in the right way. If `im*x` was instead represented as a `SymbolicUtils.Mul` wrapped in `Num`, then this would work automatically. What is the rational for creating `Complex{Num}` objects?