### PR TITLE
Update latexify_recipes.jl

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -41,6 +41,7 @@ recipe(n) = latexify_derivatives(cleanup_exprs(_toexpr(n)))
 @latexrecipe function f(n::Num)
     env --> :equation
     cdot --> false
+    fmt --> FancyNumberFormatter(5)
 
     return recipe(n)
 end


### PR DESCRIPTION
The default Latexify number formatter has a correctness problem with numbers that are stringified to scientific notation, the code
```julia
julia> latexify("1e-7 - e")
L"$1.0e-7 - e$"
```
yields
$1.0e-7 - e = -7$

This PR sets the default number formatter to instead print
```julia
julia> latexify(rand()*1e-7)
L"$6.637 \cdot 10^{-8}$"
```
$6.637 \cdot 10^{-8}$

The number of digits to print by default was set to 5, which avoids terrible outputs with tons of digits
![image](https://user-images.githubusercontent.com/3797491/203294616-360ccdbf-ed0c-46c8-9b17-59d540336928.png)

We thus solve two problems
- Correct printing of numbers in scientific notation
- Reduce extreme number of digits
