### PR TITLE
coeff throws DomainError for expressions with division

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -323,6 +323,8 @@ function coeff(p, sym=nothing)
         else
             @views prod(Iterators.flatten((coeffs[findall(!iszero, coeffs)], args[findall(iszero, coeffs)])))
         end
+    elseif isdiv(p)
+        throw(DomainError(p, "coeff on expressions with division is not yet implemented."))
     else
         p isa Number && return sym === nothing ? p : 0
         p isa Symbolic && return coeff(p, sym)


### PR DESCRIPTION
Calling coeff on expressions with symbolic division now throws a more informative DomainError instead of a StackOverflowError.

Working on making the function actually work for such expressions.