### PR TITLE
Symbolic matrices inverse via adjugate matrix. Implements #864

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -161,7 +161,8 @@ function symsub!(A::UnitLowerTriangular, b::AbstractVector, x::AbstractVector = 
     x
 end
 
-minor(B, j) = B[2:end, 1:size(B,2) .!= j]
+minor(B, j) = @view B[2:end, 1:size(B,2) .!= j]
+minor(B, i, j) = @view B[1:size(B,1) .!= i, 1:size(B,2) .!= j]
 function LinearAlgebra.det(A::AbstractMatrix{<:RCNum}; laplace=true)
     if laplace
         n = LinearAlgebra.checksquare(A)
@@ -178,6 +179,22 @@ function LinearAlgebra.det(A::AbstractMatrix{<:RCNum}; laplace=true)
             return det(UpperTriangular(A))
         end
         return det(lu(A; check = false))
+    end
+end
+
+function LinearAlgebra.inv(A::AbstractMatrix{<:RCNum}; laplace=true)
+    if laplace
+        @assert size(A,1) == size(A,2)
+        A⁻¹ = similar(A)
+        idet = 1/det(A; laplace=true)
+        for i=1:size(A,1)
+            for j = 1:size(A,1)
+                A⁻¹[i,j] = (-1)^(i+j)*det(minor(A, j, i); laplace=true)*idet
+            end
+        end
+        return A⁻¹
+    else
+        return inv(A)
     end
 end
 

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -182,7 +182,10 @@ function LinearAlgebra.det(A::AbstractMatrix{<:RCNum}; laplace=true)
     end
 end
 
-function LinearAlgebra.inv(A::AbstractMatrix{<:RCNum}; laplace=true)
+LinearAlgebra.inv(A::AbstractMatrix{<:RCNum}; laplace=true) = _invl(A; laplace=laplace)
+LinearAlgebra.inv(A::StridedMatrix{<:RCNum}; laplace=true) = _invl(A; laplace=laplace)
+
+function _invl(A::AbstractMatrix{<:RCNum}; laplace=true)
     if laplace
         @assert size(A,1) == size(A,2)
         A⁻¹ = similar(A)


### PR DESCRIPTION
This PR adds the method `inv(A::AbstractMatrix{<:RCNum}; laplace=true)`, which computes the inverse matrix via adjugate matrix (composed of determinants of minors of the original matrix).

Currently there is a problem that `inv(A)` always invokes `LinearAlgebra.inv(A::StridedMatrix{T}) where T` version of inverse. If you want to use the method from this PR, explicit keyword `laplace=true` has to be added.
This is attributed to the fact that `StridedMatrix{T}` seems to be more specific type than `AbstractMatrix{<:RCNum}`.

I am not sure how to resolve this issue. Nevertheless, this PR can already be used as it is.