### PR TITLE
Issue #961, solve_for outputting wrong answers when function is nonlinear. 

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -98,6 +98,15 @@ function solve_for(eq, var; simplify=false, check=true) # scalar case
     # the cases.
     a, b, islinear = linear_expansion(eq, var)
     check && @assert islinear
+
+    for eqᵢ in eq
+        islinear &= Symbolics.isaffine(eqᵢ.lhs-eqᵢ.rhs, var)
+    end
+
+    if !islinear 
+        throw("solve_for is currently unable to solve non-linear equations.")
+    end
+
     islinear || return nothing
     # a * x + b = 0
     if eq isa AbstractArray && var isa AbstractArray

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -107,10 +107,6 @@ function solve_for(eq, var; simplify=false, check=true) # scalar case
         islinear &= Symbolics.isaffine(eq.lhs-eq.rhs, [var])
     end
 
-    if !islinear 
-        throw("solve_for is currently unable to solve non-linear equations.")
-    end
-
     islinear || return nothing
     # a * x + b = 0
     if eq isa AbstractArray && var isa AbstractArray

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -93,7 +93,7 @@ julia> Symbolics.solve_for([x + y ~ 0, x - y ~ 2], [x, y])
  -1.0
 ```
 """
-function solve_for(eq, var; simplify=false, check=true) # scalar case
+function solve_for(eq::AbstractArray, var::AbstractArray; simplify=false, check=true) # scalar case
     # simplify defaults for `false` as canonicalization should handle most of
     # the cases.
     a, b, islinear = linear_expansion(eq, var)
@@ -123,6 +123,7 @@ function solve_for(eq, var; simplify=false, check=true) # scalar case
 end
 solve_for(eq::Equation, var::T; x...) where {T<:AbstractArray} = solve_for([eq],var, x...)
 solve_for(eq::T, var::Num; x...) where {T<:AbstractArray} = first(solve_for(eq,[var], x...))
+solve_for(eq::Equation, var::Num; x...) = (solve_for([eq],[var], x...))
 
 function _solve(A::AbstractMatrix, b::AbstractArray, do_simplify)
     A = Num.(SymbolicUtils.quick_cancel.(A))

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -101,13 +101,19 @@ function solve_for(eq, var; simplify=false, check=true) # scalar case
 
     if eq isa AbstractArray
         for eqᵢ in eq
-            islinear &= Symbolics.isaffine(eqᵢ.lhs-eqᵢ.rhs, var)
+            try
+                islinear &= Symbolics.isaffine(eqᵢ.lhs-eqᵢ.rhs, var)
+            catch e
+            end
         end
     else
-        islinear &= Symbolics.isaffine(eq.lhs-eq.rhs, [var])
+        try
+            islinear &= Symbolics.isaffine(eq.lhs-eq.rhs, [var])
+        catch e
+        end
     end
 
-    islinear || return nothing
+    if !islinear return nothing end
     # a * x + b = 0
     if eq isa AbstractArray && var isa AbstractArray
         x = _solve(a, -b, simplify)

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -93,14 +93,18 @@ julia> Symbolics.solve_for([x + y ~ 0, x - y ~ 2], [x, y])
  -1.0
 ```
 """
-function solve_for(eq::AbstractArray, var::AbstractArray; simplify=false, check=true) # scalar case
+function solve_for(eq, var; simplify=false, check=true) # scalar case
     # simplify defaults for `false` as canonicalization should handle most of
     # the cases.
     a, b, islinear = linear_expansion(eq, var)
     check && @assert islinear
 
-    for eqᵢ in eq
-        islinear &= Symbolics.isaffine(eqᵢ.lhs-eqᵢ.rhs, var)
+    if eq isa AbstractArray
+        for eqᵢ in eq
+            islinear &= Symbolics.isaffine(eqᵢ.lhs-eqᵢ.rhs, var)
+        end
+    else
+        islinear &= Symbolics.isaffine(eq.lhs-eq.rhs, [var])
     end
 
     if !islinear 
@@ -123,7 +127,6 @@ function solve_for(eq::AbstractArray, var::AbstractArray; simplify=false, check=
 end
 solve_for(eq::Equation, var::T; x...) where {T<:AbstractArray} = solve_for([eq],var, x...)
 solve_for(eq::T, var::Num; x...) where {T<:AbstractArray} = first(solve_for(eq,[var], x...))
-solve_for(eq::Equation, var::Num; x...) = (solve_for([eq],[var], x...))
 
 function _solve(A::AbstractMatrix, b::AbstractArray, do_simplify)
     A = Num.(SymbolicUtils.quick_cancel.(A))


### PR DESCRIPTION
The `linear_expansion()` function sees `x*y ~ 0` as linear due to looping over the lhs variable by variable, while observing the other variables as a constant. For example, when observing the x variable it sees its coefficient as a constant y, not as another variable. As such, it outputs a wrong bool (true). This hinders with the accuracy of the solve_for function as seen in issue #961.

In order to mitigate this, isaffine can be used since it provides more accurate results, and an error message is thrown when the equation given is nonlinear since solve_for does not currently have the capabilities to solve the equations given in issue #961.