### PR TITLE
Namespacing, deterministic variable names, subscripted variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
-version = "1.4.2"
+version = "2.0.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -27,7 +27,7 @@ RuntimeGeneratedFunctions.init(@__MODULE__)
 export simplify, substitute
 
 using SciMLBase, IfElse
-export Num
+export Num, Namespace
 using MacroTools
 import MacroTools: splitdef, combinedef, postwalk, striplines
 include("wrapper-types.jl")

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -70,55 +70,6 @@ function scalarize_getindex(x, parent=x)
     end
 end
 
-"""
-$(TYPEDEF)
-
-A named variable which represents a numerical value. The variable is uniquely
-identified by its `name`, and all variables with the same `name` are treated
-as equal.
-
-# Fields
-$(FIELDS)
-
-For example, the following code defines an independent variable `t`, a parameter
-`α`, a function parameter `σ`, a variable `x`, which depends on `t`, a variable
-`y` with no dependents, a variable `z`, which depends on `t`, `α`, and `x(t)`
-and parameters `β₁` and `β₂`.
-
-
-```julia
-σ = Num(Variable{Symbolics.FnType{Tuple{Any},Real}}(:σ)) # left uncalled, since it is used as a function
-w = Num(Variable{Symbolics.FnType{Tuple{Any},Real}}(:w)) # unknown, left uncalled
-x = Num(Variable{Symbolics.FnType{Tuple{Any},Real}}(:x))(t)  # unknown, depends on `t`
-y = Num(Variable(:y))   # unknown, no dependents
-z = Num(Variable{Symbolics.FnType{NTuple{3,Any},Real}}(:z))(t, α, x)  # unknown, multiple arguments
-β₁ = Num(Variable(:β, 1)) # with index 1
-β₂ = Num(Variable(:β, 2)) # with index 2
-
-expr = β₁ * x + y^α + σ(3) * (z - t) - β₂ * w(t - 1)
-```
-"""
-struct Variable{T} <: Function # backward compat
-    """The variable's unique name."""
-    name::Symbol
-    Variable(name) = Sym{Real}(name)
-    Variable{T}(name) where T = Sym{T}(name)
-    function Variable{T}(name, indices...) where T
-        var_name = Symbol("$(name)$(join(map_subscripts.(indices), "ˏ"))")
-        Sym{T}(var_name)
-    end
-end
-
-function Variable(name, indices...)
-    var_name = Symbol("$(name)$(join(map_subscripts.(indices), "ˏ"))")
-    Variable(var_name)
-end
-
-# TODO: move this to Symutils
-function Sym{T}(name, i, indices...) where T
-    var_name = Symbol("$(name)$(join(map_subscripts.((i, indices...,)), "ˏ"))")
-    Sym{T}(var_name)
-end
 
 function map_subscripts(indices)
     str = string(indices)
@@ -397,3 +348,59 @@ _getname(x::Symbolic) = getsource(x)[2]
 getname(x::Namespace) = Symbol(getname(x.parent), :(.), getname(x.named))
 Base.show(io::IO, x::Namespace) = print(io, getname(x))
 Base.isequal(x::Namespace, y::Namespace) = isequal(x.parent, y.parent) && isequal(x.named, y.named)
+
+"""
+    variables(name::Symbol, indices...)
+
+Create a multi-dimensional array of individual variables named with subscript
+notation. Use `@variables` instead to create symbolic array variables (as
+opposed to array of variables). See `variable` to create one variable with
+subscripts.
+
+```julia-repl
+julia> Symbolics.variables(:x, 1:3, 3:6)
+3×4 Matrix{Num}:
+ x₁ˏ₃  x₁ˏ₄  x₁ˏ₅  x₁ˏ₆
+ x₂ˏ₃  x₂ˏ₄  x₂ˏ₅  x₂ˏ₆
+ x₃ˏ₃  x₃ˏ₄  x₃ˏ₅  x₃ˏ₆
+```
+"""
+function variables(name, indices...; T=Real)
+    [variable(name, ij...; T=T) for ij in Iterators.product(indices...)]
+end
+
+"""
+    variable(name::Symbol, idx::Integer...)
+
+Create a variable with the given name along with subscripted indices.
+
+```julia-repl
+julia> Symbolics.variable(:x, 5,2,0)
+x₄ˏ₂ˏ₀
+```
+
+Also see `variables`.
+"""
+function variable(name, idx...; T=Real)
+    name_ij = Symbol(name, join(map_subscripts.(idx), "ˏ"))
+    first(@variables $name_ij::T)
+end
+
+
+# BS deprecation below
+
+struct Variable{T} end
+
+function (::Type{Variable{T}})(s, i...) where {T}
+    Base.depwarn("Variable{T}(name, idx...) is deprecated, use variable(name, idx...; T=T)", :Variable, force=true)
+    variable(s, i...; T=T)
+end
+
+(::Type{Variable})(s, i...) = Variable{Real}(s, i...)
+(::Type{Variable})(s, i...) = Variable{Real}(s, i...)
+
+function (::Type{Sym{T}})(s, x, i...) where {T}
+    Base.depwarn("Sym{T}(name, x, idx...) is deprecated, use variable(name, x, idx...; T=T)", :Variable, force=true)
+    variable(s, x, i...; T=T)
+end
+(::Type{Sym})(s, x, i...) = Sym{Real}(s, x, i...)

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -1,5 +1,5 @@
 using Symbolics
-import Symbolics: getsource, getdefaultval, wrap, unwrap
+import Symbolics: getsource, getdefaultval, wrap, unwrap, getname
 import SymbolicUtils: Term, symtype, FnType
 using Test
 
@@ -11,7 +11,7 @@ Symbolics.@register fff(t)
 
 many_vars = @variables t=0 a=1 x[1:4]=2 y[1:4](t)=3 w[1:4] = 1:4 z[1:4](t) = 2:5 p[1:4](..)
 
-@test all(t->getsource(t) === :variables, many_vars)
+@test all(t->getsource(t)[1] === :variables, many_vars)
 @test getdefaultval(t) == 0
 @test getdefaultval(a) == 1
 @test_throws ErrorException getdefaultval(x)
@@ -20,6 +20,11 @@ many_vars = @variables t=0 a=1 x[1:4]=2 y[1:4](t)=3 w[1:4] = 1:4 z[1:4](t) = 2:5
 @test getdefaultval(w[2]) == 2
 @test getdefaultval(w[4]) == 4
 @test getdefaultval(z[3]) == 4
+
+nxt = Namespace(unwrap(x), unwrap(t))
+nxt_1 = Namespace(nxt, unwrap(x))
+@test getname(nxt) == Symbol(:x, :(.), :t)
+@test getname(nxt_1) == Symbol(:x, :(.), :t, :(.), :x)
 
 @test p[1] isa Term
 @test symtype(p[1]) <: FnType{Tuple, Real}

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -1,5 +1,5 @@
 using Symbolics
-import Symbolics: getdefaultval, wrap, unwrap
+import Symbolics: getsource, getdefaultval, wrap, unwrap
 import SymbolicUtils: Term, symtype, FnType
 using Test
 
@@ -9,8 +9,9 @@ Symbolics.@register fff(t)
 
 ## @variables
 
-@variables t=0 a=1 x[1:4]=2 y[1:4](t)=3 w[1:4] = 1:4 z[1:4](t) = 2:5 p[1:4](..)
+many_vars = @variables t=0 a=1 x[1:4]=2 y[1:4](t)=3 w[1:4] = 1:4 z[1:4](t) = 2:5 p[1:4](..)
 
+@test all(t->getsource(t) === :variables, many_vars)
 @test getdefaultval(t) == 0
 @test getdefaultval(a) == 1
 @test_throws ErrorException getdefaultval(x)


### PR DESCRIPTION
This PR solves a bunch of problems:

1. Helps avoid string-based namespacing in MTK: the new `Namespace{T}<:Symobolic{T}` type holds a parent object and a variable the parent object namespaces. We should use this in place of all the ambiguous stuff we have going on.
2. `@variables` now sneakily stores the variable name, so for example, we don't need brittle hacks to identify `x[1:10](t)` and extract the name from it. This also makes it equally less hacky to walk a system of equations and extract the list of variables that is closer to what the user intended.
3. Bring back the old behavior of `@variables x[1:3, 3:6]` in the form of `variables(:x, 1:3, 3:6)`

basically this PR makes everything one hundred times better.