### PR TITLE
Quick fix Latex rendering

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -195,12 +195,9 @@ function _toexpr(O)
         sym = string(nameof(O))
         sym = replace(sym, NAMESPACE_SEPARATOR => ".")
         if length(sym) > 1
-            sym = Latexify.unicode2latex(sym)
-            sym = replace(sym, "_"=>"\\_")
-            return LaTeXString(string("\\texttt", "{", sym, "}"))
-        else
-            return Symbol(sym)
+            sym = string("\\mathtt{", sym, "}")
         end
+        return Symbol(sym)
     end
     !iscall(O) && return O
 

--- a/test/latexify_refs/integral1.txt
+++ b/test/latexify_refs/integral1.txt
@@ -1,3 +1,3 @@
 \begin{equation}
-\int_{0}^{1)} \texttt{dx} x
+\int_{0}^{1)} \mathtt{dx} x
 \end{equation}

--- a/test/latexify_refs/integral2.txt
+++ b/test/latexify_refs/integral2.txt
@@ -1,3 +1,3 @@
 \begin{equation}
-\int_{-\infty}^{\infty)} \texttt{dx} \left( u\left( x \right) \right)^{2}
+\int_{-\infty}^{\infty)} \mathtt{dx} \left( u\left( x \right) \right)^{2}
 \end{equation}

--- a/test/latexify_refs/integral3.txt
+++ b/test/latexify_refs/integral3.txt
@@ -1,3 +1,3 @@
 \begin{equation}
-\int_{ - z}^{u\left( x \right))} \texttt{dx} x^{2}
+\int_{ - z}^{u\left( x \right))} \mathtt{dx} x^{2}
 \end{equation}


### PR DESCRIPTION
A possible quick fix for #1314, without changing any behavior for now:
```julia
latexify(@variables t Gᴾ(t) Ω₀ δt αβ b₊Ω0 b₊Ω_0 circuit₊capacitor₊C A B AB)
```
```
L"\begin{equation}
\left[
\begin{array}{c}
t \\
\mathtt{G^P}\left( t \right) \\
\mathtt{\Omega{_0}} \\
\mathtt{{\delta}t} \\
\mathtt{\alpha\beta} \\
\mathtt{b.{\Omega}0} \\
\mathtt{b.\Omega\_0} \\
\mathtt{circuit.capacitor.C} \\
A \\
B \\
\mathtt{AB} \\
\end{array}
\right]
\end{equation}
"
```
![image](https://github.com/user-attachments/assets/b6c47fbe-e49b-43cf-9d53-63daa8106aa4)
