### PR TITLE
Refactor: Migrate from deprecated `unsorted_arguments` to `arguments`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -88,7 +88,7 @@ StaticArrays = "1.1"
 SymPy = "2"
 SymbolicIndexingInterface = "0.3.14"
 SymbolicLimits = "0.2.0"
-SymbolicUtils = "2.0.2"
+SymbolicUtils = "2.1"
 TermInterface = "0.4"
 julia = "1.10"
 

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -596,7 +596,7 @@ function numbered_expr(O::Symbolic,varnumbercache,args...;varordering = args[1],
             Expr(:ref, toexpr(args[1], states), toexpr.(args[2:end] .+ offset, (states,))...)
         else
             Expr(:call, Symbol(operation(O)), (numbered_expr(x,varnumbercache,args...;offset=offset,lhsname=lhsname,
-                                                             rhsnames=rhsnames,varordering=varordering) for x in arguments(O))...)
+                                                             rhsnames=rhsnames,varordering=varordering) for x in sorted_arguments(O))...)
         end
     elseif issym(O)
         tosymbol(O, escape=false)

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -37,7 +37,7 @@ function latexify_derivatives(ex)
                 integrand
             )
         elseif x.args[1] === :_textbf
-            ls = latexify(latexify_derivatives(arguments(x)[1])).s
+            ls = latexify(latexify_derivatives(sorted_arguments(x)[1])).s
             return "\\textbf{" * strip(ls, '\$') * "}"
         else
             return x
@@ -134,7 +134,7 @@ function _toexpr(O)
 
         # We need to iterate over each term in m, ignoring the numeric coefficient.
         # This iteration needs to be stable, so we can't iterate over m.dict.
-        for term in Iterators.drop(arguments(m), isone(m.coeff) ? 0 : 1)
+        for term in Iterators.drop(sorted_arguments(m), isone(m.coeff) ? 0 : 1)
             if !ispow(term)
                 push!(numer, _toexpr(term))
                 continue
@@ -182,7 +182,7 @@ function _toexpr(O)
     !iscall(O) && return O
 
     op = operation(O)
-    args = arguments(O)
+    args = sorted_arguments(O)
 
     if (op===(*)) && (args[1] === -1)
         arg_mul = Expr(:call, :(*), _toexpr(args[2:end])...)
@@ -233,8 +233,8 @@ _toexpr(eqs::AbstractArray) = map(eq->_toexpr(eq), eqs)
 _toexpr(x::Num) = _toexpr(value(x))
 
 function getindex_to_symbol(t)
-    @assert iscall(t) && operation(t) === getindex && symtype(arguments(t)[1]) <: AbstractArray
-    args = arguments(t)
+    @assert iscall(t) && operation(t) === getindex && symtype(sorted_arguments(t)[1]) <: AbstractArray
+    args = sorted_arguments(t)
     idxs = args[2:end]
     try
         sub = join(map(map_subscripts, idxs), "ˏ")

--- a/src/semipoly.jl
+++ b/src/semipoly.jl
@@ -24,7 +24,7 @@ function Base.:+(a::SemiMonomial, b::SemiMonomial)
 end
 function Base.:+(m::SemiMonomial, t)
     if iscall(t) && operation(t) == (+)
-        return Term(+, [unsorted_arguments(t); m])
+        return Term(+, [arguments(t); m])
     end
     Term(+, [m, t])
 end
@@ -42,7 +42,7 @@ function Base.:*(m::SemiMonomial, t::Symbolic)
             args = collect(all_terms(t))
             return Term(+, (m,) .* args)
         elseif op == (*)
-            return Term(*, [unsorted_arguments(t); m])
+            return Term(*, [arguments(t); m])
         end
     end
     Term(*, [t, m])
@@ -151,7 +151,7 @@ function mark_and_exponentiate(expr, vars)
              @rule (~a::isop(+))^(~b::isreal) => expand(Pow((~a), real(~b)))
              @rule *(~~xs::(xs -> all(issemimonomial, xs))) => *(~~xs...)
              @rule *(~~xs::(xs -> any(isop(+), xs))) => expand(Term(*, ~~xs))
-             @rule (~a::isop(+)) / (~b::issemimonomial) => +(map(x->x/~b, unsorted_arguments(~a))...)
+             @rule (~a::isop(+)) / (~b::issemimonomial) => +(map(x->x/~b, arguments(~a))...)
              @rule (~a::issemimonomial) / (~b::issemimonomial) => (~a) / (~b)]
     expr′ = Postwalk(RestartedChain(rules), maketerm = simpleterm)(expr′)
 end
@@ -178,7 +178,7 @@ function has_vars(expr, vars)::Bool
     if expr in vars
         return true
     elseif iscall(expr)
-        for arg in unsorted_arguments(expr)
+        for arg in arguments(expr)
             if has_vars(arg, vars)
                 return true
             end
@@ -199,7 +199,7 @@ function mark_vars(expr, vars)
         @assert length(args) == 2
         return Term{symtype(expr)}(op, map(mark_vars(vars), args))
     end
-    args = unsorted_arguments(expr)
+    args = arguments(expr)
     if op === (+) || op === (*)
         return Term{symtype(expr)}(op, map(mark_vars(vars), args))
     elseif length(args) == 1
@@ -375,7 +375,7 @@ function semiquadratic_form(exprs, vars)
                     push!(V2, v)
                 else
                     @assert isop(k, *)
-                    a, b = unsorted_arguments(k)
+                    a, b = arguments(k)
                     p, q = extrema((idxmap[a], idxmap[b]))
                     j = div(q*(q-1), 2) + p
                     push!(J2, j)
@@ -403,7 +403,7 @@ end
 
 ## Utilities
 
-all_terms(x) = iscall(x) && operation(x) == (+) ? collect(Iterators.flatten(map(all_terms, unsorted_arguments(x)))) : (x,)
+all_terms(x) = iscall(x) && operation(x) == (+) ? collect(Iterators.flatten(map(all_terms, arguments(x)))) : (x,)
 
 function unwrap_sp(m::SemiMonomial)
     degree_dict = pdegrees(m.p)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -328,7 +328,7 @@ function coeff(p, sym=nothing)
             sum(coeff(k, sym) * v for (k, v) in p.dict)
         end
     elseif ismul(p)
-        args = unsorted_arguments(p)
+        args = arguments(p)
         coeffs = map(a->coeff(a, sym), args)
         if all(iszero, coeffs)
             return 0

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -476,7 +476,7 @@ function fast_substitute(expr, subs; operator = Nothing)
     end
     iscall(expr) || return expr
     op = fast_substitute(operation(expr), subs; operator)
-    args = SymbolicUtils.unsorted_arguments(expr)
+    args = SymbolicUtils.arguments(expr)
     if !(op isa operator)
         canfold = Ref(!(op isa Symbolic))
         args = let canfold = canfold
@@ -504,7 +504,7 @@ function fast_substitute(expr, pair::Pair; operator = Nothing)
     end
     iscall(expr) || return expr
     op = fast_substitute(operation(expr), pair; operator)
-    args = SymbolicUtils.unsorted_arguments(expr)
+    args = SymbolicUtils.arguments(expr)
     if !(op isa operator)
         canfold = Ref(!(op isa Symbolic))
         args = let canfold = canfold


### PR DESCRIPTION
This PR migrates Symbolics.jl from the deprecated `unsorted_arguments` to `arguments`, following the changes introduced in PR https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/615.

Specifically, this PR:

- Replaces all instances of `unsorted_arguments` with `arguments` to align with the updated SymbolicUtils API.
- Updates functionalities that require sorted arguments, such as printing, LaTeXifying, and code generation, to use the `sorted_arguments` instead of `arguments`.

This change ensures compatibility with the latest version of SymbolicUtils.jl and eliminates deprecation warnings.