### PR TITLE
[RFC] Use the conv keyword argument in build_function

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -89,7 +89,7 @@ function _build_function(target::JuliaTarget, op, args...;
                          linenumbers = true)
 
     dargs = map(arg -> destructure_arg(arg, !checkbounds), [args...])
-    expr = toexpr(Func(dargs, [], unflatten_long_ops(op)))
+    expr = conv(Func(dargs, [], unflatten_long_ops(op)))
 
     if expression == Val{true}
         expr


### PR DESCRIPTION
I noticed in `_build_function` that the `conv` keyword argument is not used, though it is given a default value. It looks like the `toexpr` in the body of the function should have been replaced with `conv` since `toexpr` is the default value. MTK makes use of this keyword argument for `rungekutta_discretize` with `ControlSystems` and `generate_function` with `OptimizationSystem`. 

However, when `conv` is actually used (at the moment it is ignored) the functions in MTK fail. 