### PR TITLE
[WIP] Remove dependence on `SciMLBase` & improve `issymbollike`

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -140,6 +140,5 @@ export symbolics_to_sympy
 include("init.jl")
 
 AbstractSymbolic = Union{Variable, Sym, Num, Term, SymbolicUtils.Symbolic}
-issymbollike(::AbstractSymbolic) = true
 
 end # module

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -26,7 +26,7 @@ RuntimeGeneratedFunctions.init(@__MODULE__)
 
 export simplify, substitute
 
-using SciMLBase, IfElse
+using IfElse
 export Num
 using MacroTools
 import MacroTools: splitdef, combinedef, postwalk, striplines
@@ -90,5 +90,8 @@ using Requires
 
 export symbolics_to_sympy
 include("init.jl")
+
+AbstractSymbolic = Union{Variable, Sym, Num, Term, SymbolicUtils.Symbolic}
+issymbollike(::AbstractSymbolic) = true
 
 end # module

--- a/src/num.jl
+++ b/src/num.jl
@@ -22,9 +22,6 @@ Num(x::Num) = x # ideally this should never be called
 value(x) = x
 value(x::Num) = unwrap(x)
 
-SciMLBase.issymbollike(::Num) = true
-SciMLBase.issymbollike(::SymbolicUtils.Symbolic) = true
-
 SymbolicUtils.@number_methods(
                               Num,
                               Num(f(value(a))),


### PR DESCRIPTION
Working on [SciMLBase#94](https://github.com/SciML/SciMLBase.jl/issues/94). 

Redefine `issymbollike` using new ` AbstractSymbolic` type & eliminate reference to `SciMLBase`.  The definition of `issymbollike` in RecursiveArrayTools/src/vector_of_array.jl used 'Operation' but I can't find out where it came from, so I'm leaving it out of the union that defines `AbstractSymbol` for now.

Next step will be to remove specialization of `issymbollike` from `RecursiveArrayTools`, and ultimately replace this function with dispatch based on `AbstractSymbolic`. But first, need to make sure that all the necessary types are available here in `Symbolics`.
