### PR TITLE
feat: improve `diff2term` for array symbolics

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -131,8 +131,8 @@ function diff2term(O, O_metadata::Union{Dict, Nothing, Base.ImmutableDict}=nothi
             string(nameof(arguments(oldop)[1]))
         elseif oldop == getindex
             args = arguments(O)
-            opname = string(tosymbol(args[1]), "[", map(tosymbol, args[2:end])..., "]")
-            return Sym{symtype(O)}(Symbol(opname, d_separator, ds))
+            opname = string(tosymbol(args[1]))
+            return metadata(Sym{symtype(args[1])}(Symbol(opname, d_separator, ds)), metadata(args[1]))[args[2:end]...]
         elseif oldop isa Function
             return nothing
         else

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -36,7 +36,9 @@ end
 @testset "getname" begin
     @variables t x(t)[1:4]
     v = Symbolics.lower_varname(unwrap(x[2]), unwrap(t), 2)
-    @test getname(v) == Symbol("x(t)[2]ˍtt")
+    @test operation(v) == getindex
+    @test arguments(v)[2] == 2
+    @test getname(v) == getname(arguments(v)[1]) == Symbol("x(t)ˍtt")
 end
 
 @testset "getindex" begin

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -13,7 +13,7 @@ Dx = Differential(x)
 
 @test Symbol(D(D(uu))) === Symbol("uuˍtt(t)")
 @test Symbol(D(uuˍt)) === Symbol(D(D(uu)))
-@test Symbol(D(v[2])) === Symbol("v(t)[2]ˍt")
+@test Symbol(D(v[2])) === Symbol("getindex(var\"v(t)ˍt\", 2)")
 
 test_equal(a, b) = @test isequal(simplify(a), simplify(b))
 


### PR DESCRIPTION
The old behavior caused bugs in MTK.