### PR TITLE
Assume unknown functions are non-linear in `hessian_sparsity`

### DIFF
--- a/src/linearity.jl
+++ b/src/linearity.jl
@@ -1,61 +1,45 @@
 using SpecialFunctions
 import Base.Broadcast
 
-
-const linearity_known_1 = IdDict{Function,Bool}()
-const linearity_known_2 = IdDict{Function,Bool}()
-
 const linearity_map_1 = IdDict{Function, Bool}()
 const linearity_map_2 = IdDict{Function, Tuple{Bool, Bool, Bool}}()
 
 # 1-arg
-
 const monadic_linear = [deg2rad, +, rad2deg, transpose, -, conj]
 
 const monadic_nonlinear = [asind, log1p, acsch, erfc, digamma, acos, asec, acosh, airybiprime, acsc, cscd, log, tand, log10, csch, asinh, airyai, abs2, gamma, lgamma, erfcx, bessely0, cosh, sin, cos, atan, cospi, cbrt, acosd, bessely1, acoth, erfcinv, erf, dawson, inv, acotd, airyaiprime, erfinv, trigamma, asecd, besselj1, exp, acot, sqrt, sind, sinpi, asech, log2, tan, invdigamma, airybi, exp10, sech, erfi, coth, asin, cotd, cosd, sinh, abs, besselj0, csc, tanh, secd, atand, sec, acscd, cot, exp2, expm1, atanh, slog, ssqrt, scbrt]
 
-# We store 3 bools even for 1-arg functions for type stability
-const three_trues = (true, true, true)
 for f in monadic_linear
-    linearity_known_1[f] = true
     linearity_map_1[f] = true
 end
 
 for f in monadic_nonlinear
-    linearity_known_1[f] = true
     linearity_map_1[f] = false
 end
 
 # 2-arg
 for f in [+, rem2pi, -, >, isless, <, isequal, max, min, convert, <=, >=]
-    linearity_known_2[f] = true
     linearity_map_2[f] = (true, true, true)
 end
 
 for f in [*]
-    linearity_known_2[f] = true
     linearity_map_2[f] = (true, true, false)
 end
 
 for f in [/]
-    linearity_known_2[f] = true
     linearity_map_2[f] = (true, false, false)
 end
 for f in [\]
-    linearity_known_2[f] = true
     linearity_map_2[f] = (false, true, false)
 end
 
 for f in [hypot, atan, mod, rem, lbeta, ^, beta]
-    linearity_known_2[f] = true
     linearity_map_2[f] = (false, false, false)
 end
 
-haslinearity_1(@nospecialize(f)) = get(linearity_known_1, f, false)
-haslinearity_2(@nospecialize(f)) = get(linearity_known_2, f, false)
-
-linearity_1(@nospecialize(f)) = linearity_map_1[f]
-linearity_2(@nospecialize(f)) = linearity_map_2[f]
+# Fallback assumption: Function is not linear, i.e., derivatives are non-zero 
+linearity_1(@nospecialize(f)) = get(linearity_map_1, f, false)
+linearity_2(@nospecialize(f)) = get(linearity_map_2, f, (false, false, false))
 
 # TermCombination datastructure
 

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -465,3 +465,21 @@ let
     expr = 3x₁^2 + 4x₁ * x₂ + mymul1plog(q[1], x₂)
     @test Matrix(Symbolics.hessian_sparsity(expr, [x₁, x₂])) == [true true; true true]
 end
+
+# issue #555
+let
+    # first example
+    @variables p[1:1] x[1:1]
+    p = collect(p)
+    x = collect(x)
+    @test collect(Symbolics.sparsehessian(p[1] * x[1], x)) == [0;;] 
+    @test isequal(collect(Symbolics.sparsehessian(p[1] * x[1]^2, x)), [2p[1];;])
+
+    # second example
+    @variables a[1:2]
+    a = collect(a)
+    ex = (a[1]+a[2])^2
+    @test Symbolics.hessian(ex, [a[1]]) == [2;;]
+    @test collect(Symbolics.sparsehessian(ex, [a[1]])) == [2;;]
+    @test collect(Symbolics.sparsehessian(ex, a)) == fill(2, 2, 2)
+end

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -483,3 +483,18 @@ let
     @test collect(Symbolics.sparsehessian(ex, [a[1]])) == [2;;]
     @test collect(Symbolics.sparsehessian(ex, a)) == fill(2, 2, 2)
 end
+
+# issue #847
+let
+    @variables x[1:2] y[1:2]
+    x = Symbolics.scalarize(x)
+    y = Symbolics.scalarize(y)
+
+    z = (x[1] + x[2]) * (y[1] + y[2])
+    @test Symbolics.islinear(z, x)
+    @test Symbolics.isaffine(z, x)
+
+    z = (x[1] + x[2])
+    @test Symbolics.islinear(z, x)
+    @test Symbolics.isaffine(z, x)
+end

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -498,3 +498,15 @@ let
     @test Symbolics.islinear(z, x)
     @test Symbolics.isaffine(z, x)
 end
+
+# issue #790
+let
+    c(x) = [sum(x) - 1]
+    @variables xs[1:2] ys[1:1]
+    w = Symbolics.scalarize(xs)
+    v = Symbolics.scalarize(ys)
+    expr = dot(v, c(w))
+    @test !Symbolics.islinear(expr, w)
+    @test Symbolics.isaffine(expr, w)
+    @test collect(Symbolics.hessian_sparsity(expr, w)) == fill(false, 2, 2)
+end

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -510,3 +510,13 @@ let
     @test Symbolics.isaffine(expr, w)
     @test collect(Symbolics.hessian_sparsity(expr, w)) == fill(false, 2, 2)
 end
+
+# issue #749
+let
+    @variables x y
+    @register_symbolic Base.FastMath.exp_fast(x, y)
+    expr = Base.FastMath.exp_fast(x, y)
+    @test !Symbolics.islinear(expr, [x, y])
+    @test !Symbolics.isaffine(expr, [x, y])
+    @test collect(Symbolics.hessian_sparsity(expr, [x, y])) == fill(true, 2, 2)
+end


### PR DESCRIPTION
I've run into issues similar to https://github.com/JuliaSymbolics/Symbolics.jl/issues/749, https://github.com/JuliaSymbolics/Symbolics.jl/issues/643, https://github.com/JuliaSymbolics/Symbolics.jl/issues/555 etc. with `isaffine`/`islinear`/`hessian_sparsity` repeatedly.

In this PR I propose to assume that functions with unknown linearity are non-linear. This seems to be a safe default that does not report any incorrect structural zeros but would at most error on the other side (missing structural zeros).

Fixes #555.
Fixes #847.
Fixes #790.
Fixes #749.