### PR TITLE
Fix `coeff(p, sym)` when `sym` is a product (issue #1041)

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -336,15 +336,6 @@ function coeff(p, sym=nothing)
         sym = nothing
     end
 
-    return _coeff(p, sym)
-end
-
-"""
-    _coeff(p, sym)
-
-Function used internally by `coeff(p, sym)`, after the latter function performs some initial steps and re-assigns `p, sym = value(p), value(sym)`
-"""
-function _coeff(p, sym)
     if issym(p) || isterm(p)
         sym === nothing ? 0 : Int(isequal(p, sym))
     elseif ispow(p)

--- a/test/coeff.jl
+++ b/test/coeff.jl
@@ -54,3 +54,9 @@ e = x*y^2 + 2x + y^3*x^3
 @test isequal(coeff(x / 5, x), 1//5)
 @test isequal(coeff(x / y, x), 1/y)
 @test isequal(coeff(x * 5y / (1 + y + z) , x), 5y / (1 + y + z))
+
+# issue #1041 - coefficient of cross term in multivariate polynomial
+
+@test isequal(coeff(2*x*y + y, x*y), 2)
+@test isequal(coeff(2*x^2*y + y, x^2*y), 2)
+@test_throws AssertionError coeff(2*x*y + y, 2*x*y) # numerical factors not allowed in second argument of `coeff`

--- a/test/coeff.jl
+++ b/test/coeff.jl
@@ -56,7 +56,6 @@ e = x*y^2 + 2x + y^3*x^3
 @test isequal(coeff(x * 5y / (1 + y + z) , x), 5y / (1 + y + z))
 
 # issue #1041 - coefficient of cross term in multivariate polynomial
-
 @test isequal(coeff(2*x*y + y, x*y), 2)
 @test isequal(coeff(2*x^2*y + y, x^2*y), 2)
 @test_throws AssertionError coeff(2*x*y + y, 2*x*y) # numerical factors not allowed in second argument of `coeff`


### PR DESCRIPTION
Currently `coeff(p, sym)` silently returns a wrong result when `sym` is a product, as reported by issue #1041. This commit fixes the issue by iteratively computing the coefficient w.r.t. each term in the product.