### PR TITLE
Remove `getname(::Symbol)` definition as this was added directly to `SymbolicIndexingInterface`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
-version = "5.26.0"
+version = "5.26.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -81,7 +81,7 @@ SciMLBase = "2"
 Setfield = "1"
 SpecialFunctions = "2"
 StaticArrays = "1.1"
-SymbolicIndexingInterface = "0.3.12"
+SymbolicIndexingInterface = "0.3.14"
 SymbolicLimits = "0.2.0"
 SymbolicUtils = "1.4"
 julia = "1.10"

--- a/src/wrapper-types.jl
+++ b/src/wrapper-types.jl
@@ -17,8 +17,6 @@ function set_where(subt, supert)
     Expr(:where, supert, Ts...)
 end
 
-SymbolicIndexingInterface.getname(x::Symbol) = x
-
 function SymbolicIndexingInterface.getname(x::Expr)
     @assert x.head == :curly
     return x.args[1]


### PR DESCRIPTION
Added in https://github.com/SciML/SymbolicIndexingInterface.jl/commit/1339885f6a922c11c5e6f6b861eaf108c3e282ce
Which is new in 3.14: https://github.com/SciML/SymbolicIndexingInterface.jl/compare/v0.3.13...v0.3.14
so this PR also adds that as the new SymbolicIndexingInterface lowerbound.