### PR TITLE
Distinguish linear from affine and fix linearity checks on single sym

### DIFF
--- a/docs/src/manual/sparsity_detection.md
+++ b/docs/src/manual/sparsity_detection.md
@@ -1,8 +1,8 @@
-# Sparsity Detection
+# Structure and Sparsity Detection
 
 Using the tracing system provided by Symbolics.jl expressions, Symbolics.jl
-can automatically detect the sparsity patterns of Julia functions. This functionality
-is described in more detail in the paper:
+can automatically detect the sparsity patterns of Julia functions in an efficient
+way. This functionality is described in more detail in the paper:
 
 ```
 @article{gowda2019sparsity,
@@ -14,7 +14,16 @@ is described in more detail in the paper:
 
 Please cite this work if the functionality is used.
 
+## Sparsity Detection
+
 ```@docs
 Symbolics.jacobian_sparsity
 Symbolics.hessian_sparsity
+```
+
+## Structure Detection
+
+```@docs
+Symbolics.islinear
+Symbolics.isaffine
 ```

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -478,7 +478,7 @@ $(SIGNATURES)
 Check if an expression is linear with respect to a list of variable expressions.
 """
 function islinear(ex, u)
-    isaffine(ex, u) && iszero(substitute(ex, Dict(u .=> 0)))
+    isaffine(ex, u) && iszero(Num(substitute(ex, Dict(u .=> 0))))
 end
 
 """

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -476,7 +476,7 @@ $(SIGNATURES)
 Check if an expression is affine with respect to a list of variable expressions.
 """
 function islinear(ex, u)
-    isaffine(ex, u) && isequal(substitute(ex, Dict(u .=> 0)),0)
+    isaffine(ex, u) && isequal(simplify(substitute(ex, Dict(u .=> 0))),0)
 end
 
 """

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -430,6 +430,7 @@ let
           @rule +(~~xs) => reduce(+, filter(isidx, ~~xs), init=_scalar)
           @rule *(~~xs) => reduce(*, filter(isidx, ~~xs), init=_scalar)
           @rule (~f)(~x::(!isidx)) => _scalar
+
           @rule (~f)(~x::isidx) => if haslinearity_1(~f)
               combine_terms_1(linearity_1(~f), ~x)
           else
@@ -444,7 +445,8 @@ let
               else
                   error("Function of unknown linearity used: ", ~f)
               end
-          end]
+          end
+          @rule ~x::(x->x isa Sym) => 0]
     linearity_propagator = Fixpoint(Postwalk(Chain(linearity_rules); similarterm=simterm))
 
     global hessian_sparsity
@@ -476,7 +478,7 @@ $(SIGNATURES)
 Check if an expression is linear with respect to a list of variable expressions.
 """
 function islinear(ex, u)
-    isaffine(ex, u) && isequal(simplify(substitute(ex, Dict(u .=> 0))),0)
+    isaffine(ex, u) && iszero(substitute(ex, Dict(u .=> 0)))
 end
 
 """

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -464,10 +464,19 @@ end
 """
 $(SIGNATURES)
 
-Check if an expression is linear with respect to a list of variable expressions.
+Check if an expression is affine with respect to a list of variable expressions.
+"""
+function isaffine(ex, u)
+    isempty(hessian_sparsity(ex, u).nzval)
+end
+
+"""
+$(SIGNATURES)
+
+Check if an expression is affine with respect to a list of variable expressions.
 """
 function islinear(ex, u)
-    isempty(hessian_sparsity(ex, u).nzval)
+    isaffine(ex, u) && isequal(substitute(ex, Dict(u .=> 0)),0)
 end
 
 """

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -473,7 +473,7 @@ end
 """
 $(SIGNATURES)
 
-Check if an expression is affine with respect to a list of variable expressions.
+Check if an expression is linear with respect to a list of variable expressions.
 """
 function islinear(ex, u)
     isaffine(ex, u) && isequal(simplify(substitute(ex, Dict(u .=> 0))),0)

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -59,7 +59,7 @@ function A_b(eqs::AbstractArray, vars::AbstractArray, check)
     exprs = rhss(eqs) .- lhss(eqs)
     if check
         for ex in exprs
-            @assert islinear(ex, vars)
+            @assert isaffine(ex, vars)
         end
     end
     A = jacobian(exprs, vars)
@@ -68,7 +68,7 @@ function A_b(eqs::AbstractArray, vars::AbstractArray, check)
 end
 function A_b(eq, var, check)
     ex = eq.rhs - eq.lhs
-    check && @assert islinear(ex, [var])
+    check && @assert isaffine(ex, [var])
     a = expand_derivatives(Differential(var)(ex))
     b = a * var - ex
     a, b

--- a/src/linearity.jl
+++ b/src/linearity.jl
@@ -167,6 +167,8 @@ function _sparse(t::TermCombination, n)
     s1 .| s1'
 end
 
+_sparse(::Sym, ::Int) = sparse([])
+
 # 1-arg functions
 combine_terms_1(lin, term) = lin ? term : term * term
 

--- a/src/linearity.jl
+++ b/src/linearity.jl
@@ -167,7 +167,7 @@ function _sparse(t::TermCombination, n)
     s1 .| s1'
 end
 
-_sparse(::Sym, ::Int) = sparse([])
+_sparse(x::Number, n) = sparse(Int[],Int[],Int[],n,n)
 
 # 1-arg functions
 combine_terms_1(lin, term) = lin ? term : term * term

--- a/test/islinear_affine.jl
+++ b/test/islinear_affine.jl
@@ -1,0 +1,18 @@
+using Symbolics, Test
+@variables t, x(t), y(t), z(t)
+@test Symbolics.islinear(x + y,[x,y])
+@test Symbolics.islinear(x,[x,y])
+@test Symbolics.islinear(y,[x,y])
+@test !Symbolics.islinear(z,[x,y])
+
+@test Symbolics.isaffine(x + y,[x,y])
+@test Symbolics.isaffine(x,[x,y])
+@test Symbolics.isaffine(y,[x,y])
+@test Symbolics.isaffine(z,[x,y])
+@test Symbolics.isaffine(x + y + z,[x,y])
+
+@test Symbolics.isaffine(x + z * y,[x,y])
+@test Symbolics.islinear(x + z * y,[x,y])
+@test Symbolics.islinear(z * x + z * y,[x,y])
+@test_broken Symbolics.islinear(z * (x + y),[x,y])
+@test Symbolics.isaffine(z * (x + y),[x,y])

--- a/test/islinear_affine.jl
+++ b/test/islinear_affine.jl
@@ -14,5 +14,5 @@ using Symbolics, Test
 @test Symbolics.isaffine(x + z * y,[x,y])
 @test Symbolics.islinear(x + z * y,[x,y])
 @test Symbolics.islinear(z * x + z * y,[x,y])
-@test_broken Symbolics.islinear(z * (x + y),[x,y])
+@test Symbolics.islinear(z * (x + y),[x,y])
 @test Symbolics.isaffine(z * (x + y),[x,y])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ end
 
 if GROUP == "All" || GROUP == "Core"
     @safetestset "Differentiation Test" begin include("diff.jl") end
+    @safetestset "Is Linear or Affine Test" begin include("islinear_affine.jl") end
     @safetestset "Overloading Test" begin include("overloads.jl") end
     @safetestset "Build Function Test" begin include("build_function.jl") end
     @safetestset "Build Function Array Test" begin include("build_function_arrayofarray.jl") end


### PR DESCRIPTION
Fixes:

```julia
using ModelingToolkit
@parameters t p
@variables x(t)
D = Differential(t)
eqs = [D(x) ~ x]
sys = ODESystem(eqs,t)
ModelingToolkit.islinear(sys) # true

eqs = [D(x) ~ p]
sys = ODESystem(eqs,t)
ModelingToolkit.islinear(sys) # false
```