### PR TITLE
Ignore earlier Julia's before v1.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -42,7 +42,7 @@ Setfield = "0.7"
 SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0"
 SymbolicUtils = "0.9.0"
 TreeViews = "0.3"
-julia = "1.2"
+julia = "1.5"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"


### PR DESCRIPTION
We don't test them, and other dependencies will not be updating them.