### PR TITLE
implement `coeff`

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -74,7 +74,6 @@ export Equation, ConstrainedEquation
 include("equations.jl")
 
 include("utils.jl")
-export degree
 
 using ConstructionBase
 include("arrays.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -230,6 +230,11 @@ degree(p::Add, sym=nothing) = maximum(degree.(arguments(p), sym))
 degree(p::Mul, sym=nothing) = sum(degree(k^v, sym) for (k, v) in p.dict)
 degree(p::Pow, sym=nothing) = p.exp * degree(p.base, sym)
 
+"""
+    degree(p, sym=nothing)
+
+Extract the degree of `p` with respect to `sym`.
+"""
 function degree(p, sym=nothing)
     p, sym = value(p), value(sym)
     p isa Number && return 0
@@ -247,6 +252,12 @@ function coeff(p::Mul, sym=nothing)
     length(I) == length(args) ? 0 : prod(args[I])
 end
 
+"""
+    coeff(p, sym=nothing)
+
+Extract the coefficient of `p` with respect to `sym`.
+Note that `p` might need to be expanded and/or simplified with `expand` and/or `simplify`.
+"""
 function coeff(p, sym=nothing)
     p, sym = value(p), value(sym)
     p isa Number && return sym === nothing ? p : 0

--- a/test/coeff.jl
+++ b/test/coeff.jl
@@ -1,0 +1,41 @@
+using Symbolics, Test
+import Symbolics: coeff
+
+@variables x y z a b
+
+@test isequal(coeff(2), 2)
+@test isequal(coeff(2, x), 0)
+
+@test isequal(coeff(2a, x), 0)
+@test isequal(coeff(a*x, x), a)
+@test isequal(coeff(2x*a, x), 2a)
+
+@test isequal(coeff(a + x, x), 1)
+@test isequal(coeff(2(a + x), x), 2)
+
+e = 4 + x + 3x^2 + 2x^4 + a*x^2 + b
+@test isequal(coeff(e), 4)
+@test isequal(coeff(e, x^1), 1)
+@test isequal(coeff(e, x^2), 3 + a)
+@test isequal(coeff(e, x^3), 0)
+@test isequal(coeff(e, x^4), 2)
+
+e = x*y^2 + 2x + y^3*x^3
+@test isequal(coeff(e, x), 2 + y^2)
+@test isequal(coeff(e, x^3), y^3)
+@test isequal(coeff(e, y^2), x)
+@test isequal(coeff(e, y^3), x^3)
+
+@test isequal(coeff(x^2 + y^2 + z^2, sin(z)), 0)
+@test isequal(coeff(sin(z), z), 0)
+@test isequal(coeff(sin(z)), 0)
+
+# issue #236
+@test isequal(coeff(3x + 2y, x), 3)
+@test isequal(coeff(x*y, x), y)
+@test isequal(coeff(x^2 + y, x^2), 1)
+
+# expand - simplify needed
+@test isequal(coeff(expand(((x + 1)^4 + x)^3), x^2), 93)
+@test isequal(coeff(simplify((x^2 - 1) / (x - 1)), x), 1)
+@test isequal(coeff(expand((x^(1//2) + y^0.5)^2), x), 1)

--- a/test/degree.jl
+++ b/test/degree.jl
@@ -1,27 +1,35 @@
-using Symbolics
-using Test
+using Symbolics, Test
+import Symbolics: degree
 
 @variables x, y, z
+
+@test isequal(degree(x^0), 0)
+@test isequal(degree(x^1), 1)
+@test isequal(degree(x^2), 2)
 
 @test isequal(degree(1), 0)
 @test isequal(degree(x), 1)
 @test isequal(degree(x, x), 1)
+@test isequal(degree(2x, x), 1)
 @test isequal(degree(x, y), 0)
+
+@test isequal(degree(x/2, x), 1)
+@test_broken isequal(degree(x/y, x), 1)  # FIXME: `StackOverflowError`
 
 @test isequal(degree(x*y, y), 1)
 @test isequal(degree(x*y, x), 1)
 @test isequal(degree(x*y, x*y), 1)
 @test isequal(degree(x*y, z), 0)
 
-@test isequal(degree(x*y^2+2*x+y^3*x^3), 6)
-@test isequal(degree(x*y^2+2*x+y^3*x^3, y), 3)
-@test isequal(degree(x*y^2+2*x+y^3*x^6, x), 6)
+@test isequal(degree(x*y^2 + 2x + y^3*x^3), 6)
+@test isequal(degree(x*y^2 + 2x + y^3*x^3, y), 3)
+@test isequal(degree(x*y^2 + 2x + y^3*x^6, x), 6)
 
-@test isequal(degree(x*y^2+2*x+y^3*x^6, z), 0)
-@test isequal(degree(x*y^2+2*x+y^3*x^6+z, z), 1)
-@test isequal(degree(x*y^2+2*x+y^3*x^6*z, z), 1)
+@test isequal(degree(x*y^2 + 2x + y^3*x^6, z), 0)
+@test isequal(degree(x*y^2 + 2x + y^3*x^6 + z, z), 1)
+@test isequal(degree(x*y^2 + 2x + y^3*x^6*z, z), 1)
 
-@test isequal(degree(x^2 + y^2 +z^2, sin(z)), 0)
+@test isequal(degree(x^2 + y^2 + z^2, sin(z)), 0)
 @test isequal(degree(sin(z), z), 0)
 @test isequal(degree(sin(z)), 1)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ if GROUP == "All" || GROUP == "Core"
     @safetestset "Differentiation Test" begin include("diff.jl") end
     @safetestset "Difference Test" begin include("difference.jl") end
     @safetestset "Degree Test" begin include("degree.jl") end
+    @safetestset "Coeff Test" begin include("coeff.jl") end
     @safetestset "Is Linear or Affine Test" begin include("islinear_affine.jl") end
     @safetestset "Linear Solver Test" begin include("linear_solver.jl") end
     @safetestset "Groebner Bases Test" begin include("groebner_basis.jl") end


### PR DESCRIPTION
Hi,

This is a proposition in order to obtain the coefficients from `Symbolic` expressions (focusing on monomials).

```julia
using Symbolics
@variables a x y

julia> coeff(2a, x)
0
julia> coeff(a*x, x)
a
julia> coeff(3x + 2y, x)
3
julia> coeff(x * y, x)
y
julia> coeff(x^2 + y, x^2)
1
```

Fix https://github.com/JuliaSymbolics/Symbolics.jl/issues/216.
Fix https://github.com/JuliaSymbolics/Symbolics.jl/issues/374.
Fix https://github.com/JuliaSymbolics/Symbolics.jl/issues/236.

I've also rewritten `degree` as a `nfc` in the same pattern as `coeff` for consistency (~~enhance~~ after https://github.com/JuliaSymbolics/Symbolics.jl/pull/241).

~~Open question (which needs to be settled for `coeff` & `degree`): how do we handle `SymbolicUtils.Div` ?~~
~~`degree(x / y, x)` currently throws a `StackOverflowError` (added as a `@test_broken` in `test/degree.jl`).~~

EDIT: handling `Div` is outside the scope of this PR.