### PR TITLE
Fix ForwardDiff derivative of `NaNMath.pow`

### DIFF
--- a/ext/SymbolicsForwardDiffExt.jl
+++ b/ext/SymbolicsForwardDiffExt.jl
@@ -199,7 +199,7 @@ end
 # exponentiation #
 #----------------#
 
-for f in (:(Base.:^), :(NaNMath.pow))
+for (f, log) in ((:(Base.:^), :(Base.log)), (:(NaNMath.pow), :(NaNMath.log)))
     @eval begin
         @define_binary_dual_op(
             $f,
@@ -212,7 +212,7 @@ for f in (:(Base.:^), :(NaNMath.pow))
                 elseif iszero(vx) && vy > 0
                     logval = zero(vx)
                 else
-                    logval = expv * log(vx)
+                    logval = expv * ($log)(vx)
                 end
                 new_partials = _mul_partials(partials(x), partials(y), powval, logval)
                 return Dual{Txy}(expv, new_partials)
@@ -230,7 +230,7 @@ for f in (:(Base.:^), :(NaNMath.pow))
             begin
                 v = value(y)
                 expv = ($f)(x, v)
-                deriv = (iszero(x) && v > 0) ? zero(expv) : expv*log(x)
+                deriv = (iszero(x) && v > 0) ? zero(expv) : expv*($log)(x)
                 return Dual{Ty}(expv, deriv * partials(y))
             end,
             $AMBIGUOUS_TYPES

--- a/test/forwarddiff_symbolic_dual_ops.jl
+++ b/test/forwarddiff_symbolic_dual_ops.jl
@@ -114,3 +114,9 @@ end
     y(x) = isequal(z, x) ? 0 : x
     @test ForwardDiff.derivative(y, 0) == 1 # expect ∂(x)/∂x
 end
+
+@testset "NaNMath.pow (issue #1399)" begin
+    @variables x
+    @test_throws DomainError substitute(ForwardDiff.derivative(z -> x^z, 0.5), x => -1.0)
+    @test isnan(Symbolics.value(substitute(ForwardDiff.derivative(z -> NaNMath.pow(x, z), 0.5), x => -1.0)))
+end


### PR DESCRIPTION
Fixes #1399.

The PR basically copies https://github.com/JuliaDiff/ForwardDiff.jl/pull/717