### PR TITLE
"Fix" for #831 -- specialize `LinearAlgebra.dot` to dispatch on `Symbolic{<:Number}`

### DIFF
--- a/src/array-lib.jl
+++ b/src/array-lib.jl
@@ -280,6 +280,10 @@ function _matvec(A,b)
 end
 @wrapped (*)(A::AbstractMatrix, b::AbstractVector) = _matvec(A, b)
 
+# specialize `dot` to dispatch on `Symbolic{<:Number}` to eventually work for 
+# arrays of (possibly unwrapped) Symbolic types, see issue #831
+@wrapped LinearAlgebra.dot(x::Number, y::Number) = conj(x) * y
+
 #################### MAP-REDUCE ################
 #
 

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -3,6 +3,7 @@ using SymbolicUtils, Test
 using Symbolics: symtype, shape, wrap, unwrap, Unknown, Arr, arrterm, jacobian, @variables, value, get_variables, @arrayop, getname
 using Base: Slice
 using SymbolicUtils: Sym, term, operation
+import LinearAlgebra: dot
 
 @testset "arrays" begin
     @variables X[1:5, 1:5] Y[1:5, 1:5]
@@ -119,6 +120,16 @@ getdef(v) = getmetadata(v, Symbolics.VariableDefaultValue)
 
     ##653
     Symbolics.scalarize(inv(A)[1,1])
+
+    # #831
+    @syms symT sym1(symT) sym2(symT)
+    symvec = [sym1(symT), sym2(symT)]
+    weights = rand(2)
+    @test isequal(symvec'weights, dot(symvec, weights))
+    @test isequal(weights'symvec, dot(weights, symvec))
+    @syms sym3(symT)::Real sym4(symT)::Real
+    symvec = [sym3(symT), sym4(symT)]
+    @test isequal(symvec'weights, weights'symvec)
 
     # ModelingToolkit.jl#1736
     #


### PR DESCRIPTION
Wrap `LinearAlgebra.dot` so that it dispatches on symbols representing scalars that are not wrapped in `Num`.
See https://github.com/JuliaSymbolics/Symbolics.jl/issues/831 for an example.
That example is also included in the test suite.