### PR TITLE
more conscious sparse array handling in build_function

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -282,17 +282,13 @@ _issparse(x::Union{SubArray, Base.ReshapedArray, LinearAlgebra.Transpose}) = iss
 function _make_sparse_array(arr, similarto)
     if arr isa Union{SubArray, Base.ReshapedArray, LinearAlgebra.Transpose}
         quote
-            let reference = $(nzmap(x->true, arr));
-                $Setfield.@set reference.parent = $(_make_array(parent(arr),
-                                                                typeof(parent(arr))))
-            end
+            $Setfield.@set $(nzmap(x->true, arr)).parent =
+                $(_make_array(parent(arr), typeof(parent(arr))))
         end
     else
         quote
-            let reference = $(nzmap(x->true, arr));
-                $Setfield.@set reference.nzval = $(_make_array(arr.nzval,
-                                                               Vector{symtype(eltype(arr))}))
-            end
+            $Setfield.@set $(nzmap(x->true, arr)).nzval =
+                $(_make_array(arr.nzval, Vector{symtype(eltype(arr))}))
         end
     end
 end

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -275,7 +275,7 @@ end
 nzmap(f, x) = map(f, x)
 
 _issparse(x::AbstractArray) = issparse(x)
-_issparse(x::Union{SubArray, Base.ReshapedArray, LinearAlgebra.Transpose}) = issparse(parent(x))
+_issparse(x::Union{SubArray, Base.ReshapedArray, LinearAlgebra.Transpose}) = _issparse(parent(x))
 
 function _make_sparse_array(arr, similarto)
     if arr isa Union{SubArray, Base.ReshapedArray, LinearAlgebra.Transpose}

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -285,9 +285,11 @@ function _make_sparse_array(arr, similarto)
             end)
     else
         LiteralExpr(quote
-            $Setfield.@set $(nzmap(x->true, arr)).nzval =
-                $(_make_array(arr.nzval, Vector{symtype(eltype(arr))}))
-            end)
+                        let __reference = copy($(nzmap(x->true, arr)))
+                            $Setfield.@set __reference.nzval =
+                            $(_make_array(arr.nzval, Vector{symtype(eltype(arr))}))
+                        end
+                    end)
     end
 end
 

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -265,8 +265,20 @@ function toexpr(p::SpawnFetch{MultithreadedForm}, st)
     end
 end
 
-function nzmap(f, x::Union{SubArray, Base.ReshapedArray, LinearAlgebra.Transpose})
+function nzmap(f, x::Union{Base.ReshapedArray, LinearAlgebra.Transpose})
     Setfield.@set x.parent = nzmap(f, x.parent)
+end
+
+function nzmap(f, x::SubArray)
+    unview = copy(x)
+    if unview isa Union{SparseMatrixCSC, SparseVector}
+        n = nnz(unview)
+        if n != length(unview.nzval)
+            resize!(unview.nzval, n)
+            resize!(unview.rowval, n)
+        end
+    end
+    nzmap(f, unview)
 end
 
 function nzmap(f, x::AbstractSparseArray)

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -121,9 +121,7 @@ let
 
     f1,f2=build_function(@views(x[2:3,1:2]), [a,b,c], expression=Val{false})
     y = f1([1,2,3])
-    @test y isa Base.SubArray
-    @test y.parent isa Base.ReshapedArray
-    @test y.parent.parent.rowval == x.parent.rowval
+    @test y isa SparseMatrixCSC
     @test y == [0 0; 1 3]
 end
 

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -115,7 +115,6 @@ let # ModelingToolkit.jl#800
     sf1, sf2 = string(f1), string(f2)
     @test !contains(sf1, "CartesianIndex")
     @test !contains(sf2, "CartesianIndex")
-    @test contains(sf1, "SparseMatrixCSC(")
     @test contains(sf2, ".nzval")
 end
 

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -118,6 +118,13 @@ let
     @test y.parent isa SparseMatrixCSC
     @test y.parent.rowval == x.parent.rowval
     @test y == [0 2; 0 0; 1 3]
+
+    f1,f2=build_function(@views(x[2:3,1:2]), [a,b,c], expression=Val{false})
+    y = f1([1,2,3])
+    @test y isa Base.SubArray
+    @test y.parent isa Base.ReshapedArray
+    @test y.parent.parent.rowval == x.parent.rowval
+    @test y == [0 0; 1 3]
 end
 
 let # ModelingToolkit.jl#800

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -107,6 +107,19 @@ f = eval(build_function(sparse([1],[1], [(x+y)/k], 10,10), [x,y,k])[1])
 @test f([1.,1.,2])[1,1] == 1.0
 @test sum(f([1.,1.,2])) == 1.0
 
+# Reshaped SparseMatrix optimization
+let
+    @variables a b c
+
+    x = reshape(sparse([0 a 0; 0 b c]), 3, 2)
+    f1,f2=build_function(x, [a,b,c], expression=Val{false})
+    y = f1([1,2,3])
+    @test y isa Base.ReshapedArray
+    @test y.parent isa SparseMatrixCSC
+    @test y.parent.rowval == x.parent.rowval
+    @test y == [0 2; 0 0; 1 3]
+end
+
 let # ModelingToolkit.jl#800
     @variables x
     y = sparse(1:3,1:3,x)


### PR DESCRIPTION
This avoids calling `map(x->_make_array...` to recursively look for sparse arrays, and tries to use `nzmap` which leaves the zeros untouched. This eventually avoids calls to `iszero` which is very slow...

should fix the slow build_function generation in https://github.com/JuliaSymbolics/Symbolics.jl/issues/435 (it goes to < 16secs first and <1sec subsequent runs.)