### PR TITLE
Fix: Resolve `head` ambiguity and prevent `UndefVarError` and precompilation failure

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -113,7 +113,7 @@ function diff2term(O, O_metadata::Union{Dict, Nothing, Base.ImmutableDict}=nothi
     d_separator = 'ˍ'
 
     if ds === nothing
-        return maketerm(typeof(O), head(O), map(diff2term, children(O)),
+        return maketerm(typeof(O), TermInterface.head(O), map(diff2term, children(O)),
                         symtype(O),  O_metadata isa Nothing ?
             metadata(O) : Base.ImmutableDict(metadata(O)..., O_metadata...))
     else


### PR DESCRIPTION
This pull request addresses an error encountered due to the ambiguity of the `head` function. Both the DataStructures and TermInterface packages export `head`, leading to a warning, ultimately an `UndefVarError` within the Symbolics module and the precompilation failure in ModelingToolkit integration test CI https://github.com/JuliaSymbolics/SymbolicUtils.jl/actions/runs/9640298551/job/26583838382?pr=615 in PR https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/615.

To resolve this, an instance of `head(O)` within Symbolics.jl has been replaced with `TermInterface.head(O)`.