### PR TITLE
Add a missing getindex overload

### DIFF
--- a/src/extra_functions.jl
+++ b/src/extra_functions.jl
@@ -1,4 +1,5 @@
 @register Base.getindex(x,i::Integer) false
+@register Base.getindex(x::AbstractArray,i) false
 @register Base.getindex(x,i) # define one and only one promotion rule
 @register Base.binomial(n,k)
 


### PR DESCRIPTION
getindex(symbolic,integer), getindex(symbolic,symbolic), and now getindex(array,symbolic)