### PR TITLE
 Resolve isequal(Num, ForwardDiff.Dual) ambiguity

### DIFF
--- a/ext/SymbolicsForwardDiffExt.jl
+++ b/ext/SymbolicsForwardDiffExt.jl
@@ -103,6 +103,25 @@ function binary_dual_definition(M, f, Ts)
     return expr
 end
 
+#####################
+# Generic Functions #
+#####################
+
+# Predicates #
+#------------#
+
+for pred in [:isequal, :(==)]
+    @eval begin
+        @define_binary_dual_op(
+            Base.$(pred),
+            $(pred)(value(x), value(y)) && $(pred)(partials(x), partials(y)),
+            $(pred)(value(x), y)        && iszero(partials(x)),
+            $(pred)(x, value(y))        && iszero(partials(y)),
+            $AMBIGUOUS_TYPES
+        )
+    end
+end
+
 ###################################
 # General Mathematical Operations #
 ###################################

--- a/test/forwarddiff_symbolic_dual_ops.jl
+++ b/test/forwarddiff_symbolic_dual_ops.jl
@@ -110,7 +110,7 @@ end
 
 # https://github.com/JuliaSymbolics/Symbolics.jl/issues/1246
 @testset "isequal type ambiguity" begin
-    @variables x
-    xfunc(xval) = isequal(x, xval) ? xval : xval
-    @test ForwardDiff.derivative(xfunc, 0.0) == 1.0
+    @variables z
+    y(x) = isequal(z, x) ? 0 : x
+    @test ForwardDiff.derivative(y, 0) == 1 # expect ∂(x)/∂x
 end

--- a/test/forwarddiff_symbolic_dual_ops.jl
+++ b/test/forwarddiff_symbolic_dual_ops.jl
@@ -107,3 +107,10 @@ for f ∈ (hypot, muladd)
 end
 
 # fma is not defined for Symbolics.Num
+
+# https://github.com/JuliaSymbolics/Symbolics.jl/issues/1246
+@testset "isequal type ambiguity" begin
+    @variables x
+    xfunc(xval) = isequal(x, xval) ? xval : xval
+    @test ForwardDiff.derivative(xfunc, 0.0) == 1.0
+end


### PR DESCRIPTION
This is another attempt at fixing https://github.com/SciML/ModelingToolkit.jl/issues/2997 by addressing the actual root cause of the issue, which is described with a minimal example in https://github.com/JuliaSymbolics/Symbolics.jl/issues/1246. Following https://github.com/JuliaSymbolics/Symbolics.jl/pull/1036, I have also copied ForwardDiff's `isequal()` definition to resolve the type ambiguity.