### PR TITLE
add a variablemetadata supertype for downstream metadata types

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -14,8 +14,9 @@ const IndexMap = Dict{Char,Char}(
             '8' => '₈',
             '9' => '₉')
 
-struct VariableDefaultValue end
-struct VariableSource end
+abstract type AbstractVariableMetadata end
+struct VariableDefaultValue <: AbstractVariableMetadata end
+struct VariableSource <: AbstractVariableMetadata end
 
 function recurse_and_apply(f, x)
     if symtype(x) <: AbstractArray


### PR DESCRIPTION
this helps a bit with discoverability of the metadata types defined in MTK.

i want a way to take a table of parameters/variables from (and to) excel/csv

its not absolutely necessary, i can hack it without, but this would make the code a bit cleaner