### PR TITLE
fix substitute for Equation[]

### DIFF
--- a/src/equations.jl
+++ b/src/equations.jl
@@ -26,6 +26,11 @@ function SymbolicUtils.substitute(x::Equation, rules; kw...)
     sub(x.lhs; kw...) ~ sub(x.rhs; kw...)
 end
 
+function SymbolicUtils.substitute(eqs::Vector{Equation}, rules; kw...)
+    sub = substituter(rules)
+    sub.(lhss(eqs); kw...) .~ sub.(rhss(eqs); kw...)
+end
+
 lhss(xs) = map(x->x.lhs, xs)
 rhss(xs) = map(x->x.rhs, xs)
 

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -249,13 +249,10 @@ end
 D = Differential(x)
 @test isequal(expand_derivatives(D(foo(x, y, [1.2]) * x^2)), Differential(x)(foo(x, y, [1.2]))*(x^2) + 2x*foo(x, y, [1.2]))
 
-using ModelingToolkit, Test
-@parameters σ=10 ρ=28 β=8/3
-@variables t x(t)=1 y(t)=0 z(t)=0
+@variables t x(t) y(t)
 D = Differential(t)
 
-eqs = [D(x) ~ σ*(y-x),
-D(y) ~ x*(ρ-z)-σ]
+eqs = [D(x) ~ x, D(y) ~ y + x]
 
-sub_eqs = substitute(eqs, Dict(σ=>1))
-@test sub_eqs == [D(x) ~ (y-x), D(y) ~ x*(ρ-z)- 1]
+sub_eqs = substitute(eqs, Dict([D(x)=>D(x), x=>1]))
+@test sub_eqs == [D(x) ~ 1, D(y) ~ 1 + y]

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -248,3 +248,14 @@ end
 @register foo(x, y, z::Array)
 D = Differential(x)
 @test isequal(expand_derivatives(D(foo(x, y, [1.2]) * x^2)), Differential(x)(foo(x, y, [1.2]))*(x^2) + 2x*foo(x, y, [1.2]))
+
+using ModelingToolkit, Test
+@parameters σ=10 ρ=28 β=8/3
+@variables t x(t)=1 y(t)=0 z(t)=0
+D = Differential(t)
+
+eqs = [D(x) ~ σ*(y-x),
+D(y) ~ x*(ρ-z)-σ]
+
+sub_eqs = substitute(eqs, Dict(σ=>1))
+@test sub_eqs == [D(x) ~ (y-x), D(y) ~ x*(ρ-z)- 1]


### PR DESCRIPTION
currently (3.4.1) if you try to substitute on `Vector{Equation}` it defaults to the SU fallback, but doesn't actually do anything, 
ex: 
```julia
julia> using ModelingToolkit, Test, Symbolics

julia> @parameters σ=10 ρ=28 β=8/3
3-element Vector{Num}:
 σ
 ρ
 β

julia> @variables t x(t)=1 y(t)=0 z(t)=0
4-element Vector{Num}:
    t
 x(t)
 y(t)
 z(t)

julia> D = Differential(t)
(::Differential) (generic function with 2 methods)

julia> eqs = [D(x) ~ σ*(y-x),
       D(y) ~ x*(ρ-z)-σ]
2-element Vector{Equation}:
 Differential(t)(x(t)) ~ σ*(y(t) - x(t))
 Differential(t)(y(t)) ~ x(t)*(ρ - z(t)) - σ

julia> sub_eqs = substitute(eqs, Dict(σ=>1))
2-element Vector{Equation}:
 Differential(t)(x(t)) ~ σ*(y(t) - x(t))
 Differential(t)(y(t)) ~ x(t)*(ρ - z(t)) - σ

julia> map(x->substitute(x, Dict(σ=>1)), eqs)
2-element Vector{Equation}:
 Differential(t)(x(t)) ~ y(t) - x(t)
 Differential(t)(y(t)) ~ x(t)*(ρ - z(t)) - 1
```

so I just added a method and test to fix this 