### PR TITLE
Allow permissive registration

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -14,7 +14,7 @@ overloads for one function, all the rest of the registers must set
 `define_promotion` to `false` except for the first one, to avoid method
 overwriting.
 
-The `permissive` keyword argument allows objects of Any type to be passed in as an argument tracing will still stop as long as there is a symbolic input. This is useful for registering functions that have a fallback method that can handle any type. Allows using symbolics as placeholder variables for diverse types such as Neural Nets and whole unsized arrays, easing general metaprogramming with symbolics.
+The `permissive` keyword argument allows objects of Any type to be passed in as an argument, tracing will still stop as long as there is a symbolic input. This is useful for registering functions that have a fallback method that can handle any type. Allows using symbolics as placeholder variables for diverse types such as Neural Nets and whole unsized arrays, easing general metaprogramming with symbolics.
 
 # Examples
 ```julia

--- a/src/register.jl
+++ b/src/register.jl
@@ -44,7 +44,7 @@ macro register_symbolic(expr, define_promotion = true, Ts = [], permissive = fal
     types = map(args) do x
         if x isa Symbol
             if permissive
-                :(($Any, $Symbolic{<:$Real}))
+                :(($Any, $wrapper_type($Real), $Symbolic{<:$Real}))
             else
                 :(($Real, $wrapper_type($Real), $Symbolic{<:$Real}))
             end

--- a/src/register.jl
+++ b/src/register.jl
@@ -14,7 +14,7 @@ overloads for one function, all the rest of the registers must set
 `define_promotion` to `false` except for the first one, to avoid method
 overwriting.
 
-The `permissive` keyword argument allows Any type to be passed in as an argument and the registration will still occur. This is useful for registering functions that have a fallback method that can handle any type. Allows using symbolics as placeholder variables for diverse types such as Neural Nets and whole unsized arrays, easing general metaprogramming with symbolics.
+The `permissive` keyword argument allows objects of Any type to be passed in as an argument tracing will still stop as long as there is a symbolic input. This is useful for registering functions that have a fallback method that can handle any type. Allows using symbolics as placeholder variables for diverse types such as Neural Nets and whole unsized arrays, easing general metaprogramming with symbolics.
 
 # Examples
 ```julia

--- a/src/register.jl
+++ b/src/register.jl
@@ -14,7 +14,7 @@ overloads for one function, all the rest of the registers must set
 `define_promotion` to `false` except for the first one, to avoid method
 overwriting.
 
-The `permissive` keyword argument allows Any type to be passed in as an argument and the registration will still occur. This is useful for registering functions that have a fallback method that can handle any type.
+The `permissive` keyword argument allows Any type to be passed in as an argument and the registration will still occur. This is useful for registering functions that have a fallback method that can handle any type. Allows using symbolics as placeholder variables for diverse types such as Neural Nets and whole unsized arrays, easing general metaprogramming with symbolics.
 
 # Examples
 ```julia

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -112,6 +112,9 @@ Symbolics.@register_symbolic oof(x::AbstractVector)
 Symbolics.@variables x[1:100]
 @test oof(x) isa Num
 
+Symbolics.@register_symbolic(boof(x, t), true, [], true)
+@test boof([1, 2, 3], t) isa Num
+
 # Register callable structs
 # 806
 struct B


### PR DESCRIPTION
The `permissive` keyword argument allows objects of Any type to be passed in as an argument tracing will still stop as long as there is a symbolic input. This is useful for registering functions that have a fallback method that can handle any type. Allows using symbolics as placeholder variables for diverse types such as Neural Nets and whole unsized arrays, easing general metaprogramming with symbolics.

