### PR TITLE
Refactor `degree` & `coeff` for `Add` & `Mul`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -226,7 +226,7 @@ function var_from_nested_derivative(x,i=0)
 end
 
 degree(p::Union{Term,Sym}, sym=nothing) = sym === nothing ? 1 : Int(isequal(p, sym))
-degree(p::Add, sym=nothing) = maximum(degree.(arguments(p), sym))
+degree(p::Add, sym=nothing) = maximum(degree.(keys(p.dict), sym))
 degree(p::Mul, sym=nothing) = sum(degree(k, sym) * v for (k, v) in p.dict)
 degree(p::Pow, sym=nothing) = p.exp * degree(p.base, sym)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -245,7 +245,7 @@ end
 
 coeff(p::Union{Term,Sym}, sym=nothing) = sym === nothing ? 0 : Int(isequal(p, sym))
 coeff(p::Pow, sym=nothing) = sym === nothing ? 0 : Int(isequal(p, sym))
-coeff(p::Add, sym=nothing) = sum(coeff.(arguments(p), sym))
+coeff(p::Add, sym=nothing) = sum(coeff(k, sym) * v for (k, v) in p.dict)
 function coeff(p::Mul, sym=nothing)
     args = arguments(p)
     I = findall(a -> !isequal(a, sym), args)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -245,7 +245,13 @@ end
 
 coeff(p::Union{Term,Sym}, sym=nothing) = sym === nothing ? 0 : Int(isequal(p, sym))
 coeff(p::Pow, sym=nothing) = sym === nothing ? 0 : Int(isequal(p, sym))
-coeff(p::Add, sym=nothing) = sum(coeff(k, sym) * v for (k, v) in p.dict)
+function coeff(p::Add, sym=nothing)
+    if sym === nothing
+        p.coeff
+    else
+        sum(coeff(k, sym) * v for (k, v) in p.dict)
+    end
+end
 function coeff(p::Mul, sym=nothing)
     args = unsorted_arguments(p)
     I = findall(a -> !isequal(a, sym), args)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -242,7 +242,7 @@ function degree(p::Add, sym=nothing)
 end
 
 function degree(p::Mul, sym=nothing)
-    dot(degree.(keys(p.dict), sym), values(p.dict))
+    sum(degree(k, sym) * v for (k, v) in p.dict)
 end
 
 function degree(p::Term, sym=nothing)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -247,7 +247,7 @@ coeff(p::Union{Term,Sym}, sym=nothing) = sym === nothing ? 0 : Int(isequal(p, sy
 coeff(p::Pow, sym=nothing) = sym === nothing ? 0 : Int(isequal(p, sym))
 coeff(p::Add, sym=nothing) = sum(coeff(k, sym) * v for (k, v) in p.dict)
 function coeff(p::Mul, sym=nothing)
-    args = arguments(p)
+    args = unsorted_arguments(p)
     I = findall(a -> !isequal(a, sym), args)
     length(I) == length(args) ? 0 : prod(args[I])
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -242,7 +242,7 @@ function degree(p::Add, sym=nothing)
 end
 
 function degree(p::Mul, sym=nothing)
-    return sum(degree(k^v, sym) for (k, v) in zip(keys(p.dict), values(p.dict)))
+    dot(degree.(keys(p.dict), sym), values(p.dict))
 end
 
 function degree(p::Term, sym=nothing)


### PR DESCRIPTION
1. avoids creating a vector due to broadcast
2. avoids sorting arguments
3. make use of the data structures of `Mul` and `Add`