### PR TITLE
Bug fixes, integration of solve_interms_ofvar and some changes

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -210,7 +210,7 @@ include("solver/polynomialization.jl")
 include("solver/attract.jl")
 include("solver/ia_main.jl")
 include("solver/main.jl")
-include("solver/ia_rules.jl")
+include("solver/special_cases.jl")
 export symbolic_solve
 
 function symbolics_to_sympy end

--- a/src/solver/ia_main.jl
+++ b/src/solver/ia_main.jl
@@ -13,16 +13,14 @@ function isolate(lhs, var; warns=true, conditions=[], complex_roots = true, peri
 
         if check_poly_inunivar(poly, var)
             roots = []
-            new_var = gensym()
-            new_var = (@variables $new_var)[1]
             if Base.get_extension(Symbolics, :SymbolicsNemoExt) !== nothing
-                lhs_roots = solve_univar(lhs - new_var, var)
+                lhs_roots = solve_univar(lhs, var)
             else
-                a, b, islin = linear_expansion(lhs - new_var, var)
+                a, b, islin = linear_expansion(lhs, var)
                 if islin
                     lhs_roots = [-b / a]
                 else
-                    lhs_roots = [RootsOf(lhs - new_var, var)]
+                    lhs_roots = [RootsOf(lhs, var)]
                     if warns
                         @warn "Nemo is required to properly solve this expression. Execute `using Nemo` to enable this functionality."
                     end
@@ -31,7 +29,7 @@ function isolate(lhs, var; warns=true, conditions=[], complex_roots = true, peri
 
             for i in eachindex(lhs_roots)
                 for j in eachindex(rhs)
-                    push!(roots, substitute(lhs_roots[i], Dict(new_var=>rhs[j]), fold=false))
+                    push!(roots, lhs_roots[i]-rhs[j])
                 end
             end
             return roots, conditions

--- a/src/solver/ia_main.jl
+++ b/src/solver/ia_main.jl
@@ -45,7 +45,7 @@ function isolate(lhs, var; warns=true, conditions=[], complex_roots = true, peri
 
         if isequal(old_lhs, lhs) 
             warns && @warn("This expression cannot be solved with the methods available to ia_solve. Try a numerical method instead.")
-            return nothing
+            return nothing, conditions
         end
 
         old_lhs = deepcopy(lhs)
@@ -82,7 +82,7 @@ function isolate(lhs, var; warns=true, conditions=[], complex_roots = true, peri
             else
                 # 2 / x = y
                 lhs = args[2]
-                rhs = map(sol -> args[1] // sol, rhs)
+                rhs = map(sol -> term(/, args[1], sol), rhs)
             end
 
         elseif oper === (^)
@@ -114,6 +114,7 @@ function isolate(lhs, var; warns=true, conditions=[], complex_roots = true, peri
             elseif any(isequal(x, var) for x in get_variables(args[1])) &&
                    n_occurrences(args[2], var) == 0
                 lhs = args[1]
+                s, args[2] = filter_stuff(args[2])
                 rhs = map(sol -> term(^, sol, 1 // args[2]), rhs)
             else
                 lhs = args[2]
@@ -280,9 +281,9 @@ function ia_solve(lhs, var; warns = true, complex_roots = true, periodic_roots =
     conditions = []
     if nx == 0
         warns && @warn("Var not present in given expression")
-        return []
+        return nothing
     elseif nx == 1
-        sols, conditions = isolate(lhs, var; warns = warns, complex_roots, periodic_roots)
+       sols, conditions = isolate(lhs, var; warns = warns, complex_roots, periodic_roots)
     elseif nx > 1
         sols, conditions = attract(lhs, var; warns = warns, complex_roots, periodic_roots)
     end

--- a/src/solver/ia_main.jl
+++ b/src/solver/ia_main.jl
@@ -18,7 +18,7 @@ function isolate(lhs, var; warns=true, conditions=[], complex_roots = true, peri
             else
                 a, b, islin = linear_expansion(lhs, var)
                 if islin
-                    lhs_roots = [-b / a]
+                    lhs_roots = [-b // a]
                 else
                     lhs_roots = [RootsOf(lhs, var)]
                     if warns
@@ -29,7 +29,7 @@ function isolate(lhs, var; warns=true, conditions=[], complex_roots = true, peri
 
             for i in eachindex(lhs_roots)
                 for j in eachindex(rhs)
-                    push!(roots, lhs_roots[i]-rhs[j])
+                    push!(roots, rhs[j]+lhs_roots[i])
                 end
             end
             return roots, conditions

--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -259,7 +259,7 @@ implemented in the function `get_roots` and its children.
 # Examples
 
 """
-function solve_univar(expression, x; dropmultiplicity=true)
+function solve_univar(expression, x; dropmultiplicity=true, strict=true)
     args = []
     mult_n = 1
     expression = unwrap(expression)
@@ -277,6 +277,9 @@ function solve_univar(expression, x; dropmultiplicity=true)
     end
 
     subs, filtered_expr, assumptions = filter_poly(expression, x, assumptions=true)
+    if strict
+        @assert check_polynomial(filtered_expr) "This expression could not be solved by `symbolic_solve`."
+    end
     coeffs, constant = polynomial_coeffs(filtered_expr, [x])
     degree = sdegree(coeffs, x)
 
@@ -315,7 +318,6 @@ function solve_univar(expression, x; dropmultiplicity=true)
     end
 
     if isequal(arr_roots, [])
-        @assert check_polynomial(expression) "This expression could not be solved by `symbolic_solve`."
         return [RootsOf(wrap(expression), wrap(x))]
     end
 

--- a/src/solver/nemo_stuff.jl
+++ b/src/solver/nemo_stuff.jl
@@ -1,12 +1,16 @@
 # Checks that the expression is a polynomial with integer or rational
 # coefficients
-function check_polynomial(poly)
+function check_polynomial(poly; strict=true)
     poly = wrap(poly)
     vars = get_variables(poly)
     distr, rem = polynomial_coeffs(poly, vars)
-    @assert isequal(rem, 0) "Not a polynomial"
-    @assert all(c -> c isa Integer || c isa Rational, collect(values(distr))) "Coefficients must be integer or rational"
-    return true
+    if strict
+        @assert isequal(rem, 0) "Not a polynomial"
+        @assert all(c -> c isa Integer || c isa Rational, collect(values(distr))) "Coefficients must be integer or rational"
+        return true
+    else
+        return isequal(rem, 0)
+    end
 end
 
 # factor(x^2*y + b*x*y - a*x - a*b)  ->  (x*y - a)*(x + b)

--- a/src/solver/postprocess.jl
+++ b/src/solver/postprocess.jl
@@ -43,14 +43,26 @@ function _postprocess_root(x::SymbolicUtils.BasicSymbolic)
         end
     end
 
+    args = arguments(x)
+
     # (X)^0 => 1
-    if oper === (^) && isequal(arguments(x)[2], 0)
+    if oper === (^) && isequal(args[2], 0) && !isequal(args[1], 0)
         return 1
     end
 
     # (X)^1 => X
-    if oper === (^) && isequal(arguments(x)[2], 1)
-        return arguments(x)[1]
+    if oper === (^) && isequal(args[2], 1)
+        return args[1]
+    end
+
+    # (0)^X => 0
+    if oper === (^) && isequal(args[1], 0) && !isequal(args[2], 0)
+        return 0
+    end
+
+    # y / 0 => Inf
+    if oper === (/) && !isequal(args[1], 0) && isequal(args[2], 0)
+        return Inf
     end
 
     # sqrt((N / D)^2 * M) => N / D * sqrt(M)

--- a/src/solver/preprocess.jl
+++ b/src/solver/preprocess.jl
@@ -44,13 +44,10 @@ function clean_f(filtered_expr, var, subs)
 
     if oper === (/)
         args = arguments(unwrapped_f)
-        if any(isequal(var, x) for x in get_variables(args[2]))
-            filtered_expr = expand(args[1] * args[2])
+        if !all(isequal(var, x) for x in get_variables(args[2]))
+            filtered_expr = args[1]
             push!(assumptions, substitute(args[2], subs, fold=false))
-            return filtered_expr, assumptions
         end
-        filtered_expr = args[1]
-        @info "Assuming $(substitute(args[2], subs, fold=false) != 0)"
     end
     return filtered_expr, assumptions
 end

--- a/src/solver/special_cases.jl
+++ b/src/solver/special_cases.jl
@@ -37,7 +37,47 @@ function cross_multiply(eq)
         return cross_multiply(eq)
     end
 end
+"""
+    solve_interms_ofvar(eq, s; dropmultiplicity=true, warns=true)
+This special case solver expects a single equation in multiple variables and a
+variable `s` (this can be any Num, `s` is used for convenience). The function generates
+a system of equations to by observing the coefficients of the powers of `s` present in `eq`.
+E.g. a system would look like `a+b = 1`, `a-2b = 3` for the eq `(a+b)s + (a-2b)s^2 - (1)s - (3)s^2 = 0`.
+After generating this system, it calls `symbolic_solve`, which uses `solve_multivar`. `symbolic_solve` was chosen
+instead of `solve_multivar` because it postprocesses the roots in order to simplify them and make them more user friendly.
 
+Generation of system uses cross multiplication in order to simplify the equation and convert it
+to a polynomial like shape.
+
+
+# Arguments
+- eq: Single symbolics Num or SymbolicUtils.BasicSymbolic. This is equated to 0 and then solved. E.g. `expr = x+2`, we solve `x+2 = 0`
+
+- s: Variable to "isolate", i.e. ignore and generate the system of equations based on this variable's coefficients.
+
+- dropmultiplicity (optional): Print repeated roots or not?
+
+- warns (optional, this is not used currently): Warn user when something is wrong or not.
+
+# Examples
+```jldoctest
+julia> @variables a b x s;
+
+julia> eq = (a*x^2+b)*s^2 - 2s^2 + 2*b*s - 3*s + 2(x^2)*(s^3) + 10*s^3;
+
+julia> Symbolics.solve_interms_ofvar(eq, s)
+2-element Vector{Any}:
+ Dict{Num, Any}(a => -1//10, b => 3//2, x => (0 - 1im)*√(5))
+ Dict{Num, Any}(a => -1//10, b => 3//2, x => (0 + 1im)*√(5))
+```
+```jldoctest
+julia> eq = ((s^2 + 1)/(s^2 + 2*s + 1)) - ((s^2 + a)/(b*c*s^2 + (b+c)*s + d));
+
+julia> Symbolics.solve_interms_ofvar(eq, s)
+1-element Vector{Any}:
+ Dict{Num, Any}(a => 1, d => 1, b => 1, c => 1)
+```
+"""
 function solve_interms_ofvar(eq, s; dropmultiplicity=true, warns=true)
     @assert iscall(unwrap(eq))
     vars = Symbolics.get_variables(eq)

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -5,7 +5,6 @@ import Symbolics: ssqrt, slog, scbrt, symbolic_solve, ia_solve, postprocess_root
     @test Base.get_extension(Symbolics, :SymbolicsNemoExt) === nothing
     @variables x
     roots = ia_solve(log(2 + x), x)
-    @test substitute(roots[1], Dict()) == -1.0
     roots = @test_warn ["Nemo", "required"] ia_solve(log(2 + x^2), x)
     @test operation(roots[1]) == Symbolics.RootsOf
 end
@@ -85,7 +84,6 @@ end
 
 @testset "Invalid input" begin
     @test_throws AssertionError symbolic_solve(x, x^2)
-    @test_throws AssertionError symbolic_solve(1/x, x)
 end
 
 @testset "Nice univar cases" begin


### PR DESCRIPTION
New stuff:
```julia
julia> symbolic_solve(1/x, x)
1-element Vector{Float64}:
 Inf
```
```julia
julia> symbolic_solve(x^1.5, x)
1-element Vector{BigFloat}:
 0.0
 ```
 "Strict" kwarg for `solve_univar` @AayushSabharwal :
 ```julia
 julia> Symbolics.solve_univar(x^1.5 + x, x)
ERROR: AssertionError: Not a polynomial

julia> Symbolics.solve_univar(x^1.5 + x, x, strict=false)
1-element Vector{SymbolicUtils.BasicSymbolic{Number}}:
 roots_of(x + x^1.5, x)
 ```
 
Documentation and integration of `solve_interms_ofvar` was also added. `ia_rules.jl` was moved to `special_cases.jl` because thats more representative i think, since the `solve_interms_ofvar` case isnt "isolation and attraction" - its just some algebraic manipulation method we use in a special case @ChrisRackauckas (let me know what you think).