### PR TITLE
fix latexify on complex expressions

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -168,7 +168,9 @@ function _toexpr(O)
             end
         end
 
-        if isempty(numer) || !isone(abs(m.coeff))
+        if !isreal(m.coeff)
+            numer_expr = Expr(:call, :*, m.coeff, numer...)
+        elseif isempty(numer) || !isone(abs(m.coeff))
             numer_expr = Expr(:call, :*, abs(m.coeff), numer...)
         else
             numer_expr = length(numer) > 1 ? Expr(:call, :*, numer...) : numer[1]
@@ -181,7 +183,7 @@ function _toexpr(O)
             frac_expr = Expr(:call, :/, numer_expr, denom_expr)
         end
 
-        if m.coeff < 0
+        if isreal(m.coeff) && m.coeff < 0
             return Expr(:call, :-, frac_expr)
         else
             return frac_expr

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -53,6 +53,7 @@ Dy = Differential(y)
 @test_reference "latexify_refs/complex1.txt" latexify(x^2-y^2+2im*x*y)
 @test_reference "latexify_refs/complex2.txt" latexify(3im*x)
 @test_reference "latexify_refs/complex3.txt" latexify(1 - x + (1+2x)*im; imaginary_unit="\\mathbb{i}")
+@test_reference "latexify_refs/complex4.txt" latexify(im * Symbolics.Term(sqrt, [2]))
 
 @test_reference "latexify_refs/indices1.txt" latexify(h[10,10])
 @test_reference "latexify_refs/indices2.txt" latexify(h[10,10], index=:bracket)

--- a/test/latexify_refs/complex4.txt
+++ b/test/latexify_refs/complex4.txt
@@ -1,0 +1,3 @@
+\begin{equation}
+\mathit{i} \sqrt{2}
+\end{equation}


### PR DESCRIPTION
At the moment, `latexify` fails on some complex expressions involving Symbolics.
For example,
```
using Symbolics, Latexify
latexify(im * Symbolics.Term(sqrt, [2]))
```
currently results in an error.

This PR is a small fix that resolves this error with minimal changes to the existing code. More work is probably needed to ensure complex pre-factors always display nicely.