### PR TITLE
print condition in show(::Transition)

### DIFF
--- a/src/equations.jl
+++ b/src/equations.jl
@@ -72,11 +72,11 @@ function transition(from, to, cond;
                                       synchronize, priority))
 end
 function Base.show(io::IO, s::Transition)
-    print(io, _nameof(s.from), " → ", _nameof(s.to), " [")
-    print(io, "immediate: ", s.immediate, ", ")
-    print(io, "reset: ", s.reset, ", ")
-    print(io, "synchronize: ", s.synchronize, ", ")
-    print(io, "priority: ", s.priority, "]")
+    print(io, _nameof(s.from), " → ", _nameof(s.to), " if (", s.cond, ") [")
+    print(io, "immediate: ", Int(s.immediate), ", ")
+    print(io, "reset: ", Int(s.reset), ", ")
+    print(io, "sync: ", Int(s.synchronize), ", ")
+    print(io, "prio: ", s.priority, "]")
 end
 
 """


### PR DESCRIPTION
and compactify printing which now becomes a bit longer

example:

```julia
julia> equations(ff)
17-element Vector{Equation}:
 initial_state(state1)
 state1 → state2 if (activeState(state1₊stateD) & activeState(state1₊stateY)) [immediate: 1, reset: 1, sync: 0, prio: 1]
 state2 → state1 if (v(t) >= 20) [immediate: 1, reset: 1, sync: 0, prio: 1]
 initial_state(stateA)
 stateA → stateB if (v(t) >= 6) [immediate: 1, reset: 1, sync: 0, prio: 1]
 stateB → stateC if (v(t) == 0) [immediate: 1, reset: 1, sync: 0, prio: 1]
 stateC → stateD if (count(t) >= 2) [immediate: 1, reset: 1, sync: 0, prio: 1]
 stateC → stateA if (true) [immediate: 1, reset: 1, sync: 0, prio: 2]
 initial_state(stateX)
 stateX → stateY if (stateX₊i(t) > 20) [immediate: 1, reset: 1, sync: 0, prio: 1]
 Shift(t, 1)(v(t)) ~ 2 + v(t)
 Shift(t, 1)(v(t)) ~ -1 + v(t)
 Shift(t, 1)(state1₊count(t)) ~ 1 + state1₊count(t)
 Shift(t, 1)(state1₊stateX₊i(t)) ~ 1 + state1₊stateX₊i(t)
 state1₊stateX₊w(t) ~ v(t)
 Shift(t, 1)(state1₊stateY₊j(t)) ~ 1 + state1₊stateY₊j(t)
 Shift(t, 1)(v(t)) ~ 5 + v(t)
```