### PR TITLE
remove deprecation warning for @register

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -137,5 +137,3 @@ macro register_array_symbolic(expr, block)
     f, ftype, argnames, Ts, ret_type = destructure_registration_expr(expr, :([]))
     return register_array_symbolic(f, ftype, argnames, Ts, ret_type, block)
 end
-
-Base.@deprecate_binding var"@register" var"@register_symbolic"


### PR DESCRIPTION
This warning is involved in a weird Catalyst bug:
https://github.com/SciML/Catalyst.jl/issues/788
@ChrisRackauckas suggested the simplest way to get rid of it would be to just fully deprecate the register macro.