### PR TITLE
Fix fixpoint_sub warning

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -530,7 +530,7 @@ function _recursive_unwrap(val)
 end
 
 """
-    fixpoint_sub(expr, dict; operator = Nothing, maxiters = 10000)
+    fixpoint_sub(expr, dict; operator = Nothing, maxiters = 1000)
 
 Given a symbolic expression, equation or inequality `expr` perform the substitutions in
 `dict` recursively until the expression does not change. Substitutions that depend on one

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -546,10 +546,11 @@ See also: [`fast_substitute`](@ref).
 function fixpoint_sub(x, dict; operator = Nothing, maxiters = 1000)
     dict = subrules_to_dict(dict)
     y = fast_substitute(x, dict; operator)
-    while !isequal(x, y) && maxiters > 0
+    iters = maxiters
+    while !isequal(x, y) && iters > 0
         y = x
         x = fast_substitute(y, dict; operator)
-        maxiters -= 1
+        iters -= 1
     end
 
     if !isequal(x, y)


### PR DESCRIPTION
The old implementation incorrectly warns with "Did not converge after maxiters = 0 substitutions ..." because `maxiters` is decremented, losing its original value in the function call.