### PR TITLE
Moving Integral domain type from Domain to VarDomainPairing

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -112,6 +112,8 @@ export Difference
 
 include("difference.jl")
 
+include("domains.jl")
+
 export Integral
 include("integral.jl")
 
@@ -131,8 +133,6 @@ include("latexify_recipes.jl")
 
 using RecipesBase
 include("plot_recipes.jl")
-
-include("domains.jl")
 
 using Requires
 

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -124,8 +124,8 @@ function expand_derivatives(O::Symbolic, simplify=false; occurances=nothing)
                 end
             end
         elseif isa(operation(arg), Integral)
-            if isa(operation(arg).domain, AbstractInterval)
-                domain = operation(arg).domain
+            if isa(operation(arg).domain.domain, AbstractInterval)
+                domain = operation(arg).domain.domain
                 a, b = DomainSets.endpoints(domain)
                 c = 0
                 inner_function = expand_derivatives(arguments(arg)[1])

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -1,8 +1,8 @@
 # basic integral struct with upper bound and lower bound.
-struct Integral{X, T <: Domain} <: Function
+struct Integral{X, T <: Symbolics.VarDomainPairing} <: Function
     x
     domain::T
-    Integral(x,domain) = new{typeof(x),typeof(domain)}(Symbolics.value(x), domain)
+    Integral(x,domain) = new{typeof(x),typeof(domain)}(Symbolics.value.(x), domain)
 end
 
 (I::Integral)(x) = Term{SymbolicUtils.symtype(x)}(I, [x])


### PR DESCRIPTION
moves `Integral(x, ClosedInterval(0,1))` to  `Integral(x, x in ClosedInterval(0,1))`