### PR TITLE
Fix display array containing `e` or `f`

### DIFF
--- a/src/num.jl
+++ b/src/num.jl
@@ -194,3 +194,20 @@ function Base.Docs.getdoc(x::Num)
     end
     Markdown.parse(join(strings, "\n\n  "))
 end
+
+# https://github.com/JuliaSymbolics/Symbolics.jl/issues/1206#issuecomment-2271847091
+"""
+$(TYPEDSIGNATURES)
+
+Return the alignment of printing `x` of type `Num`.
+
+The alignment is a tuple `(left, right)` showing how many characters are needed 
+on either side of an alignment feature. This function returns the text width
+of `x` and `0` to avoid matching special characters, such as `e`and `f`, with 
+the alignment algorithm in Julia Base, which leads to extra white spaces on the 
+left of the characters when displaying array of symbolic variables.
+"""
+function Base.alignment(io::IO, x::Num)
+    s = sprint(show, x, context = Base.nocolor(io), sizehint = 0)
+    textwidth(s), 0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ if GROUP == "All" || GROUP == "Core"
         @safetestset "LogExpFunctions Test" begin include("logexpfunctions.jl") end
         @safetestset "LuxCore extensions Test" begin include("extensions/lux.jl") end
         @safetestset "Registration without using Test" begin include("registration_without_using.jl") end
+        @safetestset "Show Test" begin include("show.jl") end
     end
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,0 +1,28 @@
+using Symbolics
+
+# https://github.com/JuliaSymbolics/Symbolics.jl/issues/1206
+# test there is no extra white spaces on the left of e or f when displaying an array
+@testset "e f alignment in array" begin
+    r = @variables a b c d e f g h i j
+
+    io = IOBuffer()
+    td = TextDisplay(io)
+
+    display(td, r)
+    s = String(take!(io))
+    @test s == "10-element Vector{Num}:\n a\n b\n c\n d\n e\n f\n g\n h\n i\n j\n"
+
+    m = [a b c d
+         b e f g
+         c f h i
+         d g i j]
+    display(td, m)
+    s = String(take!(io))
+    @test s == "4×4 Matrix{Num}:\n a  b  c  d\n b  e  f  g\n c  f  h  i\n d  g  i  j\n"
+
+    m *= [1, 2, 3, 4]
+    display(td, m)
+    s = String(take!(io))
+    @test s ==
+          "4-element Vector{Num}:\n a + 2b + 3c + 4d\n b + 2e + 3f + 4g\n c + 2f + 3h + 4i\n d + 2g + 3i + 4j\n"
+end


### PR DESCRIPTION
With this PR, arrays that includes `e` or `f` are displayed correctly.
```julia
julia> using Symbolics

julia> r = @variables a b c d e f g h i j
10-element Vector{Num}:
 a
 b
 c
 d
 e
 f
 g
 h
 i
 j

julia> m = [a b c d
            b e f g
            c f h i
            d g i j]
4×4 Matrix{Num}:
 a  b  c  d
 b  e  f  g
 c  f  h  i
 d  g  i  j

julia> m *= [1, 2, 3, 4]
4-element Vector{Num}:
 a + 2b + 3c + 4d
 b + 2e + 3f + 4g
 c + 2f + 3h + 4i
 d + 2g + 3i + 4j
```