### PR TITLE
fix: lower default `maxiters` for `fixpoint_sub`

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -533,7 +533,7 @@ infinite loops in cases where the substitutions in `dict` are circular
 
 See also: [`fast_substitute`](@ref).
 """
-function fixpoint_sub(x, dict; operator = Nothing, maxiters = 10000)
+function fixpoint_sub(x, dict; operator = Nothing, maxiters = 1000)
     dict = subrules_to_dict(dict)
     y = fast_substitute(x, dict; operator)
     while !isequal(x, y) && maxiters > 0


### PR DESCRIPTION
10000 was a bit too high