### PR TITLE
Additional test for array substitution

### DIFF
--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -194,3 +194,12 @@ end
     r = @rule ((~A*~B)*~C) => (~A*(~B*~C)) where size(~A,1)*size(~B,2) > size(~B,1)*size(~C,2)
     @test isequal(r(unwrap((X*Y)*b)), unwrap(X*(Y*b)))
 end
+
+@testset "Partial array substitution" begin
+    @variables x[1:3] A[1:2, 1:2, 1:2]
+
+    @test substitute(x[1], Dict(x => [1, 2, 3])) === Num(1)
+    @test substitute(A[1,2,1], Dict(A => reshape(1:8, 2, 2, 2))) === Num(3)
+
+    @test substitute(A[1,2,1], Dict(A[1,2,1] => 9)) === Num(9)
+end


### PR DESCRIPTION
I would like to fix #509, namely this test case:


```julia
@variables x[1:3]
substitute(x[1], Dict([x => [1, 0, 0]]))
```

My idea is to find all indexing subexpression inside `expr`, collect them and for each of them adding a corresponding substitution in the dict before calling SymbolicUtils.substitute.
In the previous example,
```substitute(x[1], Dict([x => [1, 0, 0]]))```
would become
```substitute(x[1], Dict([x => [1, 0, 0], x[1] => 0))```
(only terms actually appearing in the expression are added to the substitution dict).

Unfortunately I don't know my way around the code. Say I have `@variables x[1:3]`, and I stumble upon `x[1]`. How can I create from it a Symbolic.Arr called x with the right dimensions in order to search the substitution Dict for its presence?



┆Issue is synchronized with this [Trello card](https://trello.com/c/LpZnxbYo) by [Unito](https://www.unito.io)
