### PR TITLE
Add method for `^(::Irrational{:ℯ}, x::Num)`

### DIFF
--- a/src/num.jl
+++ b/src/num.jl
@@ -65,6 +65,7 @@ function Base.:/(x::Complex{Num}, y::Complex{Num})
     Complex((a*c + b*d)/den, (b*c - a*d)/den)
 end
 Base.:^(z::Complex{Num}, n::Integer) = Base.power_by_squaring(z, n)
+Base.:^(::Irrational{:ℯ}, x::Num) = exp(x)
 
 function Base.show(io::IO, z::Complex{<:Num})
     r, i = reim(z)

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -167,6 +167,8 @@ z2 = c + d * im
 @test sign(Num(1)) isa Num
 @test isequal(sign(Num(1)), Num(1))
 @test isequal(sign(Num(-1)), Num(-1))
+                    
+@test isequal(ℯ^a, exp(a))
 
 using IfElse: ifelse
 @test isequal(Symbolics.derivative(abs(x), x), ifelse(signbit(x), -1, 1))


### PR DESCRIPTION
Adds a method for `Base.:^(::Irrational{:ℯ}, x::Num)` so that Symbolics can parse `ℯ^x` (where ℯ is Julia's built-in Euler's constant) as `exp(x)`. I figured I'd just make this PR after seeing someone run into an error on SO from trying to do
```julia
@variables x
ℯ^x
```