### PR TITLE
Create ZeroOperator and make D(const) a hard zero

### DIFF
--- a/src/diff.jl
+++ b/src/diff.jl
@@ -1,6 +1,16 @@
 abstract type Operator end
 propagate_shape(::Operator, x) = axes(x)
 
+struct ZeroOperator <: Operator
+end
+(::ZeroOperator)(x) = wrap(0)
+Base.show(io::IO, D::Differential) = print(io, "ZeroOperator")
+Base.nameof(D::ZeroOperator) = :ZeroOperator
+Base.:*(D1, D2::ZeroOperator) = ZeroOperator()
+Base.:*(D1::ZeroOperator, D2) = ZeroOperator()
+Base.:*(D1::ZeroOperator, D2::ZeroOperator) = ZeroOperator()
+Base.:^(D::ZeroOperator, n::Integer) = ZeroOperator()
+
 """
 $(TYPEDEF)
 
@@ -33,6 +43,7 @@ struct Differential <: Operator
     """The variable or expression to differentiate with respect to."""
     x
     Differential(x) = new(value(x))
+    Differential(x::Union{AbstractFloat, Integer}) = ZeroOperator()
 end
 function (D::Differential)(x)
     x = unwrap(x)
@@ -42,6 +53,8 @@ function (D::Differential)(x)
         term(D, x)
     end
 end
+
+(D::Differential)(x::Union{AbstractFloat, Integers}) = wrap(0)
 (D::Differential)(x::Union{Num, Arr}) = wrap(D(unwrap(x)))
 (D::Differential)(x::Complex{Num}) = wrap(ComplexTerm{Real}(D(unwrap(real(x))), D(unwrap(imag(x)))))
 SymbolicUtils.promote_symtype(::Differential, T) = T

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -17,6 +17,13 @@ Dx = Differential(x)
 
 test_equal(a, b) = @test isequal(simplify(a), simplify(b))
 
+@testset "ZeroOperator handling" begin
+    @test isequal(Differential(0.1)(x), 0)
+    @test isequal(Differential(0.1)(0.1x), 0)
+    @test isequal(Differential(1)(x), 0)
+    @test isequal(Differential(2)(2x), 0)
+end
+
 #@test @macroexpand(@derivatives D'~t D2''~t) == @macroexpand(@derivatives (D'~t), (D2''~t))
 
 @test isequal(expand_derivatives(D(t)), 1)


### PR DESCRIPTION
This fixes an odd bug that can occur when a constant can match, like `Differential(2)(2x) == x`, when it should obviously be zero. This fixes Differential(number) == ZeroOperator which acts like a hard zero. You need ZeroOperator instead of 0 because otherwise you codegen to stuff like 0(2x) and get an error that 0 does not have a call, and `zero` the function does not do things like `zero * zero` appropriately, so constructing a simple operator that acts like a true zero is the simplest solution that enforces the safety.
