### PR TITLE
fix latexify_recipes.jl for real values of type Complex

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -185,7 +185,7 @@ function _toexpr(O)
             frac_expr = Expr(:call, :/, numer_expr, denom_expr)
         end
 
-        if isreal(m.coeff) && m.coeff < 0
+        if isreal(m.coeff) && real(m.coeff) < 0
             return Expr(:call, :-, frac_expr)
         else
             return frac_expr

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -55,6 +55,9 @@ Dy = Differential(y)
 @test_reference "latexify_refs/complex3.txt" latexify(1 - x + (1+2x)*im; imaginary_unit="\\mathbb{i}")
 @test_reference "latexify_refs/complex4.txt" latexify(im * Symbolics.Term(sqrt, [2]))
 
+@syms c
+@test_reference "latexify_refs/complex5.txt" latexify((3+im/im)c)
+
 @test_reference "latexify_refs/indices1.txt" latexify(h[10,10])
 @test_reference "latexify_refs/indices2.txt" latexify(h[10,10], index=:bracket)
 

--- a/test/latexify_refs/complex5.txt
+++ b/test/latexify_refs/complex5.txt
@@ -1,0 +1,3 @@
+\begin{equation}
+4.0 c
+\end{equation}


### PR DESCRIPTION
This fixes latexify for Complex symbolic values with no imaginary part.

A `Complex` value with no imaginary part `isreal` but is not comparable, but the real part is.