### PR TITLE
Remove mention of ability to perform eigencomputations from docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -41,7 +41,7 @@ A general list of the features is:
 - Symbolic polynomials and trigonometric functions
 - Pattern matching, simplification and substitution
 - Differentiation
-- Symbolic linear algebra (factorizations, inversion, determinants, eigencomputations, etc.)
+- Symbolic linear algebra (factorizations, inversion, determinants, etc.)
 - Discrete math (representations of summations, products, binomial coefficients, etc.)
 - Logical and Boolean expressions
 - Symbolic equation solving and conversion to arbitrary precision


### PR DESCRIPTION
After some of the Slack discussions, and e.g. https://github.com/JuliaSymbolics/Symbolics.jl/issues/259 showing that the `eig-` functions don't actually work on symbolic arrays, it seems more appropriate / simpler to not mention eigencomputations here at all.