### PR TITLE
export `tosymbol`

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -92,6 +92,7 @@ export Inequality, ≲, ≳
 include("inequality.jl")
 
 import Bijections, DynamicPolynomials
+export tosymbol
 include("utils.jl")
 
 using ConstructionBase


### PR DESCRIPTION
This is a useful function to have, especially with ModelingToolkit.jl because sometimes variables from MTK are written like `x(t)` and other times they're `x`, so being able to strip out the `(t)` with `escape=true` is nice. 