### PR TITLE
Compute ndims from runtime length of axes in `@variables`

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -239,7 +239,7 @@ end
 
 function _construct_array_vars(macroname, var_name, type, call_args, val, prop, indices...)
     # TODO: just use Sym here
-    ndim = length(indices)
+    ndim = :(length(($(indices...),)))
 
     need_scalarize = false
     expr = if call_args === nothing

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -76,3 +76,12 @@ let
 
     @test Symbolics.getname(Symbolics.rename(y[2], :u)) === :u
 end
+
+let
+    s = :y
+    x = (1:2,1:3)
+    t, y = @variables t $s[x...](t)
+
+    @test ndims(y) == 2
+    @test size(y) == (2,3)
+end


### PR DESCRIPTION
previously it would think the ndims in the test case is `1`.