### PR TITLE
Fix `MIME"text/latex"` output to ensure it's in a TeX environment

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -106,11 +106,11 @@ end
     return Expr(:call, :connect, map(nameof, c.systems)...)
 end
 
-Base.show(io::IO, ::MIME"text/latex", x::Num) = print(io, latexify(x))
-Base.show(io::IO, ::MIME"text/latex", x::Symbolic) = print(io, latexify(x))
-Base.show(io::IO, ::MIME"text/latex", x::Equation) = print(io, latexify(x))
-Base.show(io::IO, ::MIME"text/latex", x::Vector{Equation}) = print(io, latexify(x))
-Base.show(io::IO, ::MIME"text/latex", x::AbstractArray{Num}) = print(io, latexify(x))
+Base.show(io::IO, ::MIME"text/latex", x::Num) = print(io, "\$\$ " * latexify(x) * " \$\$")
+Base.show(io::IO, ::MIME"text/latex", x::Symbolic) = print(io, "\$\$ " * latexify(x) * " \$\$")
+Base.show(io::IO, ::MIME"text/latex", x::Equation) = print(io, "\$\$ " * latexify(x) * " \$\$")
+Base.show(io::IO, ::MIME"text/latex", x::Vector{Equation}) = print(io, "\$\$ " * latexify(x) * " \$\$")
+Base.show(io::IO, ::MIME"text/latex", x::AbstractArray{Num}) = print(io, "\$\$ " * latexify(x) * " \$\$")
 
 _toexpr(O::ArrayOp) = _toexpr(O.term)
 


### PR DESCRIPTION
See the discussion in https://github.com/fonsp/Pluto.jl/issues/488 and https://github.com/stevengj/LaTeXStrings.jl/issues/50 and https://github.com/fonsp/Pluto.jl/pull/1164. IIUC, @stevengj makes the argument that no `MIME"text/latex"` output can be assumed to be a single LaTeX statement, which is reasonable, and the natural consequence of that is that no display environment using `MIME"text/latex"` should assume that the output is a single expression and put `$$ x $$` for you. And if that's the case, it's the job the displayer to output properly formatted TeX with the display environments defined. That is sensible, and we just need to make sure that Symbolics and ModelingToolkit does that everywhere.