### PR TITLE
Avoid depending on `SymbolicsNemoExt` in `SymbolicsGroebnerExt`

### DIFF
--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -317,15 +317,23 @@ function Symbolics.solve_multivar(eqs::Vector, vars::Vector{Num}; dropmultiplici
     sol
 end
 
-# Helps with precompilation time
-PrecompileTools.@setup_workload begin
-    @variables a b c x y z
-    simple_linear_equations = [x - y, y + 2z]
-    equations_intersect_sphere_line = [x^2 + y^2 + z^2 - 9, x - 2y + 3, y - z]
-    PrecompileTools.@compile_workload begin
-        symbolic_solve(simple_linear_equations, [x, y], warns=false)
-        symbolic_solve(equations_intersect_sphere_line, [x, y, z], warns=false)
-    end
-end
+
+# XXX: on 1.11, SymbolicsNemoExt isn't actually loaded during the pre-compilation of SymbolicsGroebnerExt,
+# so we can't run a workload using its definitions yet. (The new restriction was added in 1.11 because
+# of "AB" issues where an extension A and B would mutually expect the other to load "first")
+#
+# This can be re-enabled when it is possible for an extension A to explicitly declare that it depends on
+# an extension B.
+
+# # Helps with precompilation time
+# PrecompileTools.@setup_workload begin
+    # @variables a b c x y z
+    # simple_linear_equations = [x - y, y + 2z]
+    # equations_intersect_sphere_line = [x^2 + y^2 + z^2 - 9, x - 2y + 3, y - z]
+    # PrecompileTools.@compile_workload begin
+        # symbolic_solve(simple_linear_equations, [x, y], warns=false)
+        # symbolic_solve(equations_intersect_sphere_line, [x, y, z], warns=false)
+    # end
+# end
 
 end # module


### PR DESCRIPTION
Extensions are no longer allowed to assume that their triggers load new extensions at pre-compile time in 1.11 (this was the root cause of a number of pre-compilation / loading "cycle" issues like https://github.com/JuliaLang/julia/issues/55517), so `SymbolicsGroebnerExt` is not allowed to use the methods implemented in `SymbolicsNemoExt` at precompile-time.

That restriction was supposed to be enabled in 1.11.0, but it was unfortunately added in the 1.11.1 patch release.