### PR TITLE
add jacobian method for Arr

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -135,12 +135,6 @@ end
 const SymArray = Union{ArrayOp, Symbolic{<:AbstractArray}}
 const SymMat = Union{ArrayOp{<:AbstractMatrix}, Symbolic{<:AbstractMatrix}}
 const SymVec = Union{ArrayOp{<:AbstractVector}, Symbolic{<:AbstractVector}}
-const ArrayLike{T,N} = Union{
-    ArrayOp{AbstractArray{T,N}},
-    Symbolic{AbstractArray{T,N}},
-    Arr{T,N},
-    SymbolicUtils.Term{Arr{T, N}}
-} # Like SymArray but includes Arr and Term{Arr}
 
 ### Propagate ###
 #
@@ -402,6 +396,13 @@ function Arr(x)
     @assert A <: AbstractArray
     Arr{maybewrap(eltype(A)), ndims(A)}(x)
 end
+
+const ArrayLike{T,N} = Union{
+    ArrayOp{AbstractArray{T,N}},
+    Symbolic{AbstractArray{T,N}},
+    Arr{T,N},
+    SymbolicUtils.Term{Arr{T, N}}
+} # Like SymArray but includes Arr and Term{Arr}
 
 unwrap(x::Arr) = x.value
 

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -135,6 +135,12 @@ end
 const SymArray = Union{ArrayOp, Symbolic{<:AbstractArray}}
 const SymMat = Union{ArrayOp{<:AbstractMatrix}, Symbolic{<:AbstractMatrix}}
 const SymVec = Union{ArrayOp{<:AbstractVector}, Symbolic{<:AbstractVector}}
+const ArrayLike{T,N} = Union{
+    ArrayOp{AbstractArray{T,N}},
+    Symbolic{AbstractArray{T,N}},
+    Arr{T,N},
+    SymbolicUtils.Term{Arr{T, N}}
+} # Like SymArray but includes Arr and Term{Arr}
 
 ### Propagate ###
 #

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -369,6 +369,12 @@ function jacobian(ops::AbstractVector, vars::AbstractVector; simplify=false)
     Num[Num(expand_derivatives(Differential(value(v))(value(O)),simplify)) for O in ops, v in vars]
 end
 
+function jacobian(ops::ArrayLike{T, 1}, vars::ArrayLike{T, 1}; simplify=false) where T
+    ops = scalarize(ops)
+    vars = scalarize(vars) # Suboptimal, but prevents wrong results on Arr for now. Arr resulting from a symbolic function will fail on this due to unknown size.
+    Num[Num(expand_derivatives(Differential(value(v))(value(O)),simplify)) for O in ops, v in vars]
+end
+
 """
 $(SIGNATURES)
 


### PR DESCRIPTION
This approach still fails for Arr variables that do not contain size information, but it prevents returning the wrong result which is a current problem. Partly addresses #439 

This PR also introduces som `@test_skip` which should pass, but currently throws errors.