### PR TITLE
Add sparsehessian_vals function

### DIFF
--- a/docs/src/manual/derivatives.md
+++ b/docs/src/manual/derivatives.md
@@ -24,9 +24,11 @@ way, i.e. `Symbolics.jacobian`.
 Symbolics.derivative
 Symbolics.jacobian
 Symbolics.sparsejacobian
+Symbolics.sparsejacobian_vals
 Symbolics.gradient
 Symbolics.hessian
 Symbolics.sparsehessian
+Symbolics.sparsehessian_vals
 ```
 
 ## Adding Analytical Derivatives

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -737,6 +737,7 @@ function sparsehessian(op, vars::AbstractVector; simplify::Bool=false, full::Boo
     op = value(op)
     vars = map(value, vars)
     S = hessian_sparsity(op, vars, full=full)
+    I, J, _ = findnz(S)
 
     exprs = sparsehessian_vals(op, vars, I, J, simplify=simplify)
 


### PR DESCRIPTION
- The function `sparsehessian_vals` is similar to `sparsejacobian_vals` (#710) 
- I also started to fix (#859) but I don't know what I should modify in this function:
```julia
    function hessian_sparsity(expr, vars::AbstractVector; full::Bool=true)
        @assert !(expr isa AbstractArray)
        expr = value(expr)
        u = map(value, vars)
        idx(i) = TermCombination(Set([Dict(i=>1)]))
        dict = Dict(u .=> idx.(1:length(u)))
        f = Rewriters.Prewalk(x->haskey(dict, x) ? dict[x] : x; similarterm=basic_simterm)(expr)
        lp = linearity_propagator(f)
        S = _sparse(lp, length(u))
        S = full ? S : tril(S)
    end
```

cc @tmigot 