### PR TITLE
Add missing `@test`s in testset

### DIFF
--- a/test/utils.jl
+++ b/test/utils.jl
@@ -23,9 +23,9 @@ end
 
 @testset "symbolic_to_float" begin
     @variables x
-    symbolic_to_float((1//2 * x)/x) isa Float64
-    symbolic_to_float((1/2 * x)/x) isa Float64
-    symbolic_to_float((1//2)*√(279//4)) isa Float64
-    symbolic_to_float((big(1)//2)*√(279//4)) isa BigFloat
-    symbolic_to_float((-1//2)*√(279//4)) isa Float64
+    @test symbolic_to_float((1//2 * x)/x) isa Rational{Int}
+    @test symbolic_to_float((1/2 * x)/x) isa Float64
+    @test symbolic_to_float((1//2)*√(279//4)) isa Float64
+    @test symbolic_to_float((big(1)//2)*√(279//4)) isa BigFloat
+    @test symbolic_to_float((-1//2)*√(279//4)) isa Float64
 end


### PR DESCRIPTION
Adds missing `@test` macros from https://github.com/JuliaSymbolics/Symbolics.jl/pull/1242. Also changed the first test to test `isa Rational{Int}` since that's what the actual result is, but I can't tell if you do actually want that to be a `Float64`.