### PR TITLE
Fixed some bugs, symbolic_solve(single expr, [multiple_vars]), and precompiled nemo

### DIFF
--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -187,6 +187,7 @@ function solve_zerodim(eqs::Vector, vars::Vector{Num}; dropmultiplicity=true, wa
     generating = true
     n_iterations = 1
     separating_form = new_var
+    eqs = Symbolics.wrap.(eqs)
 
     while generating
         new_eqs = copy(eqs)

--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -303,18 +303,17 @@ function Symbolics.solve_multivar(eqs::Vector, vars::Vector{Num}; dropmultiplici
     sol
 end
 
+# Helps with precompilation time
 PrecompileTools.@setup_workload begin
     @variables a b c x y z
     equation1 = a*log(x)^b + c ~ 0
     equation_actually_polynomial = sin(x^2 +1)^2 + sin(x^2 + 1) + 3
     simple_linear_equations = [x - y, y + 2z]
-    expr_with_params = expand((x + b)*(x^2 + 2x + 1)*(x^2 - a))
     equations_intersect_sphere_line = [x^2 + y^2 + z^2 - 9, x - 2y + 3, y - z]
     PrecompileTools.@compile_workload begin
         symbolic_solve(equation1, x)
         symbolic_solve(equation_actually_polynomial)
         symbolic_solve(simple_linear_equations, [x, y])
-        symbolic_solve(expr_with_params, x, dropmultiplicity=false)
         symbolic_solve(equations_intersect_sphere_line, [x, y, z])
     end
 end

--- a/ext/SymbolicsNemoExt.jl
+++ b/ext/SymbolicsNemoExt.jl
@@ -1,5 +1,6 @@
 module SymbolicsNemoExt
 using Nemo
+import Symbolics.PrecompileTools
 
 if isdefined(Base, :get_extension)
     using Symbolics
@@ -71,6 +72,18 @@ function Symbolics.gcd_use_nemo(poly1::Num, poly2::Num)
     nemo_gcd = Nemo.gcd(nemo_poly1, nemo_poly2)
     sym_gcd = Symbolics.wrap(nemo_crude_evaluate(nemo_gcd, nemo_to_sym))
     return sym_gcd
+end
+
+
+# Helps with precompilation time
+PrecompileTools.@setup_workload begin
+    @variables a b c x y z
+    expr_with_params = expand((x + b)*(x^2 + 2x + 1)*(x^2 - a))
+    PrecompileTools.@compile_workload begin
+        symbolic_solve(expr_with_params, x, dropmultiplicity=false)
+        symbolic_solve(x^10 - a^10, x, dropmultiplicity=false)
+        symbolic_solve([x^2 - a^2, x + a], x)
+    end
 end
 
 end # module

--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -145,6 +145,11 @@ function symbolic_solve(expr, x::T; dropmultiplicity = true, warns = true) where
         expr = Vector{Num}(expr)
     end
 
+    if expr_univar && !x_univar
+        expr = [expr]
+        expr_univar = false
+    end
+
     if x_univar
         sols = []
         if expr_univar

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -54,7 +54,7 @@ function check_approx(arr1, arr2)
     return true
 end
 
-@variables x y z
+@variables x y z a b c d e
 
 @testset "Invalid input" begin
     @test_throws AssertionError Symbolics.get_roots(x, x^2)
@@ -172,6 +172,10 @@ end
     # expr = x^3 + sqrt(complex(-2//1))*x + 2
 end
 
+@testset "Multipoly solver" begin
+    @test isequal(symbolic_solve([x^2 - 1, x + 1], x)[1], -1)
+    @test isequal(symbolic_solve([x^2 - a^2, x + a], x)[1], -a)
+end
 @testset "Multivar solver" begin
     @variables x y z
     @test isequal(symbolic_solve([x^4 - 1, x - 2], [x]), [])
@@ -356,6 +360,7 @@ end
 
     # standby
     # @test Symbolics.(log(y) + x , x) == 1
+    @test Symbolics.n_func_occ(log(a*x) + b, x) == 1
     
     @test Symbolics.n_func_occ(log(x + sin((x^2 + x)/log(x))), x) == 3
     @test Symbolics.n_func_occ(x^2 + x + x^3, x) == 1
@@ -373,7 +378,6 @@ end
 
 
 @testset "Isolate/Attract solve" begin
-    @variables a b c d e x
     lhs = ia_solve(a*x^b + c, x)[1]
     lhs2 = symbolic_solve(a*x^b + c, x)[1]
     rhs = Symbolics.term(^, -c.val/a.val, 1/b.val) 
@@ -510,8 +514,6 @@ using LambertW
 #Testing
 
 @testset "Algebraic solver tests" begin
-
-    @variables x y z a b c
     function correctAns(solve_roots, known_roots)
         solve_roots = sort_roots(eval.(Symbolics.toexpr.(solve_roots)))
         known_roots = sort_roots(known_roots)

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -175,6 +175,7 @@ end
 @testset "Multipoly solver" begin
     @test isequal(symbolic_solve([x^2 - 1, x + 1], x)[1], -1)
     @test isequal(symbolic_solve([x^2 - a^2, x + a], x)[1], -a)
+    @test isequal(symbolic_solve([x^20 - a^20, x + a], x)[1], -a)
 end
 @testset "Multivar solver" begin
     @variables x y z


### PR DESCRIPTION
Now symbolic_solve supports expressions such as
```julia
symbolic_solve((x - y) * (x - z), [x, y, z])
```
and similar. Also, added precompile tool hooks (i think they're called that) to nemo.
```julia
julia> @time symbolic_solve([x^2 - a^2, x + a], x)
  7.805655 seconds (17.50 M allocations: 1.169 GiB, 2.76% gc time, 99.79% compilation time: <1% of which was recompilation)
1-element Vector{SymbolicUtils.BasicSymbolic{Real}}:
 -a
```
 
```julia
julia> @time symbolic_solve([x^2 - a^2, x + a], x)
  0.511816 seconds (1.28 M allocations: 85.815 MiB, 3.62% gc time, 98.22% compilation time)
1-element Vector{SymbolicUtils.BasicSymbolic{Real}}:
 -a
```