### PR TITLE
Let latexify decide on `cdot`

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -40,7 +40,6 @@ recipe(n) = latexify_derivatives(cleanup_exprs(_toexpr(n)))
 
 @latexrecipe function f(n::Num)
     env --> :equation
-    cdot --> false
 
     return recipe(n)
 end


### PR DESCRIPTION
`cdot --> false` leads to very confusing output, like the one below, is there a variable called $adelay$ or is it $a \cdot delay$?
![image](https://user-images.githubusercontent.com/3797491/203291163-392c508a-04b5-4298-a8ed-0bb7d4d18666.png)

The example comes from https://mtk.sciml.ai/dev/basics/Composition/

In this case, the correct answer is $a \cdot delay$, but if there was actually a variable called $adelay$ present in the system, the printed output would be incorrect.