### PR TITLE
Fixes latexify for complex symbolic numbers and arrays.

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -107,11 +107,11 @@ end
     return Expr(:call, :connect, map(nameof, c.systems)...)
 end
 
-Base.show(io::IO, ::MIME"text/latex", x::Num) = print(io, "\$\$ " * latexify(x) * " \$\$")
+Base.show(io::IO, ::MIME"text/latex", x::RCNum) = print(io, "\$\$ " * latexify(x) * " \$\$")
 Base.show(io::IO, ::MIME"text/latex", x::Symbolic) = print(io, "\$\$ " * latexify(x) * " \$\$")
 Base.show(io::IO, ::MIME"text/latex", x::Equation) = print(io, "\$\$ " * latexify(x) * " \$\$")
 Base.show(io::IO, ::MIME"text/latex", x::Vector{Equation}) = print(io, "\$\$ " * latexify(x) * " \$\$")
-Base.show(io::IO, ::MIME"text/latex", x::AbstractArray{Num}) = print(io, "\$\$ " * latexify(x) * " \$\$")
+Base.show(io::IO, ::MIME"text/latex", x::AbstractArray{<:RCNum}) = print(io, "\$\$ " * latexify(x) * " \$\$")
 
 _toexpr(O::ArrayOp) = _toexpr(O.term)
 

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -49,7 +49,8 @@ end
 @latexrecipe function f(z::Complex{Num})
     env --> :equation
     cdot --> false
-
+    
+    iszero(z.im) && return :($(recipe(z.re)))
     iszero(z.re) && return :($(recipe(z.im)) * $im)
     return :($(recipe(z.re)) + $(recipe(z.im)) * $im)
 end


### PR DESCRIPTION
This PR fixes #865 .

Basically, I've extended existing methods for `show(io::IO, ::MIME"text/latex", x)` to include `Complex{Num}` and `Array{Complex{Num}}`.

In addition to that, I have altered the `latexify_recipe` for `::Complex{Num}` to drop the zero imaginary part.
Otherwise it can lead to absurd expressions such as `0i` instead of `0`, or `ω₀+0i` instead of `ω₀` for `ω₀::Num`.
Compare
<img width="448" alt="with_zero_imag" src="https://user-images.githubusercontent.com/31563281/232035492-1d21b8cc-7a88-45e1-9d2a-6b03b24f3036.png">
and
<img width="402" alt="without_zero_imag" src="https://user-images.githubusercontent.com/31563281/232035541-985d219c-fa8a-45ad-b857-4a96c76aee5b.png">

In addition to that, we could improve it further. In the case where there is a single monomial multiplied by imaginary `i`, the parenthesis can be dropped. Also, it would be nice to put `i` directly between the numerical coefficient and the product of variables, as it is done by humans.
In regards to that, I have a question: **is it possible to distinguish `Num` with single term and with multiple terms**?
