### PR TITLE
Fix `semipolynomial_form` in case of a `SymbolicUtils.Pow` with a negative exponent

### DIFF
--- a/src/semipoly.jl
+++ b/src/semipoly.jl
@@ -61,7 +61,7 @@ function mark_and_exponentiate(expr, vars, deg)
     # Construct and propagate BoundedDegreeMonomial for ^ and *
 
 
-    rules = [@rule (~a::isboundedmonom) ^ (~b::(x-> x isa Integer)) =>
+    rules = [@rule (~a::isboundedmonom) ^ (~b::(x-> x isa Integer && x > 0)) =>
              BoundedDegreeMonomial(((~a).p)^(~b), (~a).coeff ^ (~b), ~b > deg)
              @rule (~a::isop(+)) ^ (~b::(x -> x isa Integer)) => pow_of_add(~a, ~b, deg, vars)
 

--- a/test/semipoly.jl
+++ b/test/semipoly.jl
@@ -31,6 +31,16 @@ d, r = semipolynomial_form((x+2)^12, [x], 1)
 # 657
 @test iszero(semilinear_form([x * cos(x) + x^2 * 3sin(x) + 4exp(x)], [x])[1])
 
+# check negative exponent
+# `SymbolicUtils.Pow` object with a negative exponent normally cannot be created.
+# For example, `x^-1` returns `1 / x` which is a `SymbolicUtils.Div`.
+# But `expand_derivatives` may result in a `SymbolicUtils.Pow` with a negative exponent.
+sqrt_x = sqrt(x)
+deriv = expand_derivatives(Differential(x)(sqrt_x)) # (1//2)*(sqrt(x)^-1)
+expr = substitute(deriv, Dict(sqrt_x => y)) # (1//2)*(y^-1)
+d, r = semipolynomial_form(expr, [x, y], Inf)
+@test isempty(d)
+
 @syms a b c
 
 const components = [2, a, b, c, x, y, z, (1+x), (1+y)^2, z*y, z*x]


### PR DESCRIPTION
```
using Symbolics
@variables x y
sqrt_x = sqrt(x)
deriv = expand_derivatives(Differential(x)(sqrt_x)) # (1//2)*(sqrt(x)^-1)
expr = substitute(deriv, Dict(sqrt_x => y)) # (1//2)*(y^-1)
dict, residual = semipolynomial_form(expr, [x, y], Inf)
dict

Dict{SymbolicUtils.Pow{Real, SymbolicUtils.Sym{Real, Base.ImmutableDict{DataType, Any}}, Int64, Nothing}, Rational{Int64}} with 1 entry:
  y^-1 => 1//2
```

As shown in the above, `semipolynomial_form` returns the fake monomial `y^-1` whose exponent `-1` is negative.

In principal, one cannot create a `SymbolicUtils.Pow` object with `exp` $<0$. For example,
```
julia> a = x^-3
(1 / x)^3

julia> dump(a; maxdepth = 4)
Num
  val: SymbolicUtils.Pow{Real, SymbolicUtils.Div{Real, Int64, SymbolicUtils.Sym{Real, Base.ImmutableDict{DataType, Any}}, Nothing}, Int64, Nothing}
    base: SymbolicUtils.Div{Real, Int64, SymbolicUtils.Sym{Real, Base.ImmutableDict{DataType, Any}}, Nothing}
      num: Int64 1
      den: SymbolicUtils.Sym{Real, Base.ImmutableDict{DataType, Any}}
        name: Symbol x
        metadata: Base.ImmutableDict{DataType, Any}
      simplified: Bool false
      metadata: Nothing nothing
    exp: Int64 3
    metadata: Nothing nothing
```

Here, the negative sign of the exponent is directly applied to the base.

Of course, we can easily create a `SymbolicUtils.Pow` object with `exp` $<0$ using its constructor.

```
julia> using SymbolicUtils

julia> b = SymbolicUtils.Pow(x, -1); dump(b; maxdepth = 3)
SymbolicUtils.Pow{Real, Num, Int64, Nothing}
  base: Num
    val: SymbolicUtils.Sym{Real, Base.ImmutableDict{DataType, Any}}
      name: Symbol x
      metadata: Base.ImmutableDict{DataType, Any}
  exp: Int64 -1
  metadata: Nothing nothing
```

However, this can be also done by using methods that are exposed to users.

```
julia> expr = expand_derivatives(Differential(x)(sqrt(x))) * 2
sqrt(x)^-1

julia> dump(expr; maxdepth = 3)
Num
  val: SymbolicUtils.Pow{Real, SymbolicUtils.Term{Real, Nothing}, Int64, Nothing}
    base: SymbolicUtils.Term{Real, Nothing}
      f: sqrt (function of type typeof(sqrt))
      arguments: Array{SymbolicUtils.Sym{Real, Base.ImmutableDict{DataType, Any}}}((1,))
      metadata: Nothing nothing
      hash: Base.RefValue{UInt64}
    exp: Int64 -1
    metadata: Nothing nothing
```

The transformation `@rule`s defined in `semipolynomial_form` do not consider this case. This PR fixes it.
