### PR TITLE
Add simple examples for @arrayop array operations in docs

### DIFF
--- a/docs/src/manual/arrays.md
+++ b/docs/src/manual/arrays.md
@@ -65,6 +65,43 @@ julia> size(b*b')
 (3, 3)
 ```
 
+Tensor or Einstein notation can also be used for array operations using the `@arrayop` macro. For example, a matrix-vector product can be written as:
+
+```julia
+julia> d = Symbolics.@arrayop (i,) A[i,j]*b[j]
+@arrayop(_[i] := A[i, j]*b[j])
+```
+These array operations are computed lazily:
+
+```julia
+julia> c = A*b
+(A*b)[1:5]
+
+julia> isequal(collect(c), collect(d))
+true
+```
+
+This can be useful for vector calculus operations such as the gradient of a vector expression:
+
+```julia
+julia> @variables x y;
+
+julia> V = [sin(x), x^2 + y]
+2-element Vector{Num}:
+  sin(x)
+ y + x^2
+
+julia> D = Differential.([x,y]);
+julia> expand_derivatives.(collect(Symbolics.@arrayop (i,j) D[i](V[j])))
+2×2 Matrix{Num}:
+ cos(x)  2x
+      0   1
+```
+or the divergence of a vector expression:
+```julia
+julia> expand_derivatives.(collect(Symbolics.@arrayop () D[i](V[i])))
+1 + cos(x)
+```
 ### Broadcast, map and reduce
 
 


### PR DESCRIPTION
As was discussed in #600, there are some useful abstractions for array operations that are already implemented but need to be included in the docs. This PR gives some simple examples of usage to help make the `@arrayop` macro known.