### PR TITLE
Unique function argument names for no recompilation

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -114,8 +114,8 @@ function _build_function(target::JuliaTarget, op::Arr, args...;
                          checkbounds = false,
                          linenumbers = true)
 
-    dargs = map(arg -> destructure_arg(arg, !checkbounds), [args...])
-    @show dargs
+    dargs = map((x) -> destructure_arg(x[2], !checkbounds,
+                                  Symbol("ˍ₋arg$(x[1])")), enumerate([args...]))
     expr = toexpr(Func(dargs, [], op))
 
     if expression == Val{true}
@@ -127,7 +127,6 @@ end
 
 function _build_and_inject_function(mod::Module, ex)
     if ex.head == :function && ex.args[1].head == :tuple
-        @show Expr(:call, :($mod.$(gensym())), ex.args[1].args...)
         ex.args[1] = Expr(:call, :($mod.$(gensym())), ex.args[1].args...)
     elseif ex.head == :(->)
         return _build_and_inject_function(mod, Expr(:function, ex.args...))
@@ -213,7 +212,8 @@ function _build_function(target::JuliaTarget, rhss::AbstractArray, args...;
                        fillzeros = skipzeros && !(typeof(rhss)<:SparseMatrixCSC),
                        parallel=SerialForm(), kwargs...)
 
-    dargs = map((x) -> destructure_arg(x[2], !checkbounds, Symbol("ˍ₋arg$(x[1])")), enumerate([args...]))
+    dargs = map((x) -> destructure_arg(x[2], !checkbounds,
+                                  Symbol("ˍ₋arg$(x[1])")), enumerate([args...]))
     i = findfirst(x->x isa DestructuredArgs, dargs)
     similarto = i === nothing ? Array : dargs[i].name
     oop_expr = Func(dargs, [], make_array(parallel, dargs, rhss, similarto))

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -79,14 +79,14 @@ end
 
 # Scalar output
 
-function destructure_arg(arg::Union{AbstractArray, Tuple}, inbounds)
+function destructure_arg(arg::Union{AbstractArray, Tuple}, inbounds, name)
     if !(arg isa Arr)
-        DestructuredArgs(map(value, arg), inbounds=inbounds)
+        DestructuredArgs(map(value, arg), name, inbounds=inbounds)
     else
         arg
     end
 end
-destructure_arg(arg, _) = arg
+destructure_arg(arg, _, _) = arg
 
 function _build_function(target::JuliaTarget, op, args...;
                          conv = toexpr,
@@ -95,7 +95,7 @@ function _build_function(target::JuliaTarget, op, args...;
                          checkbounds = false,
                          linenumbers = true)
 
-    dargs = map(arg -> destructure_arg(arg, !checkbounds), [args...])
+    dargs = map((x) -> destructure_arg(x[2], !checkbounds, Symbol("ˍ₋arg$(x[1])")), enumerate([args...]))
     expr = toexpr(Func(dargs, [], unflatten_long_ops(op)))
 
     if expression == Val{true}
@@ -127,6 +127,7 @@ end
 
 function _build_and_inject_function(mod::Module, ex)
     if ex.head == :function && ex.args[1].head == :tuple
+        @show Expr(:call, :($mod.$(gensym())), ex.args[1].args...)
         ex.args[1] = Expr(:call, :($mod.$(gensym())), ex.args[1].args...)
     elseif ex.head == :(->)
         return _build_and_inject_function(mod, Expr(:function, ex.args...))
@@ -212,15 +213,16 @@ function _build_function(target::JuliaTarget, rhss::AbstractArray, args...;
                        fillzeros = skipzeros && !(typeof(rhss)<:SparseMatrixCSC),
                        parallel=SerialForm(), kwargs...)
 
-    dargs = map(arg -> destructure_arg(arg, !checkbounds), [args...])
+    dargs = map((x) -> destructure_arg(x[2], !checkbounds, Symbol("ˍ₋arg$(x[1])")), enumerate([args...]))
     i = findfirst(x->x isa DestructuredArgs, dargs)
     similarto = i === nothing ? Array : dargs[i].name
     oop_expr = Func(dargs, [], make_array(parallel, dargs, rhss, similarto))
+
     if !isnothing(wrap_code[1])
         oop_expr = wrap_code[1](oop_expr)
     end
 
-    out = Sym{Any}(gensym("out"))
+    out = Sym{Any}(:ˍ₋out)
     ip_expr = Func([out, dargs...], [], set_array(parallel, dargs, out, outputidxs, rhss, checkbounds, skipzeros))
 
     if !isnothing(wrap_code[2])
@@ -382,7 +384,7 @@ buildvarnumbercache(args...) = Dict([isa(arg,AbstractArray) ? el=>(argi,eli) : a
                                     for (argi,arg) in enumerate(args) for (eli,el) in enumerate(arg)])
 
 function numbered_expr(O::Symbolic,varnumbercache,args...;varordering = args[1],offset = 0,
-                       lhsname=gensym("du"),rhsnames=[gensym("MTK") for i in 1:length(args)])
+                       lhsname=:du,rhsnames=[Symbol("MTK$i") for i in 1:length(args)])
     O = value(O)
     if (O isa Sym || isa(operation(O), Sym)) || (istree(O) && operation(O) == getindex)
         (j,i) = get(varnumbercache, O, (nothing, nothing))
@@ -406,7 +408,7 @@ function numbered_expr(O::Symbolic,varnumbercache,args...;varordering = args[1],
 end
 
 function numbered_expr(de::Equation,varnumbercache,args...;varordering = args[1],
-                       lhsname=gensym("du"),rhsnames=[gensym("MTK") for i in 1:length(args)],offset=0)
+                       lhsname=:du,rhsnames=[Symbol("MTK$i") for i in 1:length(args)],offset=0)
 
     varordering = value.(args[1])
     var = var_from_nested_derivative(de.lhs)[1]
@@ -565,7 +567,7 @@ function _build_function(target::CTarget, ex::AbstractArray, args...;
                                compiler    = compiler)
     end
 
-    
+
     varnumbercache = buildvarnumbercache(args...)
     equations = Vector{String}()
     for col ∈ 1:size(ex,2)

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -14,6 +14,10 @@ function h_julia!(out, a, b, c, d, e, g)
 end
 
 h_str = Symbolics.build_function(h, [a], [b], [c1, c2, c3], [d], [e], [g])
+h_str2 = Symbolics.build_function(h, [a], [b], [c1, c2, c3], [d], [e], [g])
+@test h_str[1] == h_str2[1]
+@test h_str[2] == h_str2[2]
+
 h_oop = eval(h_str[1])
 h_str_par = Symbolics.build_function(h, [a], [b], [c1, c2, c3], [d], [e], [g], parallel=Symbolics.MultithreadedForm())
 h_oop_par = eval(h_str_par[1])
@@ -78,6 +82,9 @@ h_julia_skip!(out_2_skip_2, inputs_skip_2...)
 h_scalar = a + b + c1 + c2 + c3 + d + e + g
 h_julia_scalar(a, b, c, d, e, g) = a[1] + b[1] + c[1] + c[2] + c[3] + d[1] + e[1] + g[1]
 h_str_scalar = Symbolics.build_function(h_scalar, [a], [b], [c1, c2, c3], [d], [e], [g])
+h_str_scalar2 = Symbolics.build_function(h_scalar, [a], [b], [c1, c2, c3], [d], [e], [g])
+@test h_str_scalar == h_str_scalar2
+
 h_oop_scalar = eval(h_str_scalar)
 @test h_oop_scalar(inputs...) == h_julia_scalar(inputs...)
 


### PR DESCRIPTION
Fixes https://discourse.julialang.org/t/function-compiles-every-time/63273/5 by giving the arguments unique names. MWE:

```julia
using ModelingToolkit, OrdinaryDiffEq

@variables t x(t) RHS(t)  # independent and dependent variables
@parameters τ       # parameters
D = Differential(t) # define an operator for the differentiation w.r.t. time

# your first ODE, consisting of a single equation, indicated by ~
@named fol_separate = ODESystem([ RHS  ~ (1 - x)/τ,
                                  D(x) ~ RHS ])

sys = structural_simplify(fol_separate)

@time begin
    prob = ODEProblem(sys, [x => 0.0], (0.0,10.0), [τ => 3.0])
    sol = solve(prob, Tsit5())
end
```

```
  0.001047 seconds (2.20 k allocations: 126.812 KiB)
  0.001023 seconds (2.20 k allocations: 126.812 KiB)
  0.001021 seconds (2.20 k allocations: 125.672 KiB)
  0.001045 seconds (2.20 k allocations: 125.672 KiB)
```

while it used to be 99.9% compile time. Tested on <1 and rebased.