### PR TITLE
Fix false positive result of passing a `Function` to `derivative`

### DIFF
--- a/src/diff.jl
+++ b/src/diff.jl
@@ -371,6 +371,8 @@ derivative(::typeof(+), args::NTuple{N,Any}, ::Val) where {N} = 1
 derivative(::typeof(*), args::NTuple{N,Any}, ::Val{i}) where {N,i} = *(deleteat!(collect(args), i)...)
 derivative(::typeof(one), args::Tuple{<:Any}, ::Val) = 0
 
+derivative(f::Function, x::Num) = derivative(f(x), x)
+
 function count_order(x)
     @assert !(x isa Symbol) "The variable $x must have an order of differentiation that is greater or equal to 1!"
     n = 1

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -372,6 +372,7 @@ derivative(::typeof(*), args::NTuple{N,Any}, ::Val{i}) where {N,i} = *(deleteat!
 derivative(::typeof(one), args::Tuple{<:Any}, ::Val) = 0
 
 derivative(f::Function, x::Num) = derivative(f(x), x)
+derivative(::Function, x::Any) = TypeError(:derivative, "2nd argument", Num, typeof(x)) |> throw
 
 function count_order(x)
     @assert !(x isa Symbol) "The variable $x must have an order of differentiation that is greater or equal to 1!"

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -390,3 +390,11 @@ let
         )
     end
 end
+
+# Check `Function` inputs throw for non-Num second input (#1085)
+let
+    @testset for f in [sqrt, sin, acos, exp, cis]
+        @test_throws TypeError Symbolics.derivative(f, rand())
+        @test_throws TypeError Symbolics.derivative(f, Val(rand(Int)))
+    end
+end

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -379,3 +379,14 @@ let
     @test isequal(Dt, identity)
     test_equal(Dt(t + 2t^2), t + 2t^2)
 end
+
+# Check `Function` inputs for derivative (#1085)
+let
+    @variables x
+    @testset for f in [sqrt, sin, acos, exp, cis]
+        @test isequal(
+            Symbolics.derivative(f, x),
+            Symbolics.derivative(f(x), x)
+        )
+    end
+end


### PR DESCRIPTION
As reported in #1085, e.g.

```
@variables x
Symbolics.derivative(sqrt, x)
```

returns 0, when it should return the derivative of `sqrt` (which is not zero of course).

Also added a catching method to throw for non-`Num` second input when first input `isa Function`.

@ChrisRackauckas mentions in #1085 to add a catching method to report "`derivative` not supported for `typeof(f)`" which I couldn't understand, I'll need further explanation? I thought it made more sense to report lack of support for `x isa Any` catch.

He also mentions a check on if `x` is symbolic in any form, I'm also not sure what that means, i.e. what other forms than `Num` are supported? `Complex{Num}` and `Integer{Num}`? (Which errors on input to `f` anyway.)

Happy to make changes as desired.