### PR TITLE
fix coeff on divisions

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -343,7 +343,12 @@ function coeff(p, sym=nothing)
             @views prod(Iterators.flatten((coeffs[findall(!iszero, coeffs)], args[findall(iszero, coeffs)])))
         end
     elseif isdiv(p)
-        throw(DomainError(p, "coeff on expressions with division is not yet implemented."))
+        numerator, denominator = arguments(p)
+        if !occursin(sym, denominator)
+            coeff(numerator, sym) / denominator
+        else
+            throw(DomainError(p, "coeff on fractions is not yet implemented."))
+        end
     else
         p isa Number && return sym === nothing ? p : 0
         p isa Symbolic && return coeff(p, sym)

--- a/test/coeff.jl
+++ b/test/coeff.jl
@@ -50,3 +50,7 @@ e = x*y^2 + 2x + y^3*x^3
 @test isequal(coeff(x^2 + 1, x^0), 1)
 @test isequal(coeff(e, x^0), 0)
 @test isequal(coeff(a*x + 3, x^0), 3)
+
+@test isequal(coeff(x / 5, x), 1//5)
+@test isequal(coeff(x / y, x), 1/y)
+@test isequal(coeff(x * 5y / (1 + y + z) , x), 5y / (1 + y + z))


### PR DESCRIPTION
This is a partial fix to issue [#925](https://github.com/JuliaSymbolics/Symbolics.jl/issues/925), making coeff usable on divisions if the target symbol is not in the denominator.
This PR will result in `coeff(x / y, x)` returning `1 / y`, instead of throwing an error, while `coeff(x / (y + x), x)` will still throw a not implemented error.
