### PR TITLE
document kwarg fold in substitute

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -64,9 +64,10 @@ include("rewrite-helpers.jl")
 include("complex.jl")
 
 """
-    substitute(expr, s)
+    substitute(expr, s; fold=true)
 
 Performs the substitution on `expr` according to rule(s) `s`.
+If `fold=false`, expressions which can be evaluated won't be evaluated.
 # Examples
 ```jldoctest
 julia> @variables t x y z(t)
@@ -79,6 +80,8 @@ julia> ex = x + y + sin(z)
 (x + y) + sin(z(t))
 julia> substitute(ex, Dict([x => z, sin(z) => z^2]))
 (z(t) + y) + (z(t) ^ 2)
+julia> substitute(sqrt(2x), Dict([x => 1]); fold=false)
+sqrt(2)
 ```
 """
 substitute


### PR DESCRIPTION
coming from another CAS like sympy the behaviour that expressions are evaluated upon substitution is unexpected. Additionally so far one has to dig one layer down into the symbolicutils documentation to see that this can be solved by a simple kwarg to substitute. This PR adds documentation to said kwarg also in Symbolics.jl.