### PR TITLE
changed output format of zero dimension sols

### DIFF
--- a/docs/src/manual/solver.md
+++ b/docs/src/manual/solver.md
@@ -63,6 +63,14 @@ Symbolics.symbolic_solve(eqs, [x,y,z])
 - [ ] Systems of polynomial equations with parameters and positive dimensional systems
 - [ ] Inequalities
 
+### Expressions we can not solve (but aim to)
+```
+# Mathematica
+
+In[1]:= Reduce[x^2 - x - 6 > 0, x]
+Out[1]= x < -2 || x > 3
+```
+
 # References
 
 [^1]: [Rouillier, F. Solving Zero-Dimensional Systems Through the Rational Univariate Representation. AAECC 9, 433–461 (1999).](https://doi.org/10.1007/s002000050114)

--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -206,6 +206,13 @@ function solve_zerodim(eqs::Vector, vars::Vector{Num}; dropmultiplicity=true, wa
             return []
         end
 
+        for i in reverse(eachindex(new_eqs))
+            all_present = Symbolics.get_variables(new_eqs[i])
+            if length(intersect(all_present, vars)) < 1
+                deleteat!(new_eqs, i)
+            end
+        end
+
         new_eqs = demote(new_eqs, vars, params)
         new_eqs = map(Symbolics.unwrap, new_eqs)
 
@@ -294,19 +301,10 @@ function transendence_basis(sys, vars)
 end
 
 function Symbolics.solve_multivar(eqs::Vector, vars::Vector{Num}; dropmultiplicity=true, warns=true)
-    for i in reverse(eachindex(eqs))
-        present_vars = Symbolics.get_variables(eqs[i])
-        if length(intersect(present_vars, vars)) < 1 && length(present_vars) != 0
-            deleteat!(eqs, i)
-        end
-    end
-
     sol = solve_zerodim(eqs, vars; dropmultiplicity=dropmultiplicity, warns=warns)
     !isnothing(sol) && return sol
-
     tr_basis = transendence_basis(eqs, vars)
     isempty(tr_basis) && return nothing
-
     vars_gen = setdiff(vars, tr_basis)
     sol = solve_zerodim(eqs, vars_gen; dropmultiplicity=dropmultiplicity, warns=warns)
 

--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -295,11 +295,6 @@ function Symbolics.solve_multivar(eqs::Vector, vars::Vector{Num}; dropmultiplici
     isempty(tr_basis) && return nothing
     vars_gen = setdiff(vars, tr_basis)
     sol = solve_zerodim(eqs, vars_gen; dropmultiplicity=dropmultiplicity, warns=warns)
-    for roots in sol
-        for x in tr_basis
-            roots[x] = x
-        end
-    end
     sol
 end
 

--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -298,6 +298,13 @@ function Symbolics.solve_multivar(eqs::Vector, vars::Vector{Num}; dropmultiplici
     isempty(tr_basis) && return nothing
     vars_gen = setdiff(vars, tr_basis)
     sol = solve_zerodim(eqs, vars_gen; dropmultiplicity=dropmultiplicity, warns=warns)
+
+    for roots in sol
+        for x in tr_basis
+            roots[x] = x
+        end
+    end
+
     sol
 end
 
@@ -311,8 +318,8 @@ PrecompileTools.@setup_workload begin
     PrecompileTools.@compile_workload begin
         symbolic_solve(equation1, x)
         symbolic_solve(equation_actually_polynomial)
-        symbolic_solve(simple_linear_equations, [x, y])
-        symbolic_solve(equations_intersect_sphere_line, [x, y, z])
+        symbolic_solve(simple_linear_equations, [x, y], warns=false)
+        symbolic_solve(equations_intersect_sphere_line, [x, y, z], warns=false)
     end
 end
 

--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -233,7 +233,10 @@ function solve_zerodim(eqs::Vector, vars::Vector{Num}; dropmultiplicity=true, wa
         end
 
         # non-cyclic case
-        n_iterations > 10 && return []
+        if n_iterations > 10 
+            warns && @warn("symbolic_solve can not currently solve this system of polynomials.")
+            return nothing
+        end
 
         n_iterations += 1
     end

--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -206,13 +206,6 @@ function solve_zerodim(eqs::Vector, vars::Vector{Num}; dropmultiplicity=true, wa
             return []
         end
 
-        for i in reverse(eachindex(new_eqs))
-            all_present = Symbolics.get_variables(new_eqs[i])
-            if length(intersect(all_present, vars)) < 1
-                deleteat!(new_eqs, i)
-            end
-        end
-
         new_eqs = demote(new_eqs, vars, params)
         new_eqs = map(Symbolics.unwrap, new_eqs)
 
@@ -301,10 +294,19 @@ function transendence_basis(sys, vars)
 end
 
 function Symbolics.solve_multivar(eqs::Vector, vars::Vector{Num}; dropmultiplicity=true, warns=true)
+    for i in reverse(eachindex(eqs))
+        present_vars = Symbolics.get_variables(eqs[i])
+        if length(intersect(present_vars, vars)) < 1 && length(present_vars) != 0
+            deleteat!(eqs, i)
+        end
+    end
+
     sol = solve_zerodim(eqs, vars; dropmultiplicity=dropmultiplicity, warns=warns)
     !isnothing(sol) && return sol
+
     tr_basis = transendence_basis(eqs, vars)
     isempty(tr_basis) && return nothing
+
     vars_gen = setdiff(vars, tr_basis)
     sol = solve_zerodim(eqs, vars_gen; dropmultiplicity=dropmultiplicity, warns=warns)
 

--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -121,10 +121,6 @@ function symbolic_solve(expr, x::T; dropmultiplicity = true, warns = true) where
         for var in x
             check_x(var)
         end
-        if length(x) == 1
-            x = x[1]
-            x_univar = true
-        end
     end
 
     if !(expr isa Vector)
@@ -213,6 +209,7 @@ function symbolic_solve(expr; x...)
     vars = wrap.(vars)
     @assert all(v isa Num for v in vars) "All variables should be Nums or BasicSymbolics"
 
+    vars = isone(length(vars)) ? vars[1] : vars
     return symbolic_solve(expr, vars; x...)
 end
 

--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -154,8 +154,8 @@ function symbolic_solve(expr, x::T; dropmultiplicity = true, warns = true) where
         sols = []
         if expr_univar
             sols = check_poly_inunivar(expr, x) ?
-                   solve_univar(expr, x, dropmultiplicity = dropmultiplicity) :
-                   ia_solve(expr, x, warns = warns)
+                   solve_univar(expr, x, dropmultiplicity=dropmultiplicity, warns=warns) :
+                   ia_solve(expr, x, warns=warns)
             isequal(sols, nothing) && return nothing
         else
             for i in eachindex(expr)
@@ -165,7 +165,7 @@ function symbolic_solve(expr, x::T; dropmultiplicity = true, warns = true) where
                 end
             end
             sols = solve_multipoly(
-                expr, x, dropmultiplicity = dropmultiplicity, warns = warns)
+                expr, x, dropmultiplicity=dropmultiplicity, warns=warns)
             isequal(sols, nothing) && return nothing
         end
 
@@ -183,7 +183,7 @@ function symbolic_solve(expr, x::T; dropmultiplicity = true, warns = true) where
             end
         end
 
-        sols = solve_multivar(expr, x, dropmultiplicity = dropmultiplicity)
+        sols = solve_multivar(expr, x, dropmultiplicity=dropmultiplicity, warns=warns)
         isequal(sols, nothing) && return nothing
         for sol in sols
             for var in x

--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -187,7 +187,10 @@ function symbolic_solve(expr, x::T; dropmultiplicity = true, warns = true) where
         isequal(sols, nothing) && return nothing
         for sol in sols
             for var in x
-                sol[var] = postprocess_root(sol[var])
+                root = get(sol, var, missing)
+                if !isequal(wrap(root), missing)
+                    sol[var] = postprocess_root(sol[var])
+                end
             end
         end
 

--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -187,8 +187,7 @@ function symbolic_solve(expr, x::T; dropmultiplicity = true, warns = true) where
         isequal(sols, nothing) && return nothing
         for sol in sols
             for var in x
-                root = get(sol, var, missing)
-                if !isequal(wrap(root), missing)
+                if haskey(sol, var)
                     sol[var] = postprocess_root(sol[var])
                 end
             end

--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -154,7 +154,7 @@ function symbolic_solve(expr, x::T; dropmultiplicity = true, warns = true) where
         sols = []
         if expr_univar
             sols = check_poly_inunivar(expr, x) ?
-                   solve_univar(expr, x, dropmultiplicity=dropmultiplicity, warns=warns) :
+                   solve_univar(expr, x, dropmultiplicity=dropmultiplicity) :
                    ia_solve(expr, x, warns=warns)
             isequal(sols, nothing) && return nothing
         else
@@ -238,7 +238,7 @@ implemented in the function `get_roots` and its children.
 # Examples
 
 """
-function solve_univar(expression, x; dropmultiplicity = true)
+function solve_univar(expression, x; dropmultiplicity=true)
     args = []
     mult_n = 1
     expression = unwrap(expression)

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -236,13 +236,13 @@ end
     # cyclic 3
     @variables z1 z2 z3
     eqs = [z1 + z2 + z3, z1*z2 + z1*z3 + z2*z3, z1*z2*z3 - 1]
-    sol = Symbolics.symbolic_solve(eqs, [z1,z2,z3])
+    sol = symbolic_solve(eqs, [z1,z2,z3])
     backward = [Symbolics.substitute(eqs, s) for s in sol]
     @test all(x -> all(isapprox.(eval(Symbolics.toexpr(x)), 0; atol=1e-6)), backward)
 
     @variables x y
     eqs = [2332//232*x + 2131232*y - 1//343434, x + y + 1]
-    sol = Symbolics.symbolic_solve(eqs, [x,y])
+    sol = symbolic_solve(eqs, [x,y])
     backward = [Symbolics.substitute(eqs, s) for s in sol]
     @test all(x -> all(isapprox.(eval(Symbolics.toexpr(x)), 0; atol=1e-6)), backward)
 
@@ -259,10 +259,12 @@ end
         # at most 4 roots by Bézout's theorem
         rand_eq(xs, d) = rand(-10:10) + rand(-10:10)*x + rand(-10:10)*y + rand(-10:10)*x*y + rand(-10:10)*x^2 + rand(-10:10)*y^2
         eqs = [rand_eq([x,y],2), rand_eq([x,y],2)]
-        sol = Symbolics.symbolic_solve(eqs, [x,y])
+        sol = symbolic_solve(eqs, [x,y])
         backward = [Symbolics.substitute(eqs, s) for s in sol]
         @test all(x -> all(isapprox.(eval(Symbolics.toexpr(x)), 0; atol=1e-6)), backward)
     end
+
+    @test isnothing(symbolic_solve([x^2, x*y, y^2], [x,y], warns=false))
 end
 
 @testset "Multivar parametric" begin

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -279,7 +279,7 @@ end
     @test isnothing(symbolic_solve([x*y - a, sin(x)], [x, y]))
 
     @variables t w u v
-    sol = symbolic_solve([t*w - 1 ~ 4, u + v + w ~ 1], [t,w,u,v])
+    sol = symbolic_solve([t*w - 1 ~ 4, u + v + w ~ 1], [t,w])
     @test isequal(sol, [Dict(t => -5 / (-1 + u + v), w => 1 - u - v)])
 end
 

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -182,7 +182,7 @@ end
     @test isequal(symbolic_solve([x^4 - 1, x - 2], [x]), [])
     
     # TODO: test this properly
-#    sol = symbolic_solve([x^3 + 1, x*y^3 - 1], [x, y])
+    sol = symbolic_solve([x^3 + 1, x*y^3 - 1], [x, y])
 
     eqs = [x*y + 2x^2, y^2 -1]
     arr_calcd_roots = sort_arr(symbolic_solve(eqs, [x,y]), [x,y])

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -283,7 +283,10 @@ end
     @test isequal(sol, [Dict(t => -5 / (-1 + u + v), w => 1 - u - v)])
 
     sol = symbolic_solve([x-y, y-z], [x])
-    @test isequal(sol, [Dict(x=>z)])
+    @test isequal(sol, [Dict(x=>y)])
+
+    sol = symbolic_solve([x-y, y-z], [x, y])
+    @test isequal(sol, [Dict(x=>z, y=>z)])
 end
 
 @testset "Factorisation" begin

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -283,10 +283,13 @@ end
     @test isequal(sol, [Dict(t => -5 / (-1 + u + v), w => 1 - u - v)])
 
     sol = symbolic_solve([x-y, y-z], [x])
-    @test isequal(sol, [Dict(x=>y)])
+    @test isequal(sol, [Dict(x=>z)])
 
     sol = symbolic_solve([x-y, y-z], [x, y])
     @test isequal(sol, [Dict(x=>z, y=>z)])
+
+    sol = symbolic_solve([x + y - z, y - z], [x])
+    @test isequal(sol, [Dict(x=>0)])
 end
 
 @testset "Factorisation" begin

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -182,7 +182,7 @@ end
     @test isequal(symbolic_solve([x^4 - 1, x - 2], [x]), [])
     
     # TODO: test this properly
-    sol = symbolic_solve([x^3 + 1, x*y^3 - 1], [x, y])
+#    sol = symbolic_solve([x^3 + 1, x*y^3 - 1], [x, y])
 
     eqs = [x*y + 2x^2, y^2 -1]
     arr_calcd_roots = sort_arr(symbolic_solve(eqs, [x,y]), [x,y])
@@ -278,7 +278,7 @@ end
 
     @variables t w u v
     sol = symbolic_solve([t*w - 1 ~ 4, u + v + w ~ 1], [t,w,u,v])
-    @test isequal(sol, [Dict(u => u, t => -5 / (-1 + u + v), v => v, w => 1 - u - v)])
+    @test isequal(sol, [Dict(t => -5 / (-1 + u + v), w => 1 - u - v)])
 end
 
 @testset "Factorisation" begin

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -281,6 +281,9 @@ end
     @variables t w u v
     sol = symbolic_solve([t*w - 1 ~ 4, u + v + w ~ 1], [t,w])
     @test isequal(sol, [Dict(t => -5 / (-1 + u + v), w => 1 - u - v)])
+
+    sol = symbolic_solve([x-y, y-z], [x])
+    @test isequal(sol, [Dict(x=>z)])
 end
 
 @testset "Factorisation" begin


### PR DESCRIPTION
Now, alex's latest issue #1235 's output is returned as 
```julia
julia> symbolic_solve([(x - y) * (x - z) * (y - z)], [x,y,z])
2-element Vector{Dict{Num, Any}}:
 Dict(x => y)
 Dict(x => z)
 ```
instead of 
```julia
julia> symbolic_solve([(x - y) * (x - z) * (y - z)], [x,y,z])
2-element Vector{Dict{Num, Any}}:
 Dict(z => z, y => y, x => y)
 Dict(z => z, y => y, x => z)
 ```
 
 Also, a warning was added for non-cyclic polynomial systems for our multivar solver. Alex and i plan to implement its solution in the near future.