### PR TITLE
Update _build_function to use inbounds keyword of DestructuredArgs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ SafeTestsets = "0"
 SciMLBase = "1.8"
 Setfield = "0.7"
 SpecialFunctions = "0.7, 0.8, 0.9, 0.10, 1.0"
-SymbolicUtils = "0.9.0, 0.10"
+SymbolicUtils = "0.10.1"
 TreeViews = "0.3"
 julia = "1.5"
 


### PR DESCRIPTION
Hi there, this PR implements the changes from https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/265 in `Symbolics.jl` to solve #177.

I'm not sure what has to be done on the dependencies management side though, so this **change might break `master`**.