### PR TITLE
wrap_code for scalar functions to enable DiscreteCallbacks in ModelingToolkit

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -103,12 +103,18 @@ function _build_function(target::JuliaTarget, op, args...;
                          checkbounds = false,
                          states = LazyState(),
                          linenumbers = true,
+                         wrap_code = nothing,
                          cse = false)
+    @show "In Symbolics!!!!"
   dargs = map((x) -> destructure_arg(x[2], !checkbounds, Symbol("ˍ₋arg$(x[1])")), enumerate([args...]))
     expr = if cse
-        toexpr(Func(dargs, [], Code.cse(op)), states)
+        fun = Func(dargs, [], Code.cse(op))
+        (wrap_code !== nothing) && (fun = wrap_code(fun))
+        toexpr(fun, states)
     else
-        toexpr(Func(dargs, [], op), states)
+        fun = Func(dargs, [], op)
+        (wrap_code !== nothing) && (fun = wrap_code(fun))        
+        toexpr(fun, states)
     end
 
     if expression == Val{true}

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -105,7 +105,6 @@ function _build_function(target::JuliaTarget, op, args...;
                          linenumbers = true,
                          wrap_code = nothing,
                          cse = false)
-    @show "In Symbolics!!!!"
   dargs = map((x) -> destructure_arg(x[2], !checkbounds, Symbol("ˍ₋arg$(x[1])")), enumerate([args...]))
     expr = if cse
         fun = Func(dargs, [], Code.cse(op))

--- a/test/build_function.jl
+++ b/test/build_function.jl
@@ -1,5 +1,7 @@
 using Symbolics, SparseArrays, LinearAlgebra, Test
 using ReferenceTests
+using Symbolics: value
+using SymbolicUtils.Code: DestructuredArgs, Func
 @variables a b c1 c2 c3 d e g
 
 # Multiple argument matrix
@@ -234,4 +236,19 @@ let #issue#587
 
     @test typeof(J) <: SparseMatrixCSC
     @test nnz(J) == nnz(sj)
+end
+
+# test header wrapping of scalar build function
+let
+    @variables x p t
+    ex = t + p * x^2
+    integrator = gensym(:MTKIntegrator)
+    header = expr -> let integrator = integrator
+        Func([expr.args[1], expr.args[2], DestructuredArgs(expr.args[3:end], integrator,
+                                                           inds = [:p])], [], expr.body)
+    end
+    f = build_function(ex, [value(x)], value(t), [value(p)]; expression = Val{false},
+                                                                wrap_code = header)
+    p = (a = 10, p = [2])
+    @test f([3], 1, p) == 19
 end


### PR DESCRIPTION
For non-scalar functions `build_function` supports a `wrap_code` argument which is used to, for example, generate affect functions taking one argument, `integrator`, that internally use `(integrator.u,integrator.p,integrator.t)`. 

I'm working on adding `DiscreteCallbacks` to ModelingToolkit, and need to generate a scalar function `condition(u,t,integrator)`, where internally we get system parameters from `integrator.p`. So now need a wrapper for the scalar version of `build_function` too. With this PR, I think I've got discrete callbacks working.