### PR TITLE
Change Scalarization behavior of dot-products, fix issue #459

### DIFF
--- a/src/array-lib.jl
+++ b/src/array-lib.jl
@@ -268,13 +268,12 @@ end
 
 function _matvec(A,b)
     @syms i::Int k::Int
+    sym_res = @arrayop (i,) A[i, k] * b[k] term=(A*b)
     if isdot(A, b)
-        make_shape((i,), A[i, k] * b[k]) # This is a dimension check
-        T = SymbolicUtils.promote_symtype(*, eltype(A), eltype(b))
-        S = SymbolicUtils.promote_symtype(+, T,T)
-        return Term{S}(*, [A, b])
+        return sym_res[1]
+    else
+        return sym_res
     end
-    @arrayop (i,) A[i, k] * b[k] term=(A*b)
 end
 @wrapped (*)(A::AbstractMatrix, b::AbstractVector) = _matvec(A, b)
 


### PR DESCRIPTION
Dot-products seem to be handled incorrectly: https://github.com/JuliaSymbolics/Symbolics.jl/issues/459
From my understanding, this is not merely a displaying error:
The old `return Term{S}(*, [A, b])` in `_matvec(A,B)` would become an incorrect SymbolicUtils `Mul` construct when `scalarize` is called.

In this fix, I handle dot-products like any matrix-vector product. If `isdot(A,b)==true`, I return the indexed result, so that it behaves like a scalar when `wrap`ed.
