### PR TITLE
replace deprecated get_symbolify by get_rewrites

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -127,7 +127,7 @@ function _build_function(target::JuliaTarget, op, args...;
     end
 end
 
-SymbolicUtils.Code.get_symbolify(x::Arr) = SymbolicUtils.Code.get_symbolify(unwrap(x))
+SymbolicUtils.Code.get_rewrites(x::Arr) = SymbolicUtils.Code.get_rewrites(unwrap(x))
 
 function _build_function(target::JuliaTarget, op::Union{Arr, ArrayOp}, args...;
                          conv = toexpr,


### PR DESCRIPTION
I found this when looking at precompilation warnings

```
   1 dependency had warnings during precompilation:
┌ Symbolics [0c5d862f-8b57-4792-8d23-62f2024744c7]
│  WARNING: Code.get_symbolify is deprecated, use get_rewrites instead.
│    likely near /home/runner/.julia/packages/Symbolics/BQlmn/src/build_function.jl:130
└  
```

in https://github.com/ranocha/BSeries.jl/pull/153