### PR TITLE
Support symbolic_solve([equations])

### DIFF
--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -220,10 +220,13 @@ end
 function symbolic_solve(expr; x...)
     if expr isa Vector
         expr = convert(Vector{Any}, expr)
+        for i in eachindex(expr)
+            expr[i] = expr[i] isa Equation ? expr[i].lhs - expr[i].rhs : expr[i]
+        end
+    else
+        expr = expr isa Equation ? expr.lhs - expr.rhs : expr
     end
-    for i in eachindex(expr)
-        expr[i] = expr[i] isa Equation ? expr[i].lhs - expr[i].rhs : expr[i]
-    end
+
 
     r = filter_poly.(expr)
     subs, filtered = r isa Tuple ? r : (map(t -> t[1], r), map(t -> t[2], r))

--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -218,6 +218,13 @@ function symbolic_solve(expr, x::T; dropmultiplicity = true, warns = true) where
 end
 
 function symbolic_solve(expr; x...)
+    if expr isa Vector
+        expr = convert(Vector{Any}, expr)
+    end
+    for i in eachindex(expr)
+        expr[i] = expr[i] isa Equation ? expr[i].lhs - expr[i].rhs : expr[i]
+    end
+
     r = filter_poly.(expr)
     subs, filtered = r isa Tuple ? r : (map(t -> t[1], r), map(t -> t[2], r))
 


### PR DESCRIPTION
```julia
symbolic_solve([x+y ~ 1, x-y~0])
```
This used to error because the function which handles `symbolic_solve(eq)` was not converting the input to Nums before detecting the input vars.