### PR TITLE
Add sorting option to `get_variables` function

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,7 @@ if GROUP == "All" || GROUP == "Core"
         @safetestset "LuxCore extensions Test" begin include("extensions/lux.jl") end
         @safetestset "Registration without using Test" begin include("registration_without_using.jl") end
         @safetestset "Show Test" begin include("show.jl") end
+        @safetestset "Utility Function Test" begin include("utils.jl") end
     end
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,21 @@
+using Symbolics
+
+@testset "get_variables" begin
+    @variables t x y z(t)
+
+    ex1 = x + y + sin(z)
+    vars1 = Symbolics.get_variables(ex1)
+    @test length(vars1) == 3
+    @test allunique(vars1)
+
+    sorted_vars1 = Symbolics.get_variables(ex1; sort = true)
+    @test isequal(sorted_vars1, [x, y, z])
+
+    ex2 = x - y
+    vars2 = Symbolics.get_variables(ex2)
+    @test length(vars2) == 2
+    @test allunique(vars2)
+
+    sorted_vars2 = Symbolics.get_variables(ex2; sort = true)
+    @test isequal(sorted_vars2, [x, y])
+end


### PR DESCRIPTION
The existing `get_variables` function does not guarantee the order of the returned variables. This can be inconvenient in cases where ordering is desired.

This PR introduces a new keyword argument `sort` to the `get_variables` function. By default, `sort` is set to `false`, preserving the previous behavior. Setting `sort = true` will result in the returned variables being sorted.
