### PR TITLE
Allow registering callable structs

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -35,6 +35,10 @@ macro register_symbolic(expr, define_promotion = true, Ts = [])
     f = expr.args[1]
     args = expr.args[2:end]
 
+    if f isa Expr && f.head == :(::)
+        @assert length(f.args) == 2
+    end
+
     types = map(args) do x
         if x isa Symbol
             :(($Real, $wrapper_type($Real), $Symbolic{<:$Real}))
@@ -65,6 +69,11 @@ macro register_symbolic(expr, define_promotion = true, Ts = [])
     verbose = false
     mod, fname = f isa Expr && f.head == :(.) ? f.args : (:(@__MODULE__), QuoteNode(f))
     Ts = Symbol("##__Ts")
+    ftype = if f isa Expr && f.head == :(::)
+        f.args[end]
+    else
+        :($typeof($f))
+    end
     quote
         $Ts = [Tuple{x...} for x in Iterators.product($(types...),)
                 if any(x->x <: $Symbolic || Symbolics.is_wrapper_type(x), x)]
@@ -79,7 +88,7 @@ macro register_symbolic(expr, define_promotion = true, Ts = [])
             $eval_method
         end
         if $define_promotion
-            (::$typeof($promote_symtype))(::$typeof($f), args...) = $ret_type
+            (::$typeof($promote_symtype))(::$ftype, args...) = $ret_type
         end
     end |> esc
 end

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -111,3 +111,20 @@ end
 Symbolics.@register_symbolic oof(x::AbstractVector)
 Symbolics.@variables x[1:100]
 @test oof(x) isa Num
+
+# Register callable structs
+# 806
+struct B
+    x::Float64
+end
+(b::B)(x) = b.x * x
+
+Symbolics.@register_symbolic (b::B)(x)
+
+@test B(2.0)(2.0) == 4.0
+let
+    foo = B(2.0)
+    @variables x
+    @test foo(x) isa Num
+    @test foo(unwrap(x)) isa BasicSymbolic
+end


### PR DESCRIPTION
Closes #806 

This technically works:
```julia
julia> using Symbolics
julia> module Foo
           struct Bar
               x::Float64
           end
           (f::Bar)(x) = f.x*x
       end
# Made module to show it works in such cases
julia> @register_symbolic (f::Foo.Bar)(x)
# Does not error
```

The required changes are due to `typeof((f::Foo.Bar))` not working in (what is now) line 91. This also requires the struct be registered as above and not as `(::Foo.Bar)(x)` so that it can be called in `eval_method`. An `@assert` has been added to ensure this.

The only issue is that the result cannot be printed:
```julia
julia> @variables t x(t)
julia> f = Foo.Bar(3)
julia> f(t) # or f(x)
Error showing value of type Num:
ERROR: MethodError: no method matching nameof(::Main.Foo.Bar)
Closest candidates are:
  nameof(::SymbolicUtils.BasicSymbolic) at ~/.julia/packages/SymbolicUtils/Vzo2s/src/types.jl:222
  nameof(::DataType) at reflection.jl:238
  nameof(::UnionAll) at reflection.jl:239
  ...
Stacktrace:
  [1] show_call(io::IOContext{Base.TTY}, f::Main.Foo.Bar, args::Vector{Any})
    @ SymbolicUtils ~/.julia/packages/SymbolicUtils/Vzo2s/src/types.jl:780
  [2] show_term(io::IOContext{Base.TTY}, t::SymbolicUtils.BasicSymbolic{Real})
    @ SymbolicUtils ~/.julia/packages/SymbolicUtils/Vzo2s/src/types.jl:821
  [3] show(io::IOContext{Base.TTY}, v::SymbolicUtils.BasicSymbolic{Real})
    @ SymbolicUtils ~/.julia/packages/SymbolicUtils/Vzo2s/src/types.jl:834
  [4] show(io::IOContext{Base.TTY}, n::Num)
    @ Symbolics ~/d/Julia/SciML/Symbolics.jl/src/num.jl:96
  [5] show(io::IOContext{Base.TTY}, #unused#::MIME{Symbol("text/plain")}, x::Num)
    @ Base.Multimedia ./multimedia.jl:47
#...
```

This is because it tries to call `nameof` on the struct [here](https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/ba96757121155bc8925977a858d48ef8dd8a234c/src/types.jl#L780) in SymbolicUtils.