### PR TITLE
Fix issue #389.

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -23,17 +23,26 @@ function latexify_derivatives(ex)
     end
 end
 
+recipe(n) = latexify_derivatives(cleanup_exprs(_toexpr(n)))
+
 @latexrecipe function f(n::Num)
     env --> :equation
     cdot --> false
 
-    return latexify_derivatives(cleanup_exprs(_toexpr(n)))
+    return recipe(n)
+end
+
+@latexrecipe function f(z::Complex{Num})
+    env --> :equation
+    cdot --> false
+
+    return :($(recipe(real(z))) + $(recipe(imag(z))) * i)
 end
 
 @latexrecipe function f(n::ArrayOp)
     env --> :equation
     cdot --> false
-    return latexify_derivatives(cleanup_exprs(_toexpr(n.term)))
+    return recipe(n.term)
 end
 
 @latexrecipe function f(n::Function)
@@ -55,7 +64,7 @@ end
     env --> :equation
     cdot --> false
 
-    return latexify_derivatives(cleanup_exprs(_toexpr(n)))
+    return recipe(n)
 end
 
 @latexrecipe function f(eqs::Vector{Equation})

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -42,3 +42,5 @@ Dy = Differential(y)
     Dx(u) ~   z
     Dx(y) ~   y*x
 ])
+
+@test_reference "latexify_refs/complex1.txt" latexify(x^2-y^2+2im*x*y)

--- a/test/latexify_refs/complex1.txt
+++ b/test/latexify_refs/complex1.txt
@@ -1,0 +1,3 @@
+\begin{equation}
+x^{2} - y^{2} + 2 x y i
+\end{equation}


### PR DESCRIPTION
This PR defines a new `@latexrecipe` to handle `Complex{Num}` types. Comments welcome.

Aside: I'm not sure if the methods defined in `src/latexify_recipes.jl` are intended to cover cases like:

```julia
using SymbolicUtils
@syms x::Real
latexify(im*x)
```

but that also fails due to hitting [this line](https://github.com/JuliaSymbolics/Symbolics.jl/blob/654e88ba8de7f874ffcc8e7f5a8b450b3b6895c9/src/latexify_recipes.jl#L152).  It seems complicated to ensure use of `@syms` or `@variables` would result in the same formatting.