### PR TITLE
Don't substitute in non-symbolic expressions

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -522,6 +522,9 @@ function fast_substitute(expr, pair::Pair; operator = Nothing)
         symtype(expr),
         metadata(expr))
 end
+function fast_substitute(expr::Number, args...; kwargs...)
+    return expr # unnecessary to substitute non-symbolic expressions
+end
 
 function getparent(x, val=_fail)
     maybe_parent = getmetadata(x, Symbolics.GetindexParent, nothing)


### PR DESCRIPTION
Adding this dispatch makes [ModelingToolkit#2997](https://github.com/SciML/ModelingToolkit.jl/issues/2997) work on my machine.
I don't think it addresses the *root cause* of that issue, but at least it circumvents whatever triggers the bug.
Anyway, this PR sounds like a safe optimization to me. Let me know what you think.