### PR TITLE
Matrix operations for `Matrix{Complex{Num}}`

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -11,7 +11,7 @@ end
 function sym_lu(A; check=true)
     SINGULAR = typemax(Int)
     m, n = size(A)
-    F = map(x->x isa Num ? x : Num(x), A)
+    F = map(x->x isa RCNum ? x : Num(x), A)
     minmn = min(m, n)
     p = Vector{LinearAlgebra.BlasInt}(undef, minmn)
     info = 0
@@ -122,7 +122,7 @@ function _solve(A::AbstractMatrix, b::AbstractArray, do_simplify)
     do_simplify ? SymbolicUtils.simplify_fractions.(sol) : sol
 end
 
-LinearAlgebra.ldiv!(A::UpperTriangular{<:Union{Symbolic,Num}}, b::AbstractVector{<:Union{Symbolic,Num}}, x::AbstractVector{<:Union{Symbolic,Num}} = b) = symsub!(A, b, x)
+LinearAlgebra.ldiv!(A::UpperTriangular{<:Union{Symbolic,RCNum}}, b::AbstractVector{<:Union{Symbolic,RCNum}}, x::AbstractVector{<:Union{Symbolic,RCNum}} = b) = symsub!(A, b, x)
 function symsub!(A::UpperTriangular, b::AbstractVector, x::AbstractVector = b)
     LinearAlgebra.require_one_based_indexing(A, b, x)
     n = size(A, 2)
@@ -142,7 +142,7 @@ function symsub!(A::UpperTriangular, b::AbstractVector, x::AbstractVector = b)
     x
 end
 
-LinearAlgebra.ldiv!(A::UnitLowerTriangular{<:Union{Symbolic,Num}}, b::AbstractVector{<:Union{Symbolic,Num}}, x::AbstractVector{<:Union{Symbolic,Num}} = b) = symsub!(A, b, x)
+LinearAlgebra.ldiv!(A::UnitLowerTriangular{<:Union{Symbolic,RCNum}}, b::AbstractVector{<:Union{Symbolic,RCNum}}, x::AbstractVector{<:Union{Symbolic,RCNum}} = b) = symsub!(A, b, x)
 function symsub!(A::UnitLowerTriangular, b::AbstractVector, x::AbstractVector = b)
     LinearAlgebra.require_one_based_indexing(A, b, x)
     n = size(A, 2)
@@ -162,7 +162,7 @@ function symsub!(A::UnitLowerTriangular, b::AbstractVector, x::AbstractVector = 
 end
 
 minor(B, j) = B[2:end, 1:size(B,2) .!= j]
-function LinearAlgebra.det(A::AbstractMatrix{<:Num}; laplace=true)
+function LinearAlgebra.det(A::AbstractMatrix{<:RCNum}; laplace=true)
     if laplace
         n = LinearAlgebra.checksquare(A)
         if n == 1
@@ -181,7 +181,7 @@ function LinearAlgebra.det(A::AbstractMatrix{<:Num}; laplace=true)
     end
 end
 
-function LinearAlgebra.norm(x::AbstractArray{Num}, p::Real=2)
+function LinearAlgebra.norm(x::AbstractArray{<:RCNum}, p::Real=2)
     p = value(p)
     issym = p isa Symbolic
     if !issym && p == 2
@@ -299,7 +299,7 @@ end
 ###
 
 # Pretty much just copy-pasted from stdlib
-SparseArrays.SparseMatrixCSC{Tv,Ti}(M::StridedMatrix) where {Tv<:Num,Ti} = _sparse(Tv,  Ti, M)
+SparseArrays.SparseMatrixCSC{Tv,Ti}(M::StridedMatrix) where {Tv<:RCNum,Ti} = _sparse(Tv,  Ti, M)
 function _sparse(::Type{Tv}, ::Type{Ti}, M) where {Tv, Ti}
     nz = count(!_iszero, M)
     colptr = zeros(Ti, size(M, 2) + 1)

--- a/src/num.jl
+++ b/src/num.jl
@@ -2,6 +2,8 @@
     val
 end
 
+const RCNum = Union{Num, Complex{Num}}
+
 unwrap(x::Num) = x.val
 
 """
@@ -162,7 +164,7 @@ Base.convert(::Type{<:Array{Num}}, x::AbstractArray) = map(Num, x)
 Base.convert(::Type{<:Array{Num}}, x::AbstractArray{Num}) = x
 Base.convert(::Type{Sym}, x::Num) = value(x) isa Sym ? value(x) : error("cannot convert $x to Sym")
 
-LinearAlgebra.lu(x::Union{Adjoint{<:Num},Transpose{<:Num},Array{<:Num}}; check=true, kw...) = sym_lu(x; check=check)
+LinearAlgebra.lu(x::Union{Adjoint{<:RCNum},Transpose{<:RCNum},Array{<:RCNum}}; check=true, kw...) = sym_lu(x; check=check)
 
 _iszero(x::Number) = iszero(x)
 _isone(x::Number) = isone(x)


### PR DESCRIPTION
This PR extends `det`, `lu`, `inv` and `SparseCSC` to the matrices of `Complex{Num}`.
It solves Issue #861 