### PR TITLE
Precompile `symbolic_solve` in `SymbolicsGroebnerExt.jl`

### DIFF
--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -2,15 +2,9 @@ module SymbolicsGroebnerExt
 
 using Groebner
 const Nemo = Groebner.Nemo
-import PrecompileTools
-
-if isdefined(Base, :get_extension)
-    using Symbolics
-    using Symbolics: Num, symtype
-else
-    using ..Symbolics
-    using ..Symbolics: Num, symtype
-end
+using Symbolics
+using Symbolics: Num, symtype
+import Symbolics.PrecompileTools
 
 """
     groebner_basis(polynomials; kwargs...)

--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -2,6 +2,7 @@ module SymbolicsGroebnerExt
 
 using Groebner
 const Nemo = Groebner.Nemo
+import PrecompileTools
 
 if isdefined(Base, :get_extension)
     using Symbolics
@@ -305,6 +306,22 @@ function Symbolics.solve_multivar(eqs::Vector, vars::Vector{Num}; dropmultiplici
         end
     end
     sol
+end
+
+PrecompileTools.@setup_workload begin
+    @variables a b c x y z
+    equation1 = a*log(x)^b + c ~ 0
+    equation_actually_polynomial = sin(x^2 +1)^2 + sin(x^2 + 1) + 3
+    simple_linear_equations = [x - y, y + 2z]
+    expr_with_params = expand((x + b)*(x^2 + 2x + 1)*(x^2 - a))
+    equations_intersect_sphere_line = [x^2 + y^2 + z^2 - 9, x - 2y + 3, y - z]
+    PrecompileTools.@compile_workload begin
+        symbolic_solve(equation1, x)
+        symbolic_solve(equation_actually_polynomial)
+        symbolic_solve(simple_linear_equations, [x, y])
+        symbolic_solve(expr_with_params, x, dropmultiplicity=false)
+        symbolic_solve(equations_intersect_sphere_line, [x, y, z])
+    end
 end
 
 end # module


### PR DESCRIPTION
Currently, `symbolic_solve`, which uses the Groebner.jl package extension, takes about 20 seconds to run for the first time on my laptop for very simple linear equations. I've added precompilation statements (using PrecompileTools) in the file `SymbolicsGroebnerExt.jl` to significantly reduce the latency for users, following some discussions on Discourse:
https://discourse.julialang.org/t/new-symbolic-solver-for-symbolics-jl/
