### PR TITLE
feat: support array variables in `linear_expansion`

### DIFF
--- a/test/linear_solver.jl
+++ b/test/linear_solver.jl
@@ -59,3 +59,18 @@ a, b, islinear = Symbolics.linear_expansion(D(x) - x, x)
 @test islinear
 @test isequal(a, -1)
 @test isequal(b, D(x))
+
+@testset "linear_expansion with array variables" begin
+    @variables x[1:2] y[1:2] z(..)
+    @test !Symbolics.linear_expansion(z(x) + x[1], x[1])[3]
+    @test !Symbolics.linear_expansion(z(x[1]) + x[1], x[1])[3]
+    a, b, islin = Symbolics.linear_expansion(z(x[2]) + x[1], x[1])
+    @test islin && isequal(a, 1) && isequal(b, z(x[2]))
+    a, b, islin = Symbolics.linear_expansion((x + x)[1], x[1])
+    @test islin && isequal(a, 2) && isequal(b, 0)
+    a, b, islin = Symbolics.linear_expansion(y[1], x[1])
+    @test islin && isequal(a, 0) && isequal(b, y[1])
+    @test !Symbolics.linear_expansion(z([x...]), x[1])[3]
+    @test !Symbolics.linear_expansion(z(collect(Symbolics.unwrap(x))), x[1])[3]
+    @test !Symbolics.linear_expansion(z([x, 2x]), x[1])[3]
+end


### PR DESCRIPTION
Before:
```julia
julia> @variables x(t)[1:2] y(t)
julia> @parameters f(::Vector{Real})
julia> @mtkbuild sys = ODESystem([D(x) ~ x .* y, y ~ sum(x)], t)
┌ Warning: Internal error: Variable (x(t))[1] was marked as being in 0 ~ -y(t) + Symbolics._mapreduce(identity, +, x(t), Colon(), (:init => false,)), but was actually zero
└ @ ModelingToolkit.StructuralTransformations ~/Julia/SciML/ModelingToolkit.jl/src/structural_transformation/utils.jl:237
┌ Warning: Internal error: Variable (x(t))[2] was marked as being in 0 ~ -y(t) + Symbolics._mapreduce(identity, +, x(t), Colon(), (:init => false,)), but was actually zero
└ @ ModelingToolkit.StructuralTransformations ~/Julia/SciML/ModelingToolkit.jl/src/structural_transformation/utils.jl:237
Model sys with 2 equations
Unknowns (2):
  (x(t))[1]
  (x(t))[2]
Parameters (0):
```

After:
```julia
julia> @mtkbuild sys = ODESystem([D(x) ~ x .* y, y ~ sum(x)], t)
Model sys with 2 equations
Unknowns (2):
  (x(t))[1]
  (x(t))[2]
Parameters (0):
```

There are also cases where `structural_simplify` would create DAEs instead of ODEs with those warnings but I can't remember how to MWE that yet.