### PR TITLE
Fixed output of coeff(expression, x^0) or equivalent to coeff(expression, 1)

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -306,7 +306,7 @@ julia> Symbolics.coeff(x^2 + y, x^2)
 function coeff(p, sym=nothing)
     p, sym = value(p), value(sym)
     
-    if sym == 1
+    if isequal(sym, 1)
         sym = nothing
     end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -305,6 +305,11 @@ julia> Symbolics.coeff(x^2 + y, x^2)
 """
 function coeff(p, sym=nothing)
     p, sym = value(p), value(sym)
+    
+    if sym == 1
+        sym = nothing
+    end
+
     if issym(p) || isterm(p)
         sym === nothing ? 0 : Int(isequal(p, sym))
     elseif ispow(p)

--- a/test/coeff.jl
+++ b/test/coeff.jl
@@ -39,3 +39,9 @@ e = x*y^2 + 2x + y^3*x^3
 @test isequal(coeff(expand(((x + 1)^4 + x)^3), x^2), 93)
 @test isequal(coeff(simplify((x^2 - 1) / (x - 1)), x), 1)
 @test isequal(coeff(expand((x^(1//2) + y^0.5)^2), x), 1)
+
+
+# issue #1098
+@test isequal(coeff(x^2 + 1, x^0), 1)
+@test isequal(coeff(e, x^0), 4)
+@test isequal(coeff(a, x^0), a)

--- a/test/coeff.jl
+++ b/test/coeff.jl
@@ -43,5 +43,5 @@ e = x*y^2 + 2x + y^3*x^3
 
 # issue #1098
 @test isequal(coeff(x^2 + 1, x^0), 1)
-@test isequal(coeff(e, x^0), 4)
-@test isequal(coeff(a, x^0), a)
+@test isequal(coeff(e, x^0), 0)
+@test isequal(coeff(a*x + 3, x^0), 3)


### PR DESCRIPTION
Since the bool sym == nothing is used repeatedly throughout the function, and `coeff(expression, nothing)` returns the coefficient of a constant (such as `1` in `x^2 +2x + 1`). A user may want to use `coeff(expression, x^0)` for readability's sake to get that constant. 