### PR TITLE
Latexify indices correctly

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -51,6 +51,7 @@ recipe(n) = latexify_derivatives(cleanup_exprs(_toexpr(n)))
     env --> :equation
     cdot --> false
     fmt --> FancyNumberFormatter(5)
+    index --> :subscript
 
     return recipe(n)
 end
@@ -58,6 +59,7 @@ end
 @latexrecipe function f(z::Complex{Num})
     env --> :equation
     cdot --> false
+    index --> :subscript
 
     iszero(z.im) && return :($(recipe(z.re)))
     iszero(z.re) && return :($(recipe(z.im)) * $im)
@@ -67,12 +69,14 @@ end
 @latexrecipe function f(n::ArrayOp)
     env --> :equation
     cdot --> false
+    index --> :subscript
     return recipe(n.term)
 end
 
 @latexrecipe function f(n::Function)
     env --> :equation
     cdot --> false
+    index --> :subscript
 
     return nameof(n)
 end
@@ -81,6 +85,7 @@ end
 @latexrecipe function f(n::Arr)
     env --> :equation
     cdot --> false
+    index --> :subscript
 
     return unwrap(n)
 end
@@ -88,11 +93,13 @@ end
 @latexrecipe function f(n::Symbolic)
     env --> :equation
     cdot --> false
+    index --> :subscript
 
     return recipe(n)
 end
 
 @latexrecipe function f(eqs::Vector{Equation})
+    index --> :subscript
     has_connections = any(x->x.lhs isa Connection, eqs)
     if has_connections
         env --> :equation
@@ -105,6 +112,7 @@ end
 
 @latexrecipe function f(eq::Equation)
     env --> :equation
+    index --> :subscript
 
     if eq.lhs isa Connection
         return eq.rhs
@@ -114,6 +122,7 @@ end
 end
 
 @latexrecipe function f(c::Connection)
+    index --> :subscript
     return Expr(:call, :connect, map(nameof, c.systems)...)
 end
 
@@ -236,12 +245,7 @@ function getindex_to_symbol(t)
     @assert iscall(t) && operation(t) === getindex && symtype(sorted_arguments(t)[1]) <: AbstractArray
     args = sorted_arguments(t)
     idxs = args[2:end]
-    try
-        sub = join(map(map_subscripts, idxs), "ˏ")
-        return Symbol(_toexpr(args[1]), sub)
-    catch
-        return :($(_toexpr(args[1]))[$(idxs...)])
-    end
+    return :($(_toexpr(args[1]))[$(idxs...)])
 end
 
 function diffdenom(e)

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -5,7 +5,7 @@ using ReferenceTests
 
 using DomainSets: Interval
 
-@variables x y z u(x) dx
+@variables x y z u(x) dx h[1:10,1:10]
 Dx = Differential(x)
 Dy = Differential(y)
 
@@ -53,3 +53,6 @@ Dy = Differential(y)
 @test_reference "latexify_refs/complex1.txt" latexify(x^2-y^2+2im*x*y)
 @test_reference "latexify_refs/complex2.txt" latexify(3im*x)
 @test_reference "latexify_refs/complex3.txt" latexify(1 - x + (1+2x)*im; imaginary_unit="\\mathbb{i}")
+
+@test_reference "latexify_refs/indices1.txt" latexify(h[10,10])
+@test_reference "latexify_refs/indices2.txt" latexify(h[10,10], index=:bracket)

--- a/test/latexify_refs/indices1.txt
+++ b/test/latexify_refs/indices1.txt
@@ -1,0 +1,3 @@
+\begin{equation}
+h_{10,10}
+\end{equation}

--- a/test/latexify_refs/indices2.txt
+++ b/test/latexify_refs/indices2.txt
@@ -1,0 +1,3 @@
+\begin{equation}
+h\left[10, 10\right]
+\end{equation}


### PR DESCRIPTION
The way indices were previously latexified was a hack which apparently worked in jupyter notebooks for single digit indices, but did not produce real LaTeX code and broke down for double digit indices.
Odds are, this looks slightly different from before -- if there is a strong preference perhaps it could be adjusted but this is really how it's supposed to be written.

Also adds a bit of configurability, in case someone prefers `x[1,1]` syntax.

Closes  #1181, closes korsbo/latexify.jl#293