### PR TITLE
[donotmerge] investigate alternative fix to 2993aa6

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,7 @@ if GROUP == "All" || GROUP == "Core"
     @safetestset "Build Function Test" begin include("build_function.jl") end
     @safetestset "Build Function Array Test" begin include("build_function_arrayofarray.jl") end
     @safetestset "Build Function Array Test Named Tuples" begin include("build_function_arrayofarray_named_tuples.jl") end
-    VERSION >= v"1.9" && @safetestset "Build Targets Test" begin include("build_targets.jl") end
+    @safetestset "Build Targets Test" begin include("build_targets.jl") end
     @safetestset "Latexify Test" begin include("latexify.jl") end
     @safetestset "Domain Test" begin include("domains.jl") end
     @safetestset "SymPy Test" begin include("sympy.jl") end


### PR DESCRIPTION
`hash(::Symbol)` seems to be stable across 1.6 and later Julia versions whereas `hash(::Symbol, ::UInt)` is not. This is of course also not guaranteed to remain that way in future releases, so a more disciplined approach to hash stability in Symbolics might be worth thinking about
