### PR TITLE
Fix Sparse Multithreaded Form

### DIFF
--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -174,3 +174,25 @@ old = out[1]
 f_expr[2](out, u)
 @test out[1] === old
 @test out[2] === u[1]
+@test expr.args[2].args[end] == :(xˍt(t))
+
+
+let # issue#136
+    @variables x y
+    A = sparse(Tridiagonal([x^i for i in 1:N-1],
+                           [x^i * y^(8-i) for i in 1:N],
+                           [y^i for i in 1:N-1]))
+
+    val = Dict(x=>1, y=>2)
+    B = map(A) do e
+        Num(substitute(e, val))
+    end
+
+    C = copy(B) - 100*I
+
+
+    f = build_function(A,[x,y],parallel=Symbolics.MultithreadedForm())[2] |> eval
+
+    f(C, [1,2])
+    @test isequal(C, B)
+end

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -1,4 +1,4 @@
-using Symbolics, SparseArrays, Test
+using Symbolics, SparseArrays, LinearAlgebra, Test
 using ReferenceTests
 @variables a b c1 c2 c3 d e g
 
@@ -174,10 +174,10 @@ old = out[1]
 f_expr[2](out, u)
 @test out[1] === old
 @test out[2] === u[1]
-@test expr.args[2].args[end] == :(xˍt(t))
 
 
 let # issue#136
+    N = 8
     @variables x y
     A = sparse(Tridiagonal([x^i for i in 1:N-1],
                            [x^i * y^(8-i) for i in 1:N],

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -191,8 +191,10 @@ let # issue#136
     C = copy(B) - 100*I
 
 
-    f = build_function(A,[x,y],parallel=Symbolics.MultithreadedForm())[2] |> eval
+    f = build_function(A,[x,y],parallel=Symbolics.MultithreadedForm())[2]
+    g = eval(f)
 
-    f(C, [1,2])
+    g(C, [1,2])
+    @test contains(repr(f), "schedule")
     @test isequal(C, B)
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaSymbolics/Symbolics.jl/issues/136 . Gives:

```julia
using Symbolics
using LinearAlgebra
using SparseArrays

@variables x y

N = 8
A = sparse(Tridiagonal([x^i for i in 1:N-1],[x^i * y^(8-i) for i in 1:N], [y^i for i in 1:N-1]))

build_function(A,[x,y],parallel=Symbolics.MultithreadedForm())[2]
```

```julia
function (var"##out#283", var"##arg#282")
    #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:278 =#
    #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:279 =#
    let x = var"##arg#282"[1], y = var"##arg#282"[2]
        #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:243 =#
        (Symbolics.var"#noop#472"())(map(fetch, (begin
                        #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:235 =#
                        let
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:236 =#
                            task = Base.Threads.Task((Symbolics.Funcall)(RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(Symbol("##out#283"), Symbol("##arg#282")), Symbolics.var"#_RGF_ModTag", Symbolics.var"#_RGF_ModTag", (0x0eb32ebc, 0x10d60592, 0x3d0146f1, 0xfc22a4d3, 0xceb11c15)}(quote
    #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:278 =#
    #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:279 =#
    let x = var"##arg#282"[1], y = var"##arg#282"[2]
        #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:323 =#
        #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:325 =# @inbounds begin
                #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:321 =#
                (var"##out#283").nzval[1] = (*)(x, (^)(y, 7))
                (var"##out#283").nzval[2] = x
                (var"##out#283").nzval[3] = y
                (var"##out#283").nzval[4] = (*)((^)(x, 2), (^)(y, 6))
                (var"##out#283").nzval[5] = (^)(x, 2)
                (var"##out#283").nzval[6] = (^)(y, 2)
                #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:323 =#
                nothing
            end
    end
end), (var"##out#283", var"##arg#282")))
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:237 =#
                            Base.Threads.schedule(task)
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:238 =#
                            task
                        end
                    end, begin
                        #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:235 =#
                        let
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:236 =#
                            task = Base.Threads.Task((Symbolics.Funcall)(RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(Symbol("##out#283"), Symbol("##arg#282")), Symbolics.var"#_RGF_ModTag", Symbolics.var"#_RGF_ModTag", (0x7ae39544, 0x1a0880df, 0x44e9899a, 0x63a97528, 0x3936eab1)}(quote
    #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:278 =#
    #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:279 =#
    let x = var"##arg#282"[1], y = var"##arg#282"[2]
        #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:323 =#
        #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:325 =# @inbounds begin
                #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:321 =#
                (var"##out#283").nzval[7] = (*)(x, (^)(y, 7))
                (var"##out#283").nzval[8] = x
                (var"##out#283").nzval[9] = y
                (var"##out#283").nzval[10] = (*)((^)(x, 2), (^)(y, 6))
                (var"##out#283").nzval[11] = (^)(x, 2)
                (var"##out#283").nzval[12] = (^)(y, 2)
                #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:323 =#
                nothing
            end
    end
end), (var"##out#283", var"##arg#282")))
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:237 =#
                            Base.Threads.schedule(task)
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:238 =#
                            task
                        end
                    end, begin
                        #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:235 =#
                        let
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:236 =#
                            task = Base.Threads.Task((Symbolics.Funcall)(RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(Symbol("##out#283"), Symbol("##arg#282")), Symbolics.var"#_RGF_ModTag", Symbolics.var"#_RGF_ModTag", (0xb57bcdcd, 0x7e4b6181, 0x1755479d, 0x7773e4eb, 0xa53402d8)}(quote
    #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:278 =#
    #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:279 =#
    let x = var"##arg#282"[1], y = var"##arg#282"[2]
        #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:323 =#
        #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:325 =# @inbounds begin
                #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:321 =#
                (var"##out#283").nzval[13] = (*)(x, (^)(y, 7))
                (var"##out#283").nzval[14] = x
                (var"##out#283").nzval[15] = y
                (var"##out#283").nzval[16] = (*)((^)(x, 2), (^)(y, 6))
                (var"##out#283").nzval[17] = (^)(x, 2)
                (var"##out#283").nzval[18] = (^)(y, 2)
                #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:323 =#
                nothing
            end
    end
end), (var"##out#283", var"##arg#282")))
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:237 =#
                            Base.Threads.schedule(task)
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:238 =#
                            task
                        end
                    end, begin
                        #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:235 =#
                        let
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:236 =#
                            task = Base.Threads.Task((Symbolics.Funcall)(RuntimeGeneratedFunctions.RuntimeGeneratedFunction{(Symbol("##out#283"), Symbol("##arg#282")), Symbolics.var"#_RGF_ModTag", Symbolics.var"#_RGF_ModTag", (0xc8ec7d7e, 0xc301dede, 0x6c4fcd9d, 0xceae0b65, 0x51337705)}(quote
    #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:278 =#
    #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:279 =#
    let x = var"##arg#282"[1], y = var"##arg#282"[2]
        #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:323 =#
        #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:325 =# @inbounds begin
                #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:321 =#
                (var"##out#283").nzval[19] = (*)(x, (^)(y, 7))
                (var"##out#283").nzval[20] = x
                (var"##out#283").nzval[21] = y
                (var"##out#283").nzval[22] = (*)((^)(x, 2), (^)(y, 6))
                #= C:\Users\accou\.julia\packages\SymbolicUtils\0Fgyc\src\code.jl:323 =#
                nothing
            end
    end
end), (var"##out#283", var"##arg#282")))
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:237 =#
                            Base.Threads.schedule(task)
                            #= C:\Users\accou\.julia\packages\Symbolics\JhAD8\src\build_function.jl:238 =#
                            task
                        end
                    end))...)
    end
end
```



┆Issue is synchronized with this [Trello card](https://trello.com/c/YYo35EEf) by [Unito](https://www.unito.io)
