### PR TITLE
Added the ability to pass known SymPy symbols to symbolics_to_sympy function

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -20,6 +20,11 @@ function __init__()
                 name = string(nameof(expr))
                 return symtype(expr) <: FnType ? SymPy.SymFunction(name) : get(symbols, name, SymPy.Sym(name))
             end
+        end 
+
+        function symbolics_to_sympy(expr, symbols) 
+            d = Dict(string(symbol) => symbol for symbol in symbols)
+            return symbolics_to_sympy(expr,d)
         end
 
     end # SymPy

--- a/src/init.jl
+++ b/src/init.jl
@@ -5,12 +5,12 @@ function __init__()
         using Symbolics: value
         using SymbolicUtils: istree, operation, arguments, symtype,
                              FnType, Symbolic
-        function symbolics_to_sympy(expr)
+        function symbolics_to_sympy(expr, symbols::Dict=Dict())
             expr = value(expr)
             expr isa Symbolic || return expr
             if istree(expr)
-                sop = symbolics_to_sympy(operation(expr))
-                sargs = map(symbolics_to_sympy, arguments(expr))
+                sop = symbolics_to_sympy(operation(expr), symbols)
+                sargs = map(a->symbolics_to_sympy(a, symbols), arguments(expr))
                 if sop === (^) && length(sargs) == 2 && sargs[2] isa Number
                     return Base.literal_pow(^, sargs[1], Val(sargs[2]))
                 else
@@ -18,7 +18,7 @@ function __init__()
                 end
             else # isa Symbolics.Sym
                 name = string(nameof(expr))
-                return symtype(expr) <: FnType ? SymPy.SymFunction(name) : SymPy.Sym(name)
+                return symtype(expr) <: FnType ? SymPy.SymFunction(name) : get(symbols, name, SymPy.Sym(name))
             end
         end
 

--- a/test/sympy.jl
+++ b/test/sympy.jl
@@ -22,3 +22,12 @@ sexpr = symbolics_to_sympy(expr)
 sp = symbolics_to_sympy(p)
 
 @test SymPy.simplify(symbolics_to_sympy(Symbolics.solve_for(expr, p))) == SymPy.solve(sexpr, sp)[1]
+
+@variables k
+sk = symbols("k", positive = True)
+@test symbolics_to_sympy(k) !== sk
+@test symbolics_to_sympy(k, Dict()) != sk
+@test symbolics_to_sympy(k, Dict("k"=>sk)) == sk
+@test symbolics_to_sympy(k, Dict("x"=>sk)) != sk
+@test symbolics_to_sympy(k, [sk]) == sk
+@test symbolics_to_sympy(k, (sk,)) == sk


### PR DESCRIPTION
SymPy has the ability to add constraints to variables:


```julia
sx = symbols("x", positive = True)
```

These variables however are different than those created by `symbolics_to_sympy`:


```julia
@variables x
symbolics_to_sympy(x) == sx # false 
```

I added the ability to pass a dictionary, a vector or a tuple of known SymPy symbols to `symbolics_to_sympy` function. 


```julia
@variables x
symbolics_to_sympy(x, Dict("x"=>sx)) == sx # true
symbolics_to_sympy(x, [sx]) == sx # true
symbolics_to_sympy(x, (sx,)) == sx # true
```

This solves #347.



┆Issue is synchronized with this [Trello card](https://trello.com/c/fJ9uYMAZ) by [Unito](https://www.unito.io)
