### PR TITLE
Add simple Num wrapper for Irrational

### DIFF
--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -50,6 +50,24 @@ julia> Symbolics.arguments(Symbolics.value(x + y))
  y
 ```
 
+Note that Julia converts irrationals — like `π` and `ℯ` — to `Float64`
+whenever they are involved in arithmetic with other numbers, including
+integers.  An expression like `2π` will be converted to a float immediately,
+so an expression like `2π * x` will leave the symbolic `x` multiplied by a
+`Float64`.  It may be preferable to have a symbolic representation of `π`
+also, which can be achieved with `Num(π)`.  For generic programming, it may be
+helpful to simply redefine the variable `π` to be of the same type as some
+other argument, as in
+```julia
+function f(x)
+    let π=oftype(x, π)
+        1 + (2//3 + 4π/5) * x
+    end
+end
+```
+This will work for any floating-point input, as well as symbolic input.
+
+
 ## Symbolic Control Flow
 
 Control flow can be expressed in Symbolics.jl in the following ways:

--- a/src/num.jl
+++ b/src/num.jl
@@ -112,6 +112,8 @@ end
 <ₑ(s, x::Num) = value(s) <ₑ value(x)
 <ₑ(s::Num, x::Num) = value(s) <ₑ value(x)
 
+Num(q::Irrational) = Num(Term(identity, q))
+
 for T in (Integer, Rational)
     @eval Base.:(^)(n::Num, i::$T) = Num(value(n)^i)
 end

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -215,3 +215,10 @@ B = [x[1] 1.0
 @test_broken Matrix{Float64}(A-B) == [0.0 1.0;0.0 0.0]
 
 @test isequal(simplify(cos(x)^2 + sin(x)^2 + im * x), 1 + x*im)
+
+using Base.MathConstants: catalan, γ, π, φ, ℯ
+for q in (catalan, γ, π, φ, ℯ)
+    nq = Num(q)
+    @test 3nq^5/7 isa Num
+    @test Symbolics.value(substitute(3nq^5/7, Dict(nq=>big(q)))) ≈ 3big(q)^5/7
+end


### PR DESCRIPTION
As discussed [on discourse](https://discourse.julialang.org/t/generic-functions-with-irrationals-that-work-with-symbolics-modelingtoolkit/83205) and in #496, symbolic expressions involving irrationals are hard to get working as expected — particularly when you don't want to fall straight back to `Float64`.  I discovered a trick to keep them symbolic for as long as necessary, involving `Term(identity, q)`.  @ChrisRackauckas suggested making a PR, so here is my attempt.

This just adds a specialization for `Num(::Irrational)`, so that the user can explicitly construct things like `Num(π)`, and it will work.  It might also be nice to add specializations for operators so that things like `π*x`, where `x` is symbolic, would work as expected.  But that's more than I know how to do here.

Also includes simple tests and documentation.

Closes #629