### PR TITLE
DiscreteUpdate to Shift

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -90,7 +90,7 @@ export Differential, expand_derivatives
 
 include("diff.jl")
 
-export Difference, DiscreteUpdate
+export Difference, Shift
 
 include("difference.jl")
 

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -67,6 +67,13 @@ function occursin_info(x, expr::Sym)
     isequal(x, expr)
 end
 
+hasderiv(eq::Equation) = hasderiv(eq.lhs) || hasderiv(eq.rhs)
+
+"""
+    hasderiv(O)
+
+Returns true if the expression or equation `O` contains [`Differential`](@ref) terms.
+"""
 function hasderiv(O)
     istree(O) || return false
     if operation(O) isa Differential

--- a/src/difference.jl
+++ b/src/difference.jl
@@ -16,13 +16,15 @@ julia> @variables t;
 julia> Δ = Difference(t; dt=0.01)
 (::Difference) (generic function with 2 methods)
 ```
+
+See also [`Shift`](@ref)
 """
 struct Difference <: Function
     """Fixed Difference"""
     t
     dt
-    update::Bool
-    Difference(t; dt, update=false) = new(value(t), dt, update)
+    shift::Bool
+    Difference(t; dt, shift=false) = new(value(t), dt, shift)
 end
 (D::Difference)(t) = Term{symtype(t)}(D, [t])
 (D::Difference)(t::Num) = Num(D(value(t)))
@@ -30,9 +32,9 @@ SymbolicUtils.promote_symtype(::Difference, t) = t
 """
 $(SIGNATURES)
 
-Represents a discrete update (shift) operator with the semantics
+Represents a discrete time-shift operator with the semantics
 ```
-DiscreteUpdate(t; dt=0.01)(y) ~ y(t+dt)
+Shift(t; dt=0.01)(y) ~ y(t+dt)
 ```
 
 # Examples
@@ -42,15 +44,17 @@ julia> using Symbolics
 
 julia> @variables t;
 
-julia> U = DiscreteUpdate(t; dt=0.01)
+julia> U = Shift(t; dt=0.01)
 (::Difference) (generic function with 2 methods)
 ```
 """
-DiscreteUpdate(t; dt) = Difference(t; dt=dt, update=true)
+Shift(t; dt) = Difference(t; dt=dt, shift=true)
 
-Base.show(io::IO, D::Difference) = print(io, "Difference(", D.t, "; dt=", D.dt, ", update=", D.update, ")")
+Base.@deprecate DiscreteUpdate(t; dt) Shift(t; dt)
 
-Base.:(==)(D1::Difference, D2::Difference) = isequal(D1.t, D2.t) && isequal(D1.dt, D2.dt) && isequal(D1.update, D2.update)
+Base.show(io::IO, D::Difference) = print(io, "Difference(", D.t, "; dt=", D.dt, ", shift=", D.shift, ")")
+
+Base.:(==)(D1::Difference, D2::Difference) = isequal(D1.t, D2.t) && isequal(D1.dt, D2.dt) && isequal(D1.shift, D2.shift)
 Base.hash(D::Difference, u::UInt) = hash(D.dt, hash(D.t, xor(u, 0x055640d6d952f101)))
 
 Base.:^(D::Difference, n::Integer) = _repeat_apply(D, n)

--- a/src/difference.jl
+++ b/src/difference.jl
@@ -58,3 +58,28 @@ Base.:(==)(D1::Difference, D2::Difference) = isequal(D1.t, D2.t) && isequal(D1.d
 Base.hash(D::Difference, u::UInt) = hash(D.dt, hash(D.t, xor(u, 0x055640d6d952f101)))
 
 Base.:^(D::Difference, n::Integer) = _repeat_apply(D, n)
+
+hasdiff(eq::Equation) = hasdiff(eq.lhs) || hasdiff(eq.rhs)
+
+
+"""
+    hasdiff(O)
+
+Returns true if the expression or equation `O` contains [`Difference`](@ref) terms (this include [`Shift`](@ref)).
+"""
+function hasdiff(O)
+    istree(O) || return false
+    if operation(O) isa Difference
+        return true
+    else
+        if O isa Union{Add, Mul}
+            any(hasdiff, keys(O.dict))
+        elseif O isa Pow
+            hasdiff(O.base) || hasdiff(O.exp)
+        elseif O isa SymbolicUtils.Div
+            hasdiff(O.num) || hasdiff(O.den)
+        else
+            any(hasdiff, arguments(O))
+        end
+    end
+end

--- a/test/difference.jl
+++ b/test/difference.jl
@@ -1,4 +1,5 @@
 using Symbolics
+using Symbolics: hasdiff
 using Test
 
 @variables t x
@@ -12,3 +13,10 @@ D2 = Difference(t; dt=0.01)
 @test D1(x) isa Num
 
 @test isequal((D1^2)(x), D1(D1(x)))
+
+# hasdiff
+@test hasdiff(D1(x) ~ x)
+@test hasdiff(x ~ D1(x))
+@test !hasdiff(t ~ x)
+@test hasdiff((D1^2)(x) ~ x)
+@test hasdiff(D1(x) ~ D2(x))


### PR DESCRIPTION
This PR makes the change proposed in 
- https://github.com/JuliaSymbolics/Symbolics.jl/pull/430

Additionally, function `hasdiff` is added and tested, works similarly to `hasderiv`.

Note: this is a breaking change. A deprecation is added to `DiscreteUpdate`,  but any access to the internal field `update` which is renamed to `shift` is breaking.