### PR TITLE
remove `@parameters` from docstrings

### DIFF
--- a/src/num.jl
+++ b/src/num.jl
@@ -83,10 +83,12 @@ SymbolicUtils.expand(n::Num) = Num(SymbolicUtils.expand(value(n)))
 Performs the substitution on `expr` according to rule(s) `s`.
 # Examples
 ```julia
-julia> @parameters t
-(t,)
-julia> @variables x y z(t)
-(x, y, z(t))
+julia> @variables t x y z(t)
+4-element Vector{Num}:
+    t
+    x
+    y
+ z(t)
 julia> ex = x + y + sin(z)
 (x + y) + sin(z(t))
 julia> substitute(ex, Dict([x => z, sin(z) => z^2]))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,11 +27,12 @@ not wrapped in the `Num` type.
 
 # Examples
 ```julia
-julia> @parameters t
-(t,)
-
-julia> @variables x y z(t)
-(x, y, z(t))
+julia> @variables t x y z(t)
+4-element Vector{Num}:
+    t
+    x
+    y
+ z(t)
 
 julia> ex = x + y + sin(z)
 (x + y) + sin(z(t))
@@ -129,8 +130,10 @@ output `y` instead of `y(t)`.
 # Examples
 
 ```julia
-julia> @parameters t; @variables z(t)
-(z(t),)
+julia> @variables t z(t)
+2-element Vector{Num}:
+    t
+ z(t)
 
 julia> Symbolics.tosymbol(z)
 Symbol("z(t)")


### PR DESCRIPTION
I guess `@parameter` is from ModelingToolkit.

I found it confusing to show up in the Documentation here, though I'm not 100% sure the proposed changes are equivalent.