### PR TITLE
Remove destructive invalidation and fix compile times

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -122,7 +122,6 @@ using Requires
 export symbolics_to_sympy
 include("init.jl")
 
-
 include("semipoly.jl")
 
 # Hacks to make wrappers "nicer"
@@ -130,7 +129,7 @@ const NumberTypes = Union{AbstractFloat,Integer,Complex{<:AbstractFloat},Complex
 (::Type{T})(x::SymbolicUtils.Symbolic) where {T<:NumberTypes} = throw(ArgumentError("Cannot convert Sym to $T since Sym is symbolic and $T is concrete. Use `substitute` to replace the symbolic unwraps."))
 for T in [Num, Complex{Num}]
     @eval begin
-        (::Type{S})(x::$T) where {S<:Union{NumberTypes,AbstractArray}} = S(Symbolics.unwrap(x))::S
+        #(::Type{S})(x::$T) where {S<:Union{NumberTypes,AbstractArray}} = S(Symbolics.unwrap(x))::S
 
         SymbolicUtils.simplify(n::$T; kw...) = wrap(SymbolicUtils.simplify(unwrap(n); kw...))
         SymbolicUtils.simplify_fractions(n::$T; kw...) = wrap(SymbolicUtils.simplify_fractions(unwrap(n); kw...))

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -208,8 +208,8 @@ A = [x[1] 2
      2    0.0]
 B = [x[1] 1.0
     2.0 0.0]
-@test_throws ArgumentError Matrix{Float64}(A)
-@test Matrix{Float64}(A-B) isa Matrix{Float64}
-@test Matrix{Float64}(A-B) == [0.0 1.0;0.0 0.0]
+@test_throws MethodError Matrix{Float64}(A)
+@test_broken Matrix{Float64}(A-B) isa Matrix{Float64}
+@test_broken Matrix{Float64}(A-B) == [0.0 1.0;0.0 0.0]
 
 @test isequal(simplify(cos(x)^2 + sin(x)^2 + im * x), 1 + x*im)


### PR DESCRIPTION
```julia
using DifferentialEquations, SnoopCompile

function lorenz(du,u,p,t)
 du[1] = 10.0(u[2]-u[1])
 du[2] = u[1]*(28.0-u[3]) - u[2]
 du[3] = u[1]*u[2] - (8/3)*u[3]
end

u0 = [1.0;0.0;0.0]
tspan = (0.0,100.0)
prob = ODEProblem(lorenz,u0,tspan)
alg = Rodas5(chunk_size = Val{3}(), linsolve = DiffEqBase.LUFactorize())
tinf = @snoopi_deep solve(prob,alg)
```

Before:

```julia
InferenceTimingNode: 1.388166/12.746425 on Core.Compiler.Timings.ROOT() with 2 direct children
```

After:

```julia
# InferenceTimingNode: 1.002721/2.089656 on Core.Compiler.Timings.ROOT() with 3 direct children
```

Fixes https://github.com/SciML/DifferentialEquations.jl/issues/785