### PR TITLE
Fix Symbolic type of residual from `semipolynomial_form` with a single non-polynomial no-addition input

### DIFF
--- a/src/semipoly.jl
+++ b/src/semipoly.jl
@@ -143,7 +143,7 @@ function bifurcate_terms(expr)
 
         return poly, nl
     else
-        return Dict(), expr
+        return Dict(), unwrap_bp(expr)
     end
 end
 

--- a/test/semipoly.jl
+++ b/test/semipoly.jl
@@ -31,6 +31,30 @@ d, r = semipolynomial_form((x+2)^12, [x], 1)
 # 657
 @test iszero(semilinear_form([x * cos(x) + x^2 * 3sin(x) + 4exp(x)], [x])[1])
 
+pow_expr = 7^(3y + sin(y))
+@test SymbolicUtils.ispow(Symbolics.unwrap(pow_expr))
+dict, nl = semipolynomial_form(pow_expr, [y], Inf)
+@test isempty(dict)
+# expect a SymbolicUtils.Pow object instead of SymbolicUtils.Term with f = ^
+@test isequal(nl, pow_expr)
+@test SymbolicUtils.ispow(nl)
+
+mul_expr = 9 * 7^y * sin(x)^4 * tan(x + y)^3
+@test SymbolicUtils.ismul(Symbolics.unwrap(mul_expr))
+dict, nl = semipolynomial_form(mul_expr, [x, y], Inf)
+@test isempty(dict)
+# expect a SymbolicUtils.Mul object instead of SymbolicUtils.Term with f = *
+@test isequal(nl, mul_expr)
+@test SymbolicUtils.ismul(nl)
+
+div_expr = x / y
+@test SymbolicUtils.isdiv(Symbolics.unwrap(div_expr))
+dict, nl = semipolynomial_form(div_expr, [x, y], Inf)
+@test isempty(dict)
+# expect a SymbolicUtils.Div object instead of SymbolicUtils.Term with f = /
+@test isequal(nl, div_expr)
+@test SymbolicUtils.isdiv(nl)
+
 @syms a b c
 
 const components = [2, a, b, c, x, y, z, (1+x), (1+y)^2, z*y, z*x]


### PR DESCRIPTION
The non-polynomial residual returned by `semipolynomial_form(expr, vars, degree)` does not maintain the `SymbolicUtils.Symbolic` subtype of the input `expr` when `expr` does not contain polynomial and its top-level operation is not `+`.

This PR fixes this issue.

The following is an example that triggers the bug.

```
using Symbolics
@variables x y
expr = 9 * 7^y * sin(x)^4 * tan(x + y)^3
value = Symbolics.unwrap(expr)
```

`value`, the internal of `expr`, is a `SymbolicUtils.Mul`.

```
julia> dump(value; maxdepth = 1)
SymbolicUtils.Mul{Real, Int64, Dict{Any, Number}, Nothing}
  coeff: Int64 9
  dict: Dict{Any, Number}
  sorted_args_cache: Base.RefValue{Any}
  hash: Base.RefValue{UInt64}
  metadata: Nothing nothing

julia> value.dict
Dict{Any, Number} with 3 entries:
  sin(x)     => 4
  tan(x + y) => 3
  7^y        => 1
```

Clearly, the whole expression is not a polynomial about `x` and `y`.

Then we call `semipolynomial_form` to get the non-polynomial part, which should be the same with the input `expr`.

```
julia> dict, nl = semipolynomial_form(expr, [x, y], Inf)
(Dict{Any, Any}(), 9(sin(x)^4)*(7^y)*(tan(y + x)^3))
```

The printed result looks fine, but its internal types and data structures are changed.

```
julia> dump(nl; maxdepth = 4)
SymbolicUtils.Term{Real, Nothing}
  f: * (function of type typeof(*))
  arguments: Array{Any}((4,))
    1: Int64 9
    2: SymbolicUtils.Term{Real, Nothing}
      f: ^ (function of type typeof(^))
      arguments: Array{Any}((2,))
        1: SymbolicUtils.Term{Real, Nothing}
        2: Int64 4
      metadata: Nothing nothing
      hash: Base.RefValue{UInt64}
        x: UInt64 0x0000000000000000
    3: SymbolicUtils.Term{Real, Nothing}
      f: ^ (function of type typeof(^))
      arguments: Array{Any}((2,))
        1: Int64 7
        2: SymbolicUtils.Sym{Real, Base.ImmutableDict{DataType, Any}}
      metadata: Nothing nothing
      hash: Base.RefValue{UInt64}
        x: UInt64 0x0000000000000000
    4: SymbolicUtils.Term{Real, Nothing}
      f: ^ (function of type typeof(^))
      arguments: Array{Any}((2,))
        1: SymbolicUtils.Term{Real, Nothing}
        2: Int64 3
      metadata: Nothing nothing
      hash: Base.RefValue{UInt64}
        x: UInt64 0x0000000000000000
  metadata: Nothing nothing
  hash: Base.RefValue{UInt64}
    x: UInt64 0x0000000000000000
```

All operations including `SymbolicUtils.Mul`, `SymbolicUtils.Add`, `SymbolicUtils.Div`, `SymbolicUtils.Pow` are changed to `SymbolicUtils.Term` with corresponding `f` and `arguments`.

As a result, `isequal` fails and we cannot exploit the nice data structure of `SymbolicUtils.Mul`, `SymbolicUtils.Add`, `SymbolicUtils.Div`, `SymbolicUtils.Pow`.

```
julia> isequal(expr, nl)
false
```

For a given `expr`, `semipolynomial_form` calls `mark_vars(expr, vars)` to transform all operations to `SymbolicUtils.Term`, and finally uses `TermInterface.similarterm` to transform them back to appropriate `SymbolicUtils.Symbolic` subtypes. 

The problem occurs in `bifurcate_terms(expr)` which is called by `semipolynomial_form` internally. `bifurcate_terms(expr)` does not call `unwrap_bp`, which calls `TermInterface.similarterm`, when the input `expr` is not a polynomial and the top-level operation of `expr` is not `+`.