### PR TITLE
Latexify fractions

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -11,13 +11,13 @@ prettify_expr(expr::Expr) = Expr(expr.head, prettify_expr.(expr.args)...)
     # that latexify can deal with
 
     rhs = getfield.(eqs, :rhs)
-    rhs = prettify_expr.(_toexpr(rhs; canonicalize=false))
+    rhs = prettify_expr.(_toexpr(rhs))
     rhs = [postwalk(x -> x isa Expr && length(x.args) == 1 ? x.args[1] : x, eq) for eq in rhs]
     rhs = [postwalk(x -> x isa Expr && x.args[1] == :_derivative && length(x.args[2].args) == 2 ? :($(Symbol(:d, x.args[2]))/($(Symbol(:d, x.args[2].args[2])))) : x, eq) for eq in rhs]
     rhs = [postwalk(x -> x isa Expr && x.args[1] == :_derivative ? "\\frac{d\\left($(Latexify.latexraw(x.args[2]))\\right)}{d$(Latexify.latexraw(x.args[3]))}" : x, eq) for eq in rhs]
 
     lhs = getfield.(eqs, :lhs)
-    lhs = prettify_expr.(_toexpr(lhs; canonicalize=false))
+    lhs = prettify_expr.(_toexpr(lhs))
     lhs = [postwalk(x -> x isa Expr && length(x.args) == 1 ? x.args[1] : x, eq) for eq in lhs]
     lhs = [postwalk(x -> x isa Expr && x.args[1] == :_derivative && length(x.args[2].args) == 2 ? :($(Symbol(:d, x.args[2]))/($(Symbol(:d, x.args[2].args[2])))) : x, eq) for eq in lhs]
     lhs = [postwalk(x -> x isa Expr && x.args[1] == :_derivative ? "\\frac{d\\left($(Latexify.latexraw(x.args[2]))\\right)}{d$(Latexify.latexraw(x.args[3]))}" : x, eq) for eq in lhs]
@@ -31,60 +31,38 @@ Base.show(io::IO, ::MIME"text/latex", x::Vector{Equation}) = print(io, latexify(
 Base.show(io::IO, ::MIME"text/latex", x::AbstractArray{Num}) = print(io, latexify(x))
 
 @latexrecipe function f(n::Num)
-    return _toexpr(n, canonicalize=false)
+    return _toexpr(n)
 end
 
 # `_toexpr` is only used for latexify
-function _toexpr(O; canonicalize=true)
-    if canonicalize
-        canonical, O = canonicalexpr(O)
-        canonical && return O
-    else
-        !istree(O) && return O
-    end
+function _toexpr(O)
+    !istree(O) && return O
+
     op = operation(O)
     args = arguments(O)
 
     if (op===(*)) && (args[1] === -1)
-        arg_mul = Expr(:call, :(*), _toexpr(args[2:end]; canonicalize=canonicalize)...)
+        arg_mul = Expr(:call, :(*), _toexpr(args[2:end])...)
         return Expr(:call, :(-), arg_mul)
     end
 
     if op isa Differential
-        ex = _toexpr(args[1]; canonicalize=canonicalize)
-        wrt = _toexpr(op.x; canonicalize=canonicalize)
+        ex = _toexpr(args[1])
+        wrt = _toexpr(op.x)
         return :(_derivative($ex, $wrt))
     elseif op isa Sym
         isempty(args) && return nameof(op)
-        return Expr(:call, _toexpr(op; canonicalize=canonicalize), _toexpr(args; canonicalize=canonicalize)...)
+        return Expr(:call, _toexpr(op), _toexpr(args)...)
     end
-    return Expr(:call, Symbol(op), _toexpr(args; canonicalize=canonicalize)...)
+    return Expr(:call, Symbol(op), _toexpr(args)...)
 end
-_toexpr(s::Sym; kw...) = nameof(s)
-_toexpr(x::Integer; kw...) = x
-_toexpr(x::AbstractFloat; kw...) = x
+_toexpr(s::Sym) = nameof(s)
+_toexpr(x::Integer) = x
+_toexpr(x::AbstractFloat) = x
 
-function _toexpr(eq::Equation; kw...)
-    Expr(:(=), _toexpr(eq.lhs; kw...), _toexpr(eq.rhs; kw...))
+function _toexpr(eq::Equation)
+    Expr(:(=), _toexpr(eq.lhs), _toexpr(eq.rhs))
 end
 
-_toexpr(eqs::AbstractArray; kw...) = map(eq->_toexpr(eq; kw...), eqs)
-_toexpr(x::Num; kw...) = _toexpr(value(x); kw...)
-
-function canonicalexpr(O)
-    !istree(O) && return true, O
-    op = operation(O)
-    args = arguments(O)
-    if op === (^)
-        if length(args) == 2 && args[2] isa Number && args[2] < 0
-            ex = _toexpr(args[1])
-            if args[2] == -1
-                expr = Expr(:call, :inv, ex)
-            else
-                expr = Expr(:call, :^, Expr(:call, inv, ex), -args[2])
-            end
-            return true, expr
-        end
-    end
-    return false, O
-end
+_toexpr(eqs::AbstractArray) = map(eq->_toexpr(eq), eqs)
+_toexpr(x::Num) = _toexpr(value(x))

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -61,6 +61,15 @@ function _toexpr(O; canonicalize=true)
     return Expr(:call, Symbol(op), _toexpr(args; canonicalize=canonicalize)...)
 end
 _toexpr(s::Sym; kw...) = nameof(s)
+_toexpr(x::Integer; kw...) = x
+_toexpr(x::AbstractFloat; kw...) = x
+
+function _toexpr(eq::Equation; kw...)
+    Expr(:(=), _toexpr(eq.lhs; kw...), _toexpr(eq.rhs; kw...))
+end
+
+_toexpr(eqs::AbstractArray; kw...) = map(eq->_toexpr(eq; kw...), eqs)
+_toexpr(x::Num; kw...) = _toexpr(value(x); kw...)
 
 function canonicalexpr(O)
     !istree(O) && return true, O
@@ -79,15 +88,3 @@ function canonicalexpr(O)
     end
     return false, O
 end
-for fun in [:_toexpr]
-    @eval begin
-        function $fun(eq::Equation; kw...)
-            Expr(:(=), $fun(eq.lhs; kw...), $fun(eq.rhs; kw...))
-        end
-
-        $fun(eqs::AbstractArray; kw...) = map(eq->$fun(eq; kw...), eqs)
-        $fun(x::Integer; kw...) = x
-        $fun(x::AbstractFloat; kw...) = x
-    end
-end
-_toexpr(x::Num; kw...) = _toexpr(value(x); kw...)

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -44,12 +44,12 @@ function _toexpr(O; canonicalize=true)
     end
     op = operation(O)
     args = arguments(O)
-    
+
     if (op===(*)) && (args[1] === -1)
-    	arg_mul = Expr(:call, :(*), _toexpr(args[2:end]; canonicalize=canonicalize)...)
+        arg_mul = Expr(:call, :(*), _toexpr(args[2:end]; canonicalize=canonicalize)...)
         return Expr(:call, :(-), arg_mul)
     end
-    
+
     if op isa Differential
         ex = _toexpr(args[1]; canonicalize=canonicalize)
         wrt = _toexpr(op.x; canonicalize=canonicalize)

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -7,10 +7,10 @@ using Latexify
 @test latexify(x^-1) == Latexify.L"$x^{-1}$"
 
 @test latexify((z + x*y^-1) / sin(z)) ==
-    Latexify.L"$\left( z + x \cdot y^{-1} \right) \cdot \sin^{-1}\left( z \right)$"
+    Latexify.L"$\frac{\left( z + \frac{x}{y} \right)}{\sin\left( z \right)}$"
 
 @test latexify((3x - 7y*z^23) * (z - z^2) / x) ==
-    Latexify.L"x^{-1} \cdot \left( z - z^{2} \right) \cdot \left( 3 \cdot x -7 \cdot y \cdot z^{23} \right)"
+    Latexify.L"$\frac{\left( z - z^{2} \right) \cdot \left( 3 \cdot x - 7 \cdot y \cdot z^{23} \right)}{x}$"
 
 @test latexify(-(-x)) == Latexify.L"$x$"
 


### PR DESCRIPTION
This PR makes `_toexpr` produce expressions with fractions in then, which in turn makes `latexify` output fractions. I subjectively think that this looks a lot nicer in Jupyter.

The PR also includes several cleanup/reorganization commits. I've done my best to keep the commits self contained, so it is probably easiest to review one commit at a time. I can remove them if you would rather not review such a large change, want to keep `git blame` useful, etc.