### PR TITLE
add flag for activating robust calculation of expand_derivatives

### DIFF
--- a/test/diff.jl
+++ b/test/diff.jl
@@ -356,9 +356,8 @@ let
 	D = Differential(t)
 	expr = b - ((D(b))^2) * D(D(b))
 	expr2 = D(expr)
-	@test isequal(expand_derivatives(expr), expand_derivatives(expr; robust=true))
-    @test isequal(expand_derivatives(expr2; robust=true), D(b) - (D(b)^2)*D(D(D(b))) - 2D(b)*(D(D(b))^2))
-	@test isequal(expand_derivatives(expr2; robust=true), expand_derivatives(expr2))   
+	@test isequal(expand_derivatives(expr), expr)
+    @test isequal(expand_derivatives(expr2), D(b) - (D(b)^2)*D(D(D(b))) - 2D(b)*(D(D(b))^2))
 end
 
 # 1126
@@ -370,13 +369,13 @@ let
     expr_gen = (fun) -> D(D(((-D(D(fun))) / g(y))))
     
     expr = expr_gen(g(y))
-    @test isequal(expand_derivatives(expr), expand_derivatives(expr; robust=true))
+    # just make sure that no errors are thrown in the following, the results are to complicated to compare
+    expand_derivatives(expr)
     expr = expr_gen(h(y))
-    @test isequal(expand_derivatives(expr), expand_derivatives(expr; robust=true))
+    expand_derivatives(expr)
 
-    expected = substitute(expand_derivatives(expr; robust=true), h(y) => f(y))
     expr = expr_gen(f(y))
-    @test isequal(expand(expand_derivatives(expr)), expand(expand_derivatives(expr; robust=true)))
+    expand_derivatives(expr)
 end
 
 # Check `is_derivative` function

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -357,8 +357,8 @@ let
 	expr = b - ((D(b))^2) * D(D(b))
 	expr2 = D(expr)
 	@test isequal(expand_derivatives(expr), expand_derivatives(expr; robust=true))
-	@test_throws BoundsError expand_derivatives(expr2)
     @test isequal(expand_derivatives(expr2; robust=true), D(b) - (D(b)^2)*D(D(D(b))) - 2D(b)*(D(D(b))^2))
+	@test isequal(expand_derivatives(expr2; robust=true), expand_derivatives(expr2))   
 end
 
 # 1126
@@ -370,14 +370,13 @@ let
     expr_gen = (fun) -> D(D(((-D(D(fun))) / g(y))))
     
     expr = expr_gen(g(y))
-    @test_broken isequal(expand_derivatives(expr), expand_derivatives(expr; robust=true))
+    @test isequal(expand_derivatives(expr), expand_derivatives(expr; robust=true))
     expr = expr_gen(h(y))
-    @test_broken isequal(expand_derivatives(expr), expand_derivatives(expr; robust=true))
+    @test isequal(expand_derivatives(expr), expand_derivatives(expr; robust=true))
 
     expected = substitute(expand_derivatives(expr; robust=true), h(y) => f(y))
     expr = expr_gen(f(y))
-    @test_throws BoundsError expand_derivatives(expr)
-    @test isequal(expand(expand_derivatives(expr; robust=true)), expected)
+    @test isequal(expand(expand_derivatives(expr)), expand(expand_derivatives(expr; robust=true)))
 end
 
 # Check `is_derivative` function


### PR DESCRIPTION
This provides a workaround for issues #1126 and #1262 by adding a flag `robust` that if set, forces expand_derivatives to always recalculate `occurrences`.

It also adds tests that check if the examples from the issues are actually solved. These tests also show that `expand_derivatives` can return a wrong result without throwing any error. Line 372 to 375 in `tests/diff.jl`:
```julia
expr = expr_gen(g(y))
@test_broken isequal(expand_derivatives(expr), expand_derivatives(expr; robust=true))
expr = expr_gen(h(y))
@test_broken isequal(expand_derivatives(expr), expand_derivatives(expr; robust=true))
```

I set the robust flag to false per default but since the result of the non-robust version is not reliable it should be considered if setting it to true should be the default.