### PR TITLE
[Trivial] Remove warning

### DIFF
--- a/src/domains.jl
+++ b/src/domains.jl
@@ -17,10 +17,10 @@ Base.:∈(variable::DomainedVar,domain::NTuple{2,Real}) = VarDomainPairing(varia
 # Multiple variables
 Base.:∈(variables::NTuple{N,DomainedVar},domain::Domain) where N = VarDomainPairing(value.(variables),domain)
 
-function infimum(d::AbstractInterval{T}) where T <: Num
+function infimum(d::AbstractInterval)
     leftendpoint(d)
 end
 
-function supremum(d::AbstractInterval{T}) where T <: Num
+function supremum(d::AbstractInterval)
     rightendpoint(d)
 end

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -21,6 +21,6 @@ function infimum(d::AbstractInterval{<:Num})
     leftendpoint(d)
 end
 
-function supremum(d::AbstractInterval)
+function supremum(d::AbstractInterval{<:Num})
     rightendpoint(d)
 end

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -17,7 +17,7 @@ Base.:∈(variable::DomainedVar,domain::NTuple{2,Real}) = VarDomainPairing(varia
 # Multiple variables
 Base.:∈(variables::NTuple{N,DomainedVar},domain::Domain) where N = VarDomainPairing(value.(variables),domain)
 
-function infimum(d::AbstractInterval)
+function infimum(d::AbstractInterval{<:Num})
     leftendpoint(d)
 end
 


### PR DESCRIPTION
When integrating Symbolics.jl with Latexify and ImageInTerminal, the following warning is emitted:

```
WARNING: method definition for supremum at /Users/nathompson7/.julia/packages/Symbolics/HDE84/src/domains.jl:22 declares type variable T but does not use it.
```

Fix it by removing the variable declaration.