### PR TITLE
Implementation of mldivide, i.e., b/A, for #871

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -664,7 +664,7 @@ end
 # A ∈ R^(m x n) x ∈ R^(n, k) = b ∈ R^(m, k)
 propagate_ndims(::typeof(\), A, b) = ndims(b)
 propagate_ndims(::typeof(inv), A) = ndims(A)
-# b/A is conceptually b*inv(A)
+# b/A is conceptually b*pinv(A)
 propagate_ndims(::typeof(/), b, A) = ndims(A)
 
 # A(m,k) * B(k,n) = C(m,n)
@@ -679,12 +679,9 @@ end
 
 # C(m,n) * A(n,k) = B(m,k)
 # B(m,k) / A(n,k) = C(m,n)
+# For vector b, adjoint(b)/A
 function propagate_shape(::typeof(/), b, A)
-    if ndims(b) == 1
-        (axes(A,2),)
-    else
         (axes(b,1), axes(A,1))
-    end
 end
 
 function propagate_shape(::typeof(inv), A)

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -639,6 +639,11 @@ end
     setmetadata(t, ScalarizeCache, Ref{Any}(nothing))
 end
 
+@wrapped function Base.:(/)(b::AbstractVecOrMat, A::AbstractMatrix)
+    t = arrterm(/, b, A)
+    setmetadata(t, ScalarizeCache, Ref{Any}(nothing))
+end
+
 @wrapped function Base.inv(A::AbstractMatrix)
     t = arrterm(inv, A)
     setmetadata(t, ScalarizeCache, Ref{Any}(nothing))
@@ -659,6 +664,8 @@ end
 # A ∈ R^(m x n) x ∈ R^(n, k) = b ∈ R^(m, k)
 propagate_ndims(::typeof(\), A, b) = ndims(b)
 propagate_ndims(::typeof(inv), A) = ndims(A)
+# b/A is conceptually b*inv(A)
+propagate_ndims(::typeof(/), b, A) = ndims(A)
 
 # A(m,k) * B(k,n) = C(m,n)
 # A(m,k) \ C(m,n)  = B(k,n)
@@ -667,6 +674,16 @@ function propagate_shape(::typeof(\), A, b)
         (axes(A,2),)
     else
         (axes(A,2), axes(b, 2))
+    end
+end
+
+# C(m,n) * A(n,k) = B(m,k)
+# B(m,k) / A(n,k) = C(m,n)
+function propagate_shape(::typeof(/), b, A)
+    if ndims(b) == 1
+        (axes(A,2),)
+    else
+        (axes(b,1), axes(A,1))
     end
 end
 

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -104,10 +104,16 @@ M \ reshape(b,2,1)
 M = [1 1; 0 2]
 M \ reshape(b,2,1)
 
-
 M = [1 a; 0 2]
 M \ b
 M \ [1, 2]
+
+# Tests for b/A
+@variables A[1:2,1:3] b[1:3]
+b1 = randn(1,3)
+M1 = randn(2,3)
+b/M
+Symbolics.substitute(reshape(b,1,3)/M1, Dict(b=>b1)) - b1/M1
 
 # test det
 @variables X[1:4,1:4]


### PR DESCRIPTION
This code implements mldivide for Symbolics.jl, as suggested in #871 

The change is minor and is my first attempt at contributing to Symbolics.jl and Julia in general.

Changes are as follows:
1. An implementation of mldivide (/) for Symbolics.jl analogous to the existing mrdivide (\\). The computations are passed through, in both cases, to LinearAlgebra.jl
2. Test cases added to test/overloads.jl

Notes:
1. LinearAlgebra.jl, which performs the computation, expects b in b/A to be Matrix{Float64}. Vector{Float64} are not supported. This constraint is brought forward in the supplied implementation for mldivide

Several improvements can be made to both mrdivide and mldivide, but these are out of scope of this PR

Comments and suggestions are welcome

ark
