### PR TITLE
Let user hook into variable Latexifying

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -151,6 +151,7 @@ include("extra_functions.jl")
 using Latexify
 using LaTeXStrings
 include("latexify_recipes.jl")
+export latexify_variable
 
 using RecipesBase
 include("plot_recipes.jl")


### PR DESCRIPTION
There has been some changes/discussion about how variables are Latexified in https://github.com/JuliaSymbolics/SymbolicUtils.jl/issues/659, https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/660, https://github.com/JuliaSymbolics/Symbolics.jl/issues/1314 and https://github.com/JuliaSymbolics/Symbolics.jl/pull/1305.

This is a suggestion to provide a hook `Symbolics.latexify_variables` that users (e.g. ModelingToolkit, Catalyst, other packages or humans) can redefine to customize this. In a fresh Julia session, it could work like this:
```julia
# 1) Default with Symbolics only (pure output)
using Symbolics, Latexify
@variables t car₊wheel₊ω(t) # angular velocity
latexify(car₊wheel₊ω) # -> car.wheel.\omega\left( t \right)

# 2) Inside ModelingToolkit?
function Symbolics.latexify_variable(name)
    return "\\mathtt{$name}" # treat subsystem and variable names like code (word-like names are very common in hierarchical modeling)  
end
latexify(car₊wheel₊ω) # -> \mathtt{car.wheel.\omega}\left( \mathtt{t} \right)

# 3) Inside another user's package?
function Symbolics.latexify_variable(name)
    names = split(name, ".") # get subsystem and variable names
    names[1:end-1] = map(name -> "\\mathrm{$name}", names[1:end-1]) # treat subsystem names like words
    names[end] = length(names[end]) > 1 ? "\\mathrm{$(names[end])}" : names[end] # treat one-letter variables like symbols and multi-letter names like words
    name = join(names, ".") # reassemble
    return name
end
latexify(car₊wheel₊ω) # -> \mathrm{car}.\mathrm{wheel}.\omega\left( t \right)
```
If ModelingToolkit gets something like a `LatexDisplayOptions` object in the future, my idea is that it could use this hook to do its thing. But for many packages, maybe it is sufficient to just override this function, based on what types of equations and variables it has.

Any thoughts on this approach and potential issues? cc @ChrisRackauckas @isaacsas