### PR TITLE
to render -1*x as -x in latex

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -46,8 +46,6 @@ function _toexpr(O; canonicalize=true)
     args = arguments(O)
     
     if (op===(*)) && (args[1] === -1)
-        println("here")
-	println(args)
     	arg_mul = Expr(:call, :(*), _toexpr(args[2:end]; canonicalize=canonicalize)...)
         return Expr(:call, :(-), arg_mul)
     end

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -45,8 +45,11 @@ function _toexpr(O; canonicalize=true)
     op = operation(O)
     args = arguments(O)
     
-    if (op===(*)) && (args[1] == -1)
-	return Symbol("-$(args[2])")
+    if (op===(*)) && (args[1] === -1)
+        println("here")
+	println(args)
+    	arg_mul = Expr(:call, :(*), _toexpr(args[2:end]; canonicalize=canonicalize)...)
+        return Expr(:call, :(-), arg_mul)
     end
     
     if op isa Differential

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -42,9 +42,13 @@ function _toexpr(O; canonicalize=true)
     else
         !istree(O) && return O
     end
-
     op = operation(O)
     args = arguments(O)
+    
+    if (op===(*)) && (args[1] == -1)
+	return Symbol("-$(args[2])")
+    end
+    
     if op isa Differential
         ex = _toexpr(args[1]; canonicalize=canonicalize)
         wrt = _toexpr(op.x; canonicalize=canonicalize)

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -10,4 +10,18 @@ using Latexify
     Latexify.L"$\left( z + x \cdot y^{-1} \right) \cdot \sin^{-1}\left( z \right)$"
 
 @test latexify((3x - 7y*z^23) * (z - z^2) / x) ==
-    Latexify.L"x^{-1} \cdot \left( z -1 \cdot z^{2} \right) \cdot \left( 3 \cdot x -7 \cdot y \cdot z^{23} \right)"
+    Latexify.L"x^{-1} \cdot \left( z - z^{2} \right) \cdot \left( 3 \cdot x -7 \cdot y \cdot z^{23} \right)"
+
+@test latexify(-(-x)) == Latexify.L"$x$"
+
+@test latexify(x/-x) == Latexify.L"$-1$"
+
+@test latexify(-x * y) == Latexify.L"$ - x \cdot y$"
+
+@test latexify(x * -y) == Latexify.L"$ - x \cdot y$"
+
+@test latexify(x * -y *z) == Latexify.L"$ - x \cdot y \cdot z$"
+
+@test latexify(x * y * -z) == Latexify.L"$ - x \cdot y \cdot z$"
+
+@test latexify(sin(x+y-z)) == Latexify.L"$\sin\left( x + y - z \right)$"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ if GROUP == "All" || GROUP == "Core"
     @safetestset "Build Function Test" begin include("build_function.jl") end
     @safetestset "Build Function Array Test" begin include("build_function_arrayofarray.jl") end
     @safetestset "Build Targets Test" begin include("build_targets.jl") end
+    @safetestset "Latexify Test" begin include("latexify.jl") end
 end
 
 if GROUP == "Downstream"


### PR DESCRIPTION
Currently a negative variable `-x` is rendered as `-1*x` in latex. Changing it to `-x` is more natural looking.