### PR TITLE
fix: fix `symbolic_type` for unwrapped array symbolics

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -489,6 +489,14 @@ getsource(x, val=_fail) = getmetadata(unwrap(x), VariableSource, val)
 
 SymbolicIndexingInterface.symbolic_type(::Type{<:Symbolics.Num}) = ScalarSymbolic()
 SymbolicIndexingInterface.symbolic_type(::Type{<:Symbolics.Arr}) = ArraySymbolic()
+function SymbolicIndexingInterface.symbolic_type(::Type{T}) where {S <: AbstractArray, T <: Symbolic{S}}
+    ArraySymbolic()
+end
+# need this otherwise the `::Type{<:BasicSymbolic}` method in SymbolicUtils is
+# more specific
+function SymbolicIndexingInterface.symbolic_type(::Type{T}) where {S <: AbstractArray, T <: BasicSymbolic{S}}
+    ArraySymbolic()
+end
 
 SymbolicIndexingInterface.hasname(x::Union{Num,Arr}) = hasname(unwrap(x))
 

--- a/test/symbolic_indexing_interface_trait.jl
+++ b/test/symbolic_indexing_interface_trait.jl
@@ -10,6 +10,7 @@ using SymbolicIndexingInterface
 @test symbolic_type(x) == ScalarSymbolic()
 @variables y[1:3]
 @test symbolic_type(y) == ArraySymbolic()
+@test symbolic_type(Symbolics.unwrap(y)) == ArraySymbolic()
 @test all(symbolic_type.(collect(y)) .== (ScalarSymbolic(),))
 @test symbolic_type(Symbolics.unwrap(y .* y)) == ArraySymbolic()
 @variables z(..)


### PR DESCRIPTION
I am very surprised this went unnoticed until now