### PR TITLE
WIP: @register changes

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -73,7 +73,7 @@ export degree
 using ConstructionBase
 include("arrays.jl")
 
-export @register
+export @register, @register_symbolic
 include("register.jl")
 
 using TreeViews

--- a/src/extra_functions.jl
+++ b/src/extra_functions.jl
@@ -1,9 +1,9 @@
-@register Base.binomial(n,k)
+@register_symbolic Base.binomial(n,k)
 
-@register Base.sign(x)::Int
+@register_symbolic Base.sign(x)::Int
 derivative(::typeof(sign), args::NTuple{1,Any}, ::Val{1}) = 0
 
-@register Base.signbit(x)::Bool
+@register_symbolic Base.signbit(x)::Bool
 derivative(::typeof(signbit), args::NTuple{1,Any}, ::Val{1}) = 0
 derivative(::typeof(abs), args::NTuple{1,Any}, ::Val{1}) = IfElse.ifelse(signbit(args[1]),-one(args[1]),one(args[1]))
 
@@ -24,31 +24,31 @@ function derivative(::typeof(max), args::NTuple{2,Any}, ::Val{2})
     IfElse.ifelse(x > y, zero(y), one(y))
 end
 
-@register Base.ceil(x)
-@register Base.floor(x)
-@register Base.factorial(x)
+@register_symbolic Base.ceil(x)
+@register_symbolic Base.floor(x)
+@register_symbolic Base.factorial(x)
 
 function derivative(::Union{typeof(ceil),typeof(floor),typeof(factorial)}, args::NTuple{1,Any}, ::Val{1})
     zero(args[1])
 end
 
-@register Base.rand(x)
-@register Base.randn(x)
+@register_symbolic Base.rand(x)
+@register_symbolic Base.randn(x)
 
-@register Distributions.pdf(dist,x)
-@register Distributions.logpdf(dist,x)
-@register Distributions.cdf(dist,x)
-@register Distributions.logcdf(dist,x)
-@register Distributions.quantile(dist,x)
+@register_symbolic Distributions.pdf(dist,x)
+@register_symbolic Distributions.logpdf(dist,x)
+@register_symbolic Distributions.cdf(dist,x)
+@register_symbolic Distributions.logcdf(dist,x)
+@register_symbolic Distributions.quantile(dist,x)
 
-@register Distributions.Uniform(mu,sigma) false
-@register Distributions.Normal(mu,sigma) false
+@register_symbolic Distributions.Uniform(mu,sigma) false
+@register_symbolic Distributions.Normal(mu,sigma) false
 
-@register ∈(x::Real, y::AbstractArray)::Bool
-@register ∪(x, y)
-@register ∩(x, y)
-@register ∨(x, y)
-@register ∧(x, y)
-@register ⊆(x, y)
+@register_symbolic ∈(x::Real, y::AbstractArray)::Bool
+@register_symbolic ∪(x, y)
+@register_symbolic ∩(x, y)
+@register_symbolic ∨(x, y)
+@register_symbolic ∧(x, y)
+@register_symbolic ⊆(x, y)
 
 LinearAlgebra.norm(x::Num, p::Real) = abs(x)

--- a/src/extra_functions.jl
+++ b/src/extra_functions.jl
@@ -6,6 +6,7 @@ derivative(::typeof(sign), args::NTuple{1,Any}, ::Val{1}) = 0
 @register Base.signbit(x)::Bool
 derivative(::typeof(signbit), args::NTuple{1,Any}, ::Val{1}) = 0
 derivative(::typeof(abs), args::NTuple{1,Any}, ::Val{1}) = IfElse.ifelse(signbit(args[1]),-one(args[1]),one(args[1]))
+
 function derivative(::typeof(min), args::NTuple{2,Any}, ::Val{1})
     x, y = args
     IfElse.ifelse(x < y, one(x), zero(x))
@@ -22,7 +23,7 @@ function derivative(::typeof(max), args::NTuple{2,Any}, ::Val{2})
     x, y = args
     IfElse.ifelse(x > y, zero(y), one(y))
 end
-            
+
 @register Base.ceil(x)
 @register Base.floor(x)
 @register Base.factorial(x)
@@ -30,7 +31,7 @@ end
 function derivative(::Union{typeof(ceil),typeof(floor),typeof(factorial)}, args::NTuple{1,Any}, ::Val{1})
     zero(args[1])
 end
-            
+
 @register Base.rand(x)
 @register Base.randn(x)
 

--- a/src/extra_functions.jl
+++ b/src/extra_functions.jl
@@ -43,7 +43,7 @@ end
 @register Distributions.Uniform(mu,sigma) false
 @register Distributions.Normal(mu,sigma) false
 
-@register ∈(x::Num, y::AbstractArray)
+@register ∈(x::Real, y::AbstractArray)::Bool
 @register ∪(x, y)
 @register ∩(x, y)
 @register ∨(x, y)

--- a/src/register.jl
+++ b/src/register.jl
@@ -49,7 +49,7 @@ macro register(expr, define_promotion = true, Ts = [])
     end
 
     eval_method = :(@eval function $f($(Expr(:$, :(s...))),)
-                        $wrap($Term{$ret_type}($f, [$(Expr(:$, :(s_syms...)))]))
+                        $wrap($Term{$ret_type}($f, map($unwrap, [$(Expr(:$, :(s_syms...)))])))
                     end)
     verbose = false
     mod, fname = f isa Expr && f.head == :(.) ? f.args : (:(@__MODULE__), QuoteNode(f))

--- a/src/register.jl
+++ b/src/register.jl
@@ -1,7 +1,7 @@
 using SymbolicUtils: Symbolic
 
 """
-    @register(expr, define_promotion = true, Ts = [Num, Symbolic, Real])
+    @register_symbolic(expr, define_promotion = true, Ts = [Num, Symbolic, Real])
 
 Overload appropriate methods so that Symbolics can stop tracing into the
 registered function. If `define_promotion` is true, then a promotion method in
@@ -16,13 +16,13 @@ overwritting.
 
 # Examples
 ```julia
-@register foo(x, y)
-@register foo(x, y::Bool) false # do not overload a duplicate promotion rule
-@register goo(x, y::Int) # `y` is not overloaded to take symbolic objects
-@register hoo(x, y)::Int # `hoo` returns `Int`
+@register_symbolic foo(x, y)
+@register_symbolic foo(x, y::Bool) false # do not overload a duplicate promotion rule
+@register_symbolic goo(x, y::Int) # `y` is not overloaded to take symbolic objects
+@register_symbolic hoo(x, y)::Int # `hoo` returns `Int`
 ```
 """
-macro register(expr, define_promotion = true, Ts = [])
+macro register_symbolic(expr, define_promotion = true, Ts = [])
     if expr.head === :(::)
         ret_type = expr.args[2]
         expr = expr.args[1]
@@ -78,6 +78,8 @@ macro register(expr, define_promotion = true, Ts = [])
         end
     end |> esc
 end
+
+Base.@deprecate_binding var"@register" var"@register_symbolic"
 
 # Ensure that Num that get @registered from outside the ModelingToolkit
 # module can work without having to bring in the associated function into the

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -150,12 +150,13 @@ Symbolics.@register no_der(x)
                  Symbolics.derivative([sin(cos(x)), hypot(x, no_der(x))], x),
                  [
                   -sin(x) * cos(cos(x)),
-                  x/hypot(x, no_der(x)) + no_der(x)*Differential(x)(no_der(x))/hypot(x, no_der(x))
+                  x/hypot(x, no_der(x)) +
+                      no_der(x)*Differential(x)(no_der(x))/hypot(x, no_der(x))
                  ]
                 )
 
 Symbolics.@register intfun(x)::Int
-@test Symbolics.symtype(intfun(x)) === Int
+@test Symbolics.symtype(intfun(x).val) === Int
 
 eqs = [σ*(y-x),
        x*(ρ-z)-y,

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -145,7 +145,7 @@ canonequal(a, b) = isequal(simplify(a), simplify(b))
                  -sin(x) * cos(cos(x))
                 )
 
-Symbolics.@register no_der(x)
+Symbolics.@register_symbolic no_der(x)
 @test canonequal(
                  Symbolics.derivative([sin(cos(x)), hypot(x, no_der(x))], x),
                  [
@@ -155,7 +155,7 @@ Symbolics.@register no_der(x)
                  ]
                 )
 
-Symbolics.@register intfun(x)::Int
+Symbolics.@register_symbolic intfun(x)::Int
 @test Symbolics.symtype(intfun(x).val) === Int
 
 eqs = [σ*(y-x),
@@ -245,7 +245,7 @@ let
 end
 
 @variables x y
-@register foo(x, y, z::Array)
+@register_symbolic foo(x, y, z::Array)
 D = Differential(x)
 @test isequal(expand_derivatives(D(foo(x, y, [1.2]) * x^2)), Differential(x)(foo(x, y, [1.2]))*(x^2) + 2x*foo(x, y, [1.2]))
 

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -194,7 +194,6 @@ end
         res.=[a*x^2, y^3, b*x^4, sin(y), c*x+y, x+z^2, a*z+x, x+y^2+sin(z)]
     end
 
-    
     input=rand(3)
     output=rand(8)
 

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -4,7 +4,7 @@ import SymbolicUtils: Term, symtype, FnType
 using Test
 
 @variables t
-Symbolics.@register fff(t)
+Symbolics.@register_symbolic fff(t)
 @test isequal(fff(t), Symbolics.Num(Symbolics.Term{Real}(fff, [Symbolics.value(t)])))
 
 ## @variables


### PR DESCRIPTION
```julia
julia> @register foo(x::AbstractArray)::Real

julia> @variables x[1:9]
1-element Vector{Symbolics.Arr{Num, 1}}:
 x[1:9]

julia> foo(x)
foo(x[1:9])

julia> foo(x) |> typeof
Num

julia> foo([1])
ERROR: MethodError: no method matching foo(::Vector{Int64})
Closest candidates are:
  foo(::SymbolicUtils.Symbolic{var"#s25"} where var"#s25"<:AbstractFoo, ::SymbolicUtils.Symbolic{var"#s24"} where var"#s24"<:Real) at /home/shashi/.julia/dev/Symbolics/src/wrapper-types.jl:126
  foo(::FooWrap, ::SymbolicUtils.Symbolic{var"#s23"} where var"#s23"<:Real) at /home/shashi/.julia/dev/Symbolics/src/wrapper-types.jl:126
  foo(::AbstractFoo, ::SymbolicUtils.Symbolic{var"#s26"} where var"#s26"<:Real) at /home/shashi/.julia/dev/Symbolics/src/wrapper-types.jl:126
  ...
Stacktrace:
 [1] top-level scope

```
Also:
```julia
julia> @register bar(x::Real)::AbstractVector{Real}

julia> bar(x[1])
(bar(x[1]))

julia> bar(x[1]) |> typeof
Symbolics.Arr{Num, 1}

julia> bar([1])
ERROR: MethodError: no method matching bar(::Vector{Int64})
Closest candidates are:
  bar(::SymbolicUtils.Symbolic{var"#s27"} where var"#s27"<:Real) at /home/shashi/.julia/dev/Symbolics/src/register.jl:51
  bar(::Num) at /home/shashi/.julia/dev/Symbolics/src/register.jl:51
Stacktrace:
 [1] top-level scope
   @ REPL[20]:1

```

It avoids defining methods for `Real` and `AbstractArray` or non-symbolic arguments so that we can safely extend functions that already have those methods.

Fixes #438

cc @baggepinnen @YingboMa @MasonProtter 