### PR TITLE
Handle `BasicSymbolic` expressions in test

### DIFF
--- a/test/semipoly.jl
+++ b/test/semipoly.jl
@@ -426,6 +426,10 @@ end
 
 const components = [2, a, b, c, x, y, z, (1+x), (1+y)^2, z*y, z*x]
 
+function verify(t::Symbolics.BasicSymbolic{Number}, d, wrt, nl)
+    verify(Num(t), d, wrt, nl)
+end
+
 function verify(t, d, wrt, nl)
     try
         iszero(t - (isempty(d) ? nl : sum(k*v for (k, v) in d) + nl))

--- a/test/semipoly.jl
+++ b/test/semipoly.jl
@@ -509,3 +509,7 @@ for i=1:20
         trial()
     end
 end
+
+@testset "Extracted from fuzz testing" begin
+    @test verify(2.25(2.0 + 2c)*(c^2), Dict{Any, Any}(c^3 => 4.5, c^2 => 4.5), Num[c, y, z], 0)
+end


### PR DESCRIPTION
The testing expression generator generates expressions of type `Symbolics.BasicSymbolic{Number}` when all the selected variables are of that type (generated by `@syms` instead of `@variables`).

Add a method to wrap these expressions with a `Num` before checking for cancelation.