### PR TITLE
Cassette context to avoid ambiguity issues and need for specialization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "4.14.0"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
+Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
@@ -46,6 +47,7 @@ DomainSets = "0.5"
 Groebner = "0.1, 0.2"
 IfElse = "0.1"
 LaTeXStrings = "1.3"
+LambertW = "0.4.5"
 Latexify = "0.11, 0.12, 0.13, 0.14, 0.15"
 MacroTools = "0.5"
 Metatheory = "1.2.0"
@@ -62,7 +64,6 @@ StaticArrays = "1.1"
 SymbolicUtils = "0.18, 0.19"
 TermInterface = "0.2, 0.3"
 TreeViews = "0.3"
-LambertW = "0.4.5"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "4.14.0"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
-Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
@@ -47,7 +46,6 @@ DomainSets = "0.5"
 Groebner = "0.1, 0.2"
 IfElse = "0.1"
 LaTeXStrings = "1.3"
-LambertW = "0.4.5"
 Latexify = "0.11, 0.12, 0.13, 0.14, 0.15"
 MacroTools = "0.5"
 Metatheory = "1.2.0"
@@ -64,6 +62,7 @@ StaticArrays = "1.1"
 SymbolicUtils = "0.18, 0.19"
 TermInterface = "0.2, 0.3"
 TreeViews = "0.3"
+LambertW = "0.4.5"
 julia = "1.6"
 
 [extras]

--- a/src/cassette_wrapped.jl
+++ b/src/cassette_wrapped.jl
@@ -1,4 +1,4 @@
-# define a context type and export it
+# define a context type
 Cassette.@context SymbolicContext
 
 # this is a near copy of `wrap_func_expr` in file "wrapper_types.jl"

--- a/src/cassette_wrapped.jl
+++ b/src/cassette_wrapped.jl
@@ -1,6 +1,5 @@
 # define a context type and export it
 Cassette.@context SymbolicContext
-export SymbolicContext
 
 # this is a near copy of `wrap_func_expr` in file "wrapper_types.jl"
 # Instead of overloading `fname`, however, we specialize 

--- a/src/cassette_wrapped.jl
+++ b/src/cassette_wrapped.jl
@@ -58,7 +58,6 @@ function ctx_wrap_func_expr(mod, expr)
     types = map(type_options, args)
 
     impl = :(function $impl_name($(names...))
-        println("dubbed")
         $body
     end)
     # TODO: maybe don't drop first lol

--- a/src/cassette_wrapped.jl
+++ b/src/cassette_wrapped.jl
@@ -1,0 +1,178 @@
+# define a context type and export it
+Cassette.@context SymbolicContext
+export SymbolicContext
+
+# this is a near copy of `wrap_func_expr` in file "wrapper_types.jl"
+# Instead of overloading `fname`, however, we specialize 
+# `Cassette.overdub` on the symbolic argument types.
+function ctx_wrap_func_expr(mod, expr)
+    @assert expr.head == :function || (expr.head == :(=) &&
+                                       expr.args[1] isa Expr &&
+                                       expr.args[1].head == :call)
+
+    def = splitdef(expr)
+
+    sig = expr.args[1]
+    body = def[:body]
+
+    fname = def[:name]
+    args = get(def, :args, [])
+    kwargs = get(def, :kwargs, [])
+
+    impl_name = Symbol(fname,"_", hash(string(args)*string(kwargs)))
+
+    function kwargname(kwarg)
+        if kwarg isa Expr && kwarg.head == :kw
+            kwarg.args[1]
+        elseif kwarg isa Expr && kwarg.head == :(...)
+            kwarg.args[1]
+        else
+            kwarg
+        end
+    end
+
+    function argname(arg)
+        if arg isa Expr && (arg.head == :(::) || arg.head == :(...))
+            arg.args[1]
+        elseif arg isa Expr
+            error("$arg not supported as an argument")
+        else
+            arg
+        end
+    end
+
+    names = vcat(argname.(args), kwargname.(kwargs))
+
+    function type_options(arg)
+        if arg isa Expr && arg.head == :(::)
+            T = Base.eval(mod, arg.args[2])
+            has_symwrapper(T) ? (T, :(SymbolicUtils.Symbolic{<:$T}), wrapper_type(T)) :
+                                (T,:(SymbolicUtils.Symbolic{<:$T}))
+        elseif arg isa Expr && arg.head == :(...)
+            Ts = type_options(arg.args[1])
+            map(x->Vararg{x},Ts)
+        else
+            (Any,)
+        end
+    end
+
+    types = map(type_options, args)
+
+    impl = :(function $impl_name($(names...))
+        println("dubbed")
+        $body
+    end)
+    # TODO: maybe don't drop first lol
+    methods = map(Iterators.drop(Iterators.product(types...), 1)) do Ts
+        method_args = map(names, Ts) do n, T
+            :($n::$T)
+        end
+
+        fbody = :(if any($iswrapped, ($(names...),))
+                      $wrap($impl_name($([:($unwrap($arg)) for arg in names]...)))
+                  else
+                      $impl_name($(names...))
+                  end)
+
+        if isempty(kwargs)
+            :(function Cassette.overdub(::SymbolicContext, ::typeof($(fname)), $(method_args...))
+                  $fbody
+              end)
+        else
+            :(function Cassette.overdub(::SymbolicContext, ::typeof($(fname)), $(method_args...); $(kwargs...))
+                  $fbody
+              end)
+        end
+    end
+
+    quote
+        $impl
+        $(methods...)
+    end |> esc
+end
+
+macro ctx_wrapped(expr)
+    ctx_wrap_func_expr(__module__, expr)
+end
+
+# due to issue 
+# https://github.com/JuliaPackaging/Requires.jl/issues/86
+# we do all the wrapping in this file, too.
+
+# "array-lib.jl"
+@ctx_wrapped function getindex_posthook(f, x::AbstractArray)
+    if hasmetadata(x, GetindexPosthookCtx)
+        g = getmetadata(x, GetindexPosthookCtx)
+        setmetadata(x,
+                    GetindexPosthookCtx,
+                    (res, args...) -> f(g(res, args...), args...))
+    else
+        setmetadata(x, GetindexPosthookCtx, f)
+    end
+end
+@ctx_wrapped function -(x::CartesianIndex, y::CartesianIndex)
+    CartesianIndex((tup(x) .- tup(y))...)
+end
+@ctx_wrapped function +(x::CartesianIndex, y::CartesianIndex)
+    CartesianIndex((tup(x) .+ tup(y))...)
+end
+@ctx_wrapped function Base.adjoint(A::AbstractMatrix)
+    @syms i::Int j::Int
+    @arrayop (i, j) A[j, i] term=A'
+end
+@ctx_wrapped function Base.adjoint(b::AbstractVector)
+    @syms i::Int
+    @arrayop (1, i) b[i] term=b'
+end
+@ctx_wrapped (*)(A::AbstractMatrix, B::AbstractMatrix) = _matmul(A, B)
+@ctx_wrapped (*)(A::AbstractVector, B::AbstractMatrix) = _matmul(A, B)
+@ctx_wrapped (*)(A::AbstractMatrix, b::AbstractVector) = _matvec(A, b)
+@ctx_wrapped Base.map(f, x::AbstractArray) = _map(f, x)
+@ctx_wrapped Base.map(f, x::AbstractArray, xs...) = _map(f, x, xs...)
+@ctx_wrapped Base.map(f, x, y::AbstractArray, z...) = _map(f, x, y, z...)
+@ctx_wrapped Base.map(f, x, y, z::AbstractArray, w...) = _map(f, x, y, z, w...)
+@ctx_wrapped function Base.mapreduce(f, g, x::AbstractArray; dims=:, kw...)
+    idx = makesubscripts(ndims(x))
+    out_idx = [dims == (:) || i in dims ? 1 : idx[i] for i = 1:ndims(x)]
+    expr = f(x[idx...])
+    T = symtype(g(expr, expr))
+    if dims === (:)
+        return Term{T}(_mapreduce, [f, g, x, dims, (kw...,)])
+    end
+
+    Atype = propagate_atype(_mapreduce, f, g, x, dims, (kw...,))
+    ArrayOp(Atype{T, ndims(x)},
+            (out_idx...,),
+            expr,
+            g,
+            Term{Any}(_mapreduce, [f, g, x, dims, (kw...,)]))
+end
+for (ff, opts) in [sum => (identity, +, false),
+                  prod => (identity, *, true),
+                  any => (identity, (|), false),
+                  all => (identity, (&), true)]
+
+    f, g, init = opts
+    @eval @ctx_wrapped function $(ff)(x::AbstractArray;
+                                     dims=:, init=$init)
+        mapreduce($f, $g, x, dims=dims, init=init)
+    end
+    @eval @ctx_wrapped function $(ff)(f::Function, x::AbstractArray;
+                                     dims=:, init=$init)
+        mapreduce(f, $g, x, dims=dims, init=init)
+    end
+end
+
+# "arrays.jl"
+@ctx_wrapped function Base.:(\)(A::AbstractMatrix, b::AbstractVecOrMat)
+    t = arrterm(\, A, b)
+    setmetadata(t, ScalarizeCache, Ref{Any}(nothing))
+end
+@ctx_wrapped function Base.inv(A::AbstractMatrix)
+    t = arrterm(inv, A)
+    setmetadata(t, ScalarizeCache, Ref{Any}(nothing))
+end
+@ctx_wrapped function LinearAlgebra.det(x::AbstractMatrix; laplace=true)
+    Term{eltype(x)}(_det, [x, laplace])
+end
+@ctx_wrapped Base.isempty(x::AbstractArray) = shape(unwrap(x)) !== Unknown() && _iszero(length(x))

--- a/src/init.jl
+++ b/src/init.jl
@@ -23,4 +23,6 @@ function __init__()
         end
 
     end # SymPy
+
+    @require Cassette="7057c7e9-c182-5462-911a-8362d720325c" include("cassette_wrapped.jl")
 end


### PR DESCRIPTION
tldr: A proposal on how to avoid method ambiguities and the need for hyperspecialization.

This pull request defines the context type `SymbolicContext` to enable overdubbing with `Cassette.jl`. Cassette is made an optional dependence via `Require.jl`. If Cassette is loaded, then the `@ctx_wrapped` macro is executed for all method definitions currently wrapped with `@wrapped`. Afterwards, overdubbing can be used as follows:
```julia
using Symbolics
using Cassette: @overdub

@variables (x::Real)[1:2]
a = rand(2)

@overdub Symbolics.SymbolicContext() a'x
```

The pull request was mainly motivated by [this issue](https://github.com/JuliaSymbolics/Symbolics.jl/issues/575). 
Without some specialization, `a'x` would not have worked.
It feels like https://github.com/JuliaSymbolics/Symbolics.jl/issues/635 is related, too (?)

The issue is caused by the fact that some packages might define very specialized methods for some function(s) where one argument is loosely restricted by type whereas the other is not, so that our wrapped method competes against the specialized method and we get an ambiguity error.
As Symbolic users, most of the time we would prefer the symbolically wrapped method, and we could opt to define a method with corresponding (stricter) signature ourselves.

But how to choose, which methods to overload? After all, there are many different matrix and vector types in `LinearAlgebra` alone. With Cassette, we don't have to decide but simply use a custom context for multiple dispatch. There might be some drawbacks. I guess, there will be a performance penalty (haven't tested) yet. And scoping becomes more difficult.

Alternatively, we could look into [Hyperspecialize](https://juliahub.com/ui/Packages/Hyperspecialize/igWe1/0.2.0).