### PR TITLE
fix: call `transform` on dependent array variables in `@variables`

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -173,9 +173,7 @@ function construct_dep_array_vars(macroname, lhs, type, call_args, indices, val,
 
     ex = :($wrap($ex))
 
-    if call_args[1] == :..
-        ex = :($transform($ex))
-    end
+    ex = :($transform($ex))
     if isruntime
         lhs = gensym(lhs)
     end


### PR DESCRIPTION
I'm not sure why this was specifically guarded in a condition before