### PR TITLE
Enable the creation of variables using `@variables X(vec...)`

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -148,7 +148,6 @@ function _parse_vars(macroname, type, x, transform=identity)
             isruntime, fname = unwrap_runtime_var(v.args[1])
             call_args = map(last∘unwrap_runtime_var, @view v.args[2:end])
             var_name, expr = construct_vars(macroname, fname, type′, call_args, val, options, transform, isruntime)
-
         else
             var_name, expr = construct_vars(macroname, v, type′, nothing, val, options, transform, isruntime)
         end

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -389,3 +389,31 @@ fns = @test_nowarn @variables begin
 end
 
 test_all_functions(fns)
+
+# Tests that variables can be declared using vectors of dependants.
+let
+    @variables x y z v w
+    args1 = [x]
+    args2 = [x, y]
+    args3 = [x, y, z]
+
+    v1 = only(@variables X(x))
+    v2 = only(@variables X(args1...))
+    @test isequal(v1, v2)
+
+    v1 = only(@variables X(x,y))
+    v2 = only(@variables X(args3[1:2]...))
+    @test isequal(v1, v2)
+
+    v1 = only(@variables X(x, y, z))
+    v2 = only(@variables X([args2; z]...))
+    @test isequal(v1, v2)
+
+    v1 = only(@variables X(x, y, z, v))
+    v2 = only(@variables X(vcat(args2, [z, v])...))
+    @test isequal(v1, v2)
+
+    v1 = only(@variables X(x, y, z, v, w))
+    v2 = only(@variables X([v for v in [args3; [v, w]]]...))
+    @test isequal(v1, v2)
+end


### PR DESCRIPTION
This enables:
```julia
@variables x y z
args = [x, y, z]
@variables X(args...)
```
which is equivalent to
```julia
@variables X(x, y, z)
```
 
Currently, the former throws an error. This should enable people to collect e.g. independent variables in a vector, and then using it as dependencies in `@variables`. This will also fix a problem in Catalyst where we no longer can creat observables correctly.