### PR TITLE
add isone(::Num)

### DIFF
--- a/src/num.jl
+++ b/src/num.jl
@@ -111,6 +111,13 @@ function Base.iszero(x::Num)
     return (_x isa Number || _x isa SymbolicUtils.MPoly) && iszero(_x)
 end
 
+function Base.isone(x::Num)
+    x = value(x)
+    x isa Number && isone(x) && return true
+    _x = SymbolicUtils.to_mpoly(x)[1]
+    return (_x isa Number || _x isa SymbolicUtils.MPoly) && isone(_x)
+end
+
 import SymbolicUtils: <ₑ, Symbolic, Term, operation, arguments
 
 Base.show(io::IO, n::Num) = show_numwrap[] ? print(io, :(Num($(value(n))))) : Base.show(io, value(n))

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -160,6 +160,10 @@ using IfElse: ifelse
 @test isequal(Symbolics.derivative(signbit(x), x), 0)
 
 @test iszero(Num(0.0))
+@test isone(Num(1.0))
+@test isone(complex(Num(1), Num(0)))
+@test iszero(complex(Num(0), Num(0)))
+
 x = Num.(randn(10))
 @test norm(x) == norm(Symbolics.value.(x))
 @test norm(x, Inf) == norm(Symbolics.value.(x), Inf)


### PR DESCRIPTION
This is just a copy of the above `iszero` implementation. Without this `_isone` on complex numbers will not work correctly because one `isone` on complex numbers checks `iszero` and `isone` on the real and imaginary parts, one of which currently return false, while the other returns a Num containing the boolean expression.