### PR TITLE
Fix D^t compile time problem

### DIFF
--- a/src/diff.jl
+++ b/src/diff.jl
@@ -337,7 +337,7 @@ function count_order(x)
     n, x.args[1]
 end
 
-_repeat_apply(f, n) = n == 1 ? f : f ∘ _repeat_apply(f, n-1)
+_repeat_apply(f, n) = n == 1 ? f : ComposedFunction{Any,Any}(f, _repeat_apply(f, n-1))
 function _differential_macro(x)
     ex = Expr(:block)
     push!(ex.args,  :(Base.depwarn("`@derivatives D'''~x` is deprecated. Use `Differential(x)^3` instead.", Symbol("@derivatives"), force=true)))


### PR DESCRIPTION
```julia
julia> using Symbolics

julia> @variables t u(t)
2-element Vector{Num}:
    t
 u(t)

julia> N = 20
20

julia> D = Differential(t)
(::Differential) (generic function with 2 methods)

julia> DN = D^N
Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t) ∘ Differential(t)

julia> @time DN(u)
  0.045852 seconds (128.03 k allocations: 7.480 MiB, 99.69% compilation time)
Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(Differential(t)(u(t)))))))))))))))))))))
```