### PR TITLE
Fix `hessian_sparsity` docstring signature

### DIFF
--- a/src/diff.jl
+++ b/src/diff.jl
@@ -581,7 +581,7 @@ isidx(x) = x isa TermCombination
 """
     hessian_sparsity(op, vars::AbstractVector)
 
-Return the sparsity pattern of the Hessian of an array of expressions with respect to
+Return the sparsity pattern of the Hessian of an expression with respect to
 an array of variable expressions.
 """
 function hessian_sparsity end

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -579,7 +579,7 @@ end
 isidx(x) = x isa TermCombination
 
 """
-    hessian_sparsity(ops::AbstractVector, vars::AbstractVector)
+    hessian_sparsity(op, vars::AbstractVector)
 
 Return the sparsity pattern of the Hessian of an array of expressions with respect to
 an array of variable expressions.


### PR DESCRIPTION
`hessian_sparsity` expects a single scalar-valued function, but the type of the 1st argument in its docstring signature shows `AbstractVector`.

https://github.com/JuliaSymbolics/Symbolics.jl/blob/ab7e1aa725f5599e1fb9a9b6e76beb5e392f820c/src/diff.jl#L620-L622