### PR TITLE
refactor: remove undefined export `@register`

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -87,7 +87,7 @@ include("utils.jl")
 using ConstructionBase
 include("arrays.jl")
 
-export @register, @register_symbolic, @register_array_symbolic
+export @register_symbolic, @register_array_symbolic
 include("register.jl")
 
 export @variables, Variable


### PR DESCRIPTION
`@register` was removed in favor of `@register_symbolic` and its deprecation warning is also removed in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1071