### PR TITLE
More efficient expression building for non-julia targets

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -463,7 +463,7 @@ function _build_function(target::CTarget, eqs::Array{<:Equation}, args...;
 
     @warn "build_function(::Array{<:Equation}...) is deprecated. Use build_function(::AbstractArray...) instead."
 
-    buildvarnumbercache(args...)
+    varnumbercache = buildvarnumbercache(args...)
     differential_equation = string(join([numbered_expr(eq,varnumbercache,args...,lhsname=lhsname,
                                   rhsnames=rhsnames,offset=-1) for
                                   (i, eq) ∈ enumerate(eqs)],";\n  "),";")

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -358,8 +358,8 @@ function numbered_expr(O::Symbolic,varnumbercache,args...;varordering = args[1],
                        lhsname=gensym("du"),rhsnames=[gensym("MTK") for i in 1:length(args)])
     O = value(O)
     if O isa Sym || isa(operation(O), Sym)
-        if haskey(varnumbercache,O)
-            (j,i) = varnumbercache[O]
+        (j,i) = get(varnumbercache, O, (nothing, nothing))
+        if !isnothing(j)
             return i==0 ? :($(rhsnames[j])) : :($(rhsnames[j])[$(i+offset)])
         end
     end


### PR DESCRIPTION
In `build_function` for non-julia targets, symbolic variables in expressions are replaced by references to the corresponding element of the input arrays. To find the right index, input arrays were searched linearly for the right symbolic variable for each replacement. Now we first (and only once) build a dictionary for symbolic variable -> index lookup. This speeds up `build_function` for expressions with large numbers of variables.