### PR TITLE
Fix `latexify` for `Num`

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -30,6 +30,10 @@ Base.show(io::IO, ::MIME"text/latex", x::Symbolic) = print(io, latexify(x))
 Base.show(io::IO, ::MIME"text/latex", x::Vector{Equation}) = print(io, latexify(x))
 Base.show(io::IO, ::MIME"text/latex", x::AbstractArray{Num}) = print(io, latexify(x))
 
+@latexrecipe function f(n::Num)
+    return _toexpr(n, canonicalize=false)
+end
+
 # `_toexpr` is only used for latexify
 function _toexpr(O; canonicalize=true)
     if canonicalize
@@ -49,7 +53,7 @@ function _toexpr(O; canonicalize=true)
         isempty(args) && return nameof(op)
         return Expr(:call, _toexpr(op; canonicalize=canonicalize), _toexpr(args; canonicalize=canonicalize)...)
     end
-    return Expr(:call, op, _toexpr(args; canonicalize=canonicalize)...)
+    return Expr(:call, Symbol(op), _toexpr(args; canonicalize=canonicalize)...)
 end
 _toexpr(s::Sym; kw...) = nameof(s)
 
@@ -61,9 +65,9 @@ function canonicalexpr(O)
         if length(args) == 2 && args[2] isa Number && args[2] < 0
             ex = _toexpr(args[1])
             if args[2] == -1
-                expr = Expr(:call, inv, ex)
+                expr = Expr(:call, :inv, ex)
             else
-                expr = Expr(:call, ^, Expr(:call, inv, ex), -args[2])
+                expr = Expr(:call, :^, Expr(:call, inv, ex), -args[2])
             end
             return true, expr
         end

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -1,0 +1,13 @@
+using Symbolics
+using Test
+using Latexify
+
+@variables x y z
+
+@test latexify(x^-1) == Latexify.L"$x^{-1}$"
+
+@test latexify((z + x*y^-1) / sin(z)) ==
+    Latexify.L"$\left( z + x \cdot y^{-1} \right) \cdot \sin^{-1}\left( z \right)$"
+
+@test latexify((3x - 7y*z^23) * (z - z^2) / x) ==
+    Latexify.L"x^{-1} \cdot \left( z -1 \cdot z^{2} \right) \cdot \left( 3 \cdot x -7 \cdot y \cdot z^{23} \right)"


### PR DESCRIPTION
Previously, calling `latexify(n::Num)` would just call `string(n)` because `Num <: Real`. Now, `latexify(n::Num)` creates an expression from `value(n)`, and then `latexify`'s that.

The calls to `Symbol` are necessary because `Latexify` expects an operation represented as a symbol, and not the actual function type (`typeof(*)` vs `:*` for example).

Fixes #109. Fixes #135.