### PR TITLE
Dependent array variable convention deprecation

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -577,6 +577,9 @@ function scalarize_op(f, arr, idx)
         wrap(getmetadata(arr, ScalarizeCache)[][idx...])
     else
         thing = f(scalarize.(map(wrap, arguments(arr)))...)
+        if !hasmetadata(arr, ScalarizeCache)
+            arr = setmetadata(arr, ScalarizeCache, Ref{Any}(nothing))
+        end
         getmetadata(arr, ScalarizeCache)[] = thing
         wrap(thing[idx...])
     end

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -53,9 +53,13 @@ Base.hash(D::Differential, u::UInt) = hash(D.x, xor(u, 0xdddddddddddddddd))
 _isfalse(occ::Bool) = occ === false
 _isfalse(occ::Term) = _isfalse(operation(occ))
 
-function occursin_info(x, expr)
+function occursin_info(x, expr, fail = true)
     if symtype(expr) <: AbstractArray
-        error("Differentiation of expressions involving arrays and array variables is not yet supported.")
+        if fail
+            error("Differentiation with array expressions is not yet supported")
+        else
+            return occursin(x, expr)
+        end
     end
 
     # Allow scalarized expressions
@@ -65,11 +69,13 @@ function occursin_info(x, expr)
          is_scalar_indexed(operation(ex)))
     end
 
+    # x[1] == x[1] but not x[2]
     if is_scalar_indexed(x) && is_scalar_indexed(expr) &&
         isequal(first(arguments(x)), first(arguments(expr)))
         return isequal(operation(x), operation(expr)) &&
                isequal(arguments(x), arguments(expr))
     end
+
     if is_scalar_indexed(x) && is_scalar_indexed(expr) &&
         !occursin(first(arguments(x)), first(arguments(expr)))
         return false
@@ -83,7 +89,7 @@ function occursin_info(x, expr)
     if isequal(x, expr)
         true
     else
-        args = map(a->occursin_info(x, a), arguments(expr))
+        args = map(a->occursin_info(x, a, operation(expr) !== getindex), arguments(expr))
         if all(_isfalse, args)
             return false
         end
@@ -91,9 +97,9 @@ function occursin_info(x, expr)
     end
 end
 
-function occursin_info(x, expr::Sym)
-    if symtype(expr) <: AbstractArray
-        error("Differentiation of expressions involving arrays and array variables is not yet supported.")
+function occursin_info(x, expr::Sym, fail)
+    if symtype(expr) <: AbstractArray && fail
+            error("Differentiation of expressions involving arrays and array variables is not yet supported.")
     end
     isequal(x, expr)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -111,6 +111,7 @@ function diff2term(O)
     else
         ds = nothing
     end
+    d_separator = 'ˍ'
 
     if ds === nothing
         return similarterm(O, operation(O), map(diff2term, arguments(O)), metadata=metadata(O))
@@ -118,12 +119,15 @@ function diff2term(O)
         oldop = operation(O)
         if oldop isa Sym
             opname = string(nameof(oldop))
+            args = arguments(O)
         elseif oldop isa Term && operation(oldop) === getindex
             opname = string(nameof(arguments(oldop)[1]))
-        else
-            throw(ArgumentError("A differentiated state's operation must be a `Sym`, so states like `D(u + u)` are disallowed. Got `$oldop`."))
+            args = arguments(O)
+        elseif oldop == getindex
+            args = arguments(O)
+            opname = string(tosymbol(args[1]), "[", map(tosymbol, args[2:end])..., "]")
+            return Sym{symtype(O)}(Symbol(opname, d_separator, ds))
         end
-        d_separator = 'ˍ'
         newname = occursin(d_separator, opname) ? Symbol(opname, ds) : Symbol(opname, d_separator, ds)
         return setname(similarterm(O, rename(oldop, newname), arguments(O), metadata=metadata(O)), newname)
     end
@@ -162,6 +166,9 @@ function tosymbol(t::Term; states=nothing, escape=true)
         args = arguments(t)
     elseif operation(t) isa Differential
         term = diff2term(t)
+        if issym(term)
+            return nameof(term)
+        end
         op = Symbol(operation(term))
         args = arguments(term)
     else

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -155,10 +155,11 @@ end
 
 function construct_dep_array_vars(macroname, lhs, type, call_args, indices, val, prop, transform, isruntime)
     ndim = :($length(($(indices...),)))
+    vname = !isruntime ? Meta.quot(lhs) : lhs
     if call_args[1] == :..
-        ex = :($CallWithMetadata($Sym{$FnType{Tuple, Array{$type, $ndim}}}($(Meta.quot(lhs)))))
+        ex = :($CallWithMetadata($Sym{$FnType{Tuple, Array{$type, $ndim}}}($vname)))
     else
-        ex = :($Sym{$FnType{Tuple, Array{$type, $ndim}}}($(Meta.quot(lhs)))(map($unwrap, ($(call_args...),))...))
+        ex = :($Sym{$FnType{Tuple, Array{$type, $ndim}}}($vname)(map($unwrap, ($(call_args...),))...))
     end
     ex = :($setmetadata($ex, $ArrayShapeCtx, ($(indices...),)))
 
@@ -172,6 +173,9 @@ function construct_dep_array_vars(macroname, lhs, type, call_args, indices, val,
 
     if call_args[1] == :..
         ex = :($transform($ex))
+    end
+    if isruntime
+        lhs = gensym(lhs)
     end
     lhs, :($lhs = $ex)
 end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -166,7 +166,7 @@ function construct_dep_array_vars(macroname, lhs, type, call_args, indices, val,
         ex = :($setdefaultval($ex, $val))
     end
     ex = setprops_expr(ex, prop, macroname, Meta.quot(lhs))
-    ex = :($scalarize_getindex($ex))
+    #ex = :($scalarize_getindex($ex))
 
     ex = :($wrap($ex))
 

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -126,7 +126,10 @@ function _parse_vars(macroname, type, x, transform=identity)
         iscall = Meta.isexpr(v, :call)
         isarray = Meta.isexpr(v, :ref)
         if iscall && Meta.isexpr(v.args[1], :ref)
-            @warn("Array of function variable $v is deprecated. Use dependent array variables instead, for example: $(Expr(:ref, Expr(:call, v.args[1].args[1], v.args[2]), v.args[1].args[2:end]...)). Note that this changes the semantics of the variable, the deprecated semantics will be deleted in the next release in order to facilitate better implementation of various features of Symbolics.")
+            @warn("The variable syntax $v is deprecated. Use $(Expr(:ref, Expr(:call, v.args[1].args[1], v.args[2]), v.args[1].args[2:end]...)) instead.
+                  The former creates an array of functions, while the latter creates an array valued function.
+                  The deprecated syntax will cause an error in the next major release of Symbolics.
+                  This change will facilitate better implementation of various features of Symbolics.")
         end
         issym  = v isa Symbol
         @assert iscall || isarray || issym "@$macroname expects a tuple of expressions or an expression of a tuple (`@$macroname x y z(t) v[1:3] w[1:2,1:4]` or `@$macroname x y z(t) v[1:3] w[1:2,1:4] k=1.0`)"

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -46,7 +46,7 @@ end
 
 getdef(v) = getmetadata(v, Symbolics.VariableDefaultValue)
 @testset "broadcast & scalarize" begin
-    @variables A[1:5,1:3]=42 b[1:3]=[2, 3, 5] t x[1:4](t) u[1:1]
+    @variables A[1:5,1:3]=42 b[1:3]=[2, 3, 5] t x(t)[1:4] u[1:1]
     AA = Symbolics.scalarize(A)
     bb = Symbolics.scalarize(b)
     @test all(isequal(42), getdef.(AA))
@@ -109,12 +109,6 @@ getdef(v) = getmetadata(v, Symbolics.VariableDefaultValue)
         @test isequal(substitute(Symbolics.scalarize(A6 ), repl_dict), test_mat^6)
         @test isequal(substitute(Symbolics.scalarize(A7 ), repl_dict), test_mat^7)
     end
-end
-
-@testset "Parent" begin
-    @variables t x(t)[1:4]
-    x = unwrap(x)
-    @test Symbolics.getparent(collect(x)[1]).metadata === x.metadata
 end
 
 n = 2

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -23,7 +23,7 @@ using SymbolicUtils: Sym, term, operation
     @test symtype(X[i,j]) == Real
     @test symtype(X[1,j]) == Real
 
-    @variables t x[1:2](t)
+    @variables t x(t)[1:2]
     @test isequal(get_variables(0 ~ x[1]), [x[1]])
     @test Set(get_variables(2x)) == Set(collect(x)) # both array elements are present
     @test isequal(get_variables(2x[1]), [x[1]])
@@ -39,9 +39,9 @@ end
     @test isequal(unwrap(X[:, 2]), Symbolics.@arrayop(XX[:,2], (i,), XX[i, 2]))
     @test isequal(unwrap(X[:, 2:3]), Symbolics.@arrayop(XX[:,2:3], (i,j), XX[i, j], (+), (j in 2:3)))
 
-    @variables t x[1:4](t)
+    @variables t x(t)[1:4]
     @syms i::Int
-    @test isequal(x[i], operation(unwrap(x[i]))(t))
+    @test isequal(x[i], operation(unwrap(x))(t)[i])
 end
 
 getdef(v) = getmetadata(v, Symbolics.VariableDefaultValue)
@@ -112,7 +112,7 @@ getdef(v) = getmetadata(v, Symbolics.VariableDefaultValue)
 end
 
 @testset "Parent" begin
-    @variables t x[1:4](t)
+    @variables t x(t)[1:4]
     x = unwrap(x)
     @test Symbolics.getparent(collect(x)[1]).metadata === x.metadata
 end

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -6,14 +6,14 @@ using Symbolics: value
 # Derivatives
 @variables t σ ρ β
 @variables x y z
-@variables uu(t) uuˍt(t) v[1:3](t)
+@variables uu(t) uuˍt(t) v(t)[1:3]
 D = Differential(t)
 D2 = Differential(t)^2
 Dx = Differential(x)
 
 @test Symbol(D(D(uu))) === Symbol("uuˍtt(t)")
 @test Symbol(D(uuˍt)) === Symbol(D(D(uu)))
-@test Symbol(D(v[2])) === Symbol("getindex(vˍt, 2)(t)")
+@test Symbol(D(v[2])) === Symbol("v(t)[2]ˍt")
 
 test_equal(a, b) = @test isequal(simplify(a), simplify(b))
 
@@ -245,7 +245,7 @@ sp_hess = Symbolics.sparsehessian(rr, X)
 @test isequal(map(spoly, findnz(sparse(reference_hes))[3]), map(spoly, findnz(sp_hess)[3]))
 
 #96
-@variables t x[1:4](t) ẋ[1:4](t)
+@variables t x(t)[1:4] ẋ(t)[1:4]
 expression = sin(x[1] + x[2] + x[3] + x[4]) |> Differential(t) |> expand_derivatives
 expression2 = substitute(expression, Dict(collect(Differential(t).(x) .=> ẋ)))
 @test isequal(expression2, (ẋ[1] + ẋ[2] + ẋ[3] + ẋ[4])*cos(x[1] + x[2] + x[3] + x[4]))
@@ -300,7 +300,7 @@ end
 # make sure derivative(x[1](t), y) does not fail
 let
     @variables t a(t)
-    vars = collect(@variables(x[1:1](t))[1])
+    vars = collect(@variables(x(t)[1:1])[1])
     ps = collect(@variables(ps[1:1])[1])
     @test Symbolics.derivative(ps[1], vars[1]) == 0
     @test Symbolics.derivative(ps[1], a) == 0
@@ -332,7 +332,7 @@ xt2 = substitute(x, [t => t2])
 # 581
 #
 let
-    @variables x[1:3](t)
+    @variables x(t)[1:3]
     @test iszero(Symbolics.derivative(x[1], x[2]))
 end
 

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -9,7 +9,7 @@ Symbolics.@register_symbolic fff(t)
 
 ## @variables
 
-many_vars = @variables t=0 a=1 x[1:4]=2 y[1:4](t)=3 w[1:4] = 1:4 z[1:4](t) = 2:5 p[1:4](..)
+many_vars = @variables t=0 a=1 x[1:4]=2 y(t)[1:4]=3 w[1:4] = 1:4 z(t)[1:4] = 2:5 p(..)[1:4]
 
 @test all(t->getsource(t)[1] === :variables, many_vars)
 @test getdefaultval(t) == 0
@@ -21,9 +21,8 @@ many_vars = @variables t=0 a=1 x[1:4]=2 y[1:4](t)=3 w[1:4] = 1:4 z[1:4](t) = 2:5
 @test getdefaultval(w[4]) == 4
 @test getdefaultval(z[3]) == 4
 
-@test p[1] isa Symbolics.CallWithMetadata
-@test symtype(p[1]) <: FnType{Tuple, Real}
-@test p[1](t) isa Symbolics.Num
+@test symtype(p) <: FnType{Tuple, Array{Real,1}}
+@test p(t)[1] isa Symbolics.Num
 
 
 ## Wrapper types
@@ -63,7 +62,7 @@ end
 
 
 let
-    vars = @variables t a b(a) c(..) x[1:2] y[1:3](t) z[1:2](..)
+    vars = @variables t a b(a) c(..) x[1:2] y(t)[1:3] z(..)[1:2]
     vars2 = [Symbolics.rename(v, Symbol(Symbolics.getname(v), "_2")) for v in vars]
 
     for (v, v2) in zip(vars, vars2)
@@ -71,8 +70,6 @@ let
         @test Symbol(Symbolics.getname(v), "_2") == Symbolics.getname(v2)
     end
 
-    @test Symbolics.getname(getmetadata(z[2](t), Symbolics.GetindexParent)) === :z
-    @test Symbolics.getname(getmetadata(vars2[end][2](t), Symbolics.GetindexParent)) === :z_2
 
     @test Symbolics.getname(Symbolics.rename(y[2], :u)) === :u
 end
@@ -80,7 +77,7 @@ end
 let
     s = :y
     x = (1:2,1:3)
-    t, y = @variables t $s[x...](t)
+    t, y = @variables t $s(t)[x...]
 
     @test ndims(y) == 2
     @test size(y) == (2,3)

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -1,11 +1,11 @@
-using Symbolics
 using Symbolics: Sym, FnType, Term, value, scalarize
+using Symbolics
 using LinearAlgebra
 using SparseArrays: sparse
 using Test
 
 a, b, c = :runtime_symbol_value, :value_b, :value_c
-vars = @variables t $a $b(t) $c[1:3](t)
+vars = @variables t $a $b(t) $c(t)[1:3]
 @test t isa Num
 @test a === :runtime_symbol_value
 @test b === :value_b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using SafeTestsets, Test, Pkg
+using Symbolics
 
 const GROUP = get(ENV, "GROUP", "All")
 


### PR DESCRIPTION
Added the new variation of the calling convention without removing the old version (precursor release to #620, this now prints warnings like this:

```
┌ Warning: Array of function variable (x[1:4])(t) is deprecated. Use dependent array variables instead, for example: (x(t))[1:4]. Note that this changes the semantics of the variable, the deprecated semantics will be deleted in the next release in order to facilitate better implementation of various features of Symbolics.
┌ Warning: Array of function variable (p[1:4])(..) is deprecated. Use dependent array variables instead, for example: (p(..))[1:4]. Note that this changes the semantics of the variable, the deprecated semantics will be deleted in the next release in order to facilitate better implementation of various features of Symbolics.
┌ Warning: Array of function variable (($s)[x...])(t) is deprecated. Use dependent array variables instead, for example: (($s)(t))[x...]. Note that this changes the semantics of the variable, the deprecated semantics will be deleted in the next release in order to facilitate better implementation of various features of Symbolics.

```

Currently running CI to see that nothing old gets broken except for the warnings. Will start modifying tests to use the new convention in the coming commits.