### PR TITLE
Add support for negative index

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -2,6 +2,7 @@ using SymbolicUtils: FnType, Sym
 using Setfield
 
 const IndexMap = Dict{Char,Char}(
+            '-' => '₋',
             '0' => '₀',
             '1' => '₁',
             '2' => '₂',


### PR DESCRIPTION
Closes #133. With this PR:

```julia
julia> using Symbolics; @variables x[-3:3]
[ Info: Precompiling Symbolics [0c5d862f-8b57-4792-8d23-62f2024744c7]
1-element Vector{Vector{Num}}:
 [x₋₃, x₋₂, x₋₁, x₀, x₁, x₂, x₃]
```