### PR TITLE
Explicit return of indexed array variables from get_variables

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -47,7 +47,7 @@ get_variables(e::Num, varlist=nothing) = get_variables(value(e), varlist)
 get_variables!(vars, e, varlist=nothing) = vars
 
 function is_singleton(e::Term)
-    typeof(operation(e)) == typeof(getindex) && return true
+    operation(e) === getindex && return true
     operation(e) isa Sym
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -46,7 +46,11 @@ julia> Symbolics.get_variables(ex)
 get_variables(e::Num, varlist=nothing) = get_variables(value(e), varlist)
 get_variables!(vars, e, varlist=nothing) = vars
 
-is_singleton(e::Term) = operation(e) isa Sym
+function is_singleton(e::Term)
+    typeof(operation(e)) == typeof(getindex) && return true
+    operation(e) isa Sym
+end
+
 is_singleton(e::Sym) = true
 is_singleton(e) = false
 
@@ -205,7 +209,7 @@ end
 function degree(p::Add, sym=nothing)
     return maximum(degree(key, sym) for key in keys(p.dict))
 end
-        
+
 function degree(p::Mul, sym=nothing)
     return sum(degree(k^v, sym) for (k, v) in zip(keys(p.dict), values(p.dict)))
 end
@@ -217,7 +221,7 @@ function degree(p::Term, sym=nothing)
         return Int(isequal(p, sym))
     end
 end
- 
+
 function degree(p, sym=nothing)
     p = value(p)
     sym = value(sym)

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -195,3 +195,10 @@ x = Num.(randn(10))
 @variables t p x(t) y(t) z(t)
 @test isequal(substitute(y ~ x*p, Dict(x => z, y => t)), t ~ z*p)
 @test ~(!((1 < x) & (x < 2) | (x >= 100) ⊻ (x <= 1000) & (x != 100))) isa Num
+
+
+# Maybe move me
+
+@variables x[1:3]
+ex = x[1]+x[2]
+@test isequal(Symbolics.get_variables(ex), Symbolics.scalarize(x[1:2]))


### PR DESCRIPTION
Should resolve the issue of collecting variables created by indexing a symbolic array:

Before
```julia
@variables x[1:3] y z(t)
ex = x[1] + y + sin(z)
Symbolics.get_variables(ex) # Returns x, y, z(t) 
``` 

After:
```julia
@variables x[1:3] y z(t)
ex = x[1] + y + sin(z)
Symbolics.get_variables(ex) # Returns  x[1], y, z(t)
``` 

Tbh, maybe there is a more elegant dispatch I've not come up wth :smile: 

Related to https://github.com/SciML/DataDrivenDiffEq.jl/pull/230