### PR TITLE
Use fixed width text for compound variable names

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -194,9 +194,9 @@ function _toexpr(O)
     if issym(O) 
         sym = string(nameof(O))
         sym = replace(sym, NAMESPACE_SEPARATOR => ".")
-        sym = Latexify.unicode2latex(sym)
-        sym = replace(sym, "_"=>"\\_")
         if length(sym) > 1
+            sym = Latexify.unicode2latex(sym)
+            sym = replace(sym, "_"=>"\\_")
             return LaTeXString(string("\\texttt", "{", sym, "}"))
         else
             return Symbol(sym)

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -193,7 +193,12 @@ function _toexpr(O)
     end
     if issym(O) 
         sym = string(nameof(O))
-        return Symbol(replace(sym, NAMESPACE_SEPARATOR => "."))
+        sym = replace(sym, NAMESPACE_SEPARATOR => ".")
+        if length(sym) > 1
+            return LaTeXString(string("\\texttt", "{", sym, "}"))
+        else
+            return sym
+        end
     end
     !iscall(O) && return O
 

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -197,7 +197,7 @@ function _toexpr(O)
         if length(sym) > 1
             return LaTeXString(string("\\texttt", "{", sym, "}"))
         else
-            return sym
+            return Symbol(sym)
         end
     end
     !iscall(O) && return O

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -194,6 +194,8 @@ function _toexpr(O)
     if issym(O) 
         sym = string(nameof(O))
         sym = replace(sym, NAMESPACE_SEPARATOR => ".")
+        sym = Latexify.unicode2latex(sym)
+        sym = replace(sym, "_"=>"\\_")
         if length(sym) > 1
             return LaTeXString(string("\\texttt", "{", sym, "}"))
         else

--- a/test/latexify_refs/integral1.txt
+++ b/test/latexify_refs/integral1.txt
@@ -1,3 +1,3 @@
 \begin{equation}
-\int_{0}^{1)} dx x
+\int_{0}^{1)} \texttt{dx} x
 \end{equation}

--- a/test/latexify_refs/integral1.txt
+++ b/test/latexify_refs/integral1.txt
@@ -1,3 +1,3 @@
 \begin{equation}
-\int_{0}^{1)} dx x
+\\int_{0}^{1)} \\texttt{dx} x
 \end{equation}

--- a/test/latexify_refs/integral1.txt
+++ b/test/latexify_refs/integral1.txt
@@ -1,3 +1,3 @@
 \begin{equation}
-\\int_{0}^{1)} \\texttt{dx} x
+\int_{0}^{1)} dx x
 \end{equation}

--- a/test/latexify_refs/integral2.txt
+++ b/test/latexify_refs/integral2.txt
@@ -1,3 +1,3 @@
 \begin{equation}
-\int_{-\infty}^{\infty)} dx \left( u\left( x \right) \right)^{2}
+\int_{-\infty}^{\infty)} \texttt{dx} \left( u\left( x \right) \right)^{2}
 \end{equation}

--- a/test/latexify_refs/integral3.txt
+++ b/test/latexify_refs/integral3.txt
@@ -1,3 +1,3 @@
 \begin{equation}
-\int_{ - z}^{u\left( x \right))} dx x^{2}
+\int_{ - z}^{u\left( x \right))} \texttt{dx} x^{2}
 \end{equation}


### PR DESCRIPTION
`capacitor` makes sense as code but does not make as much sense inside of latex output. When you look at it, it italics each of the letters which makes it look like its c times a times ..., which isn't quite right.

Instead, this uses `\texttt{name}` in order to more clearly delineate a value which is a compound name. Using the fixed width text also looks quite "computer-y" so it has a nice connection to `verbose` and is clearly a "computer variable" in the expression.
