### PR TITLE
Add numerator, denominator, terms and factors convenience functions

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -95,7 +95,7 @@ export Inequality, ≲, ≳
 include("inequality.jl")
 
 import Bijections, DynamicPolynomials
-export tosymbol
+export tosymbol, terms, factors
 include("utils.jl")
 
 using ConstructionBase

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -478,3 +478,52 @@ function Base.denominator(x::Union{Num, Symbolic})
     end
     return wrap(x)
 end
+
+"""
+    arguments(x, op::Function)
+
+Get the arguments of the symbolic expression `x` with respect to the operation or function `op`.
+"""
+function arguments(x, op::Function)
+    x = unwrap(x)
+    if iscall(x) && operation(x) == op
+        args = [arguments(arg, op) for arg in arguments(x)] # recurse into each argument and obtain its factors
+        args = reduce(vcat, args) # concatenate array of arrays into one array
+    else
+        args = [wrap(x)] # base case
+    end
+    return args
+end
+
+"""
+    terms(x)
+
+Get the terms of the symbolic expression `x`.
+
+Examples
+========
+```julia-repl
+julia> terms(-x + y - z)
+3-element Vector{Num}:
+ -z
+  y
+ -x
+```
+"""
+terms(x) = arguments(x, +)
+
+"""
+    factors(x)
+
+Get the factors of the symbolic expression `x`.
+Examples
+========
+```julia-repl
+julia> factors(2 * x * y)
+3-element Vector{Num}:
+ 2
+ y
+ x
+```
+"""
+factors(x) = arguments(x, *)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -436,3 +436,45 @@ symbolic_to_float(x::Number) = x
 function symbolic_to_float(x::SymbolicUtils.BasicSymbolic)
     substitute(x,Dict())
 end
+
+"""
+    numerator(x)
+
+Return the numerator of the symbolic expression `x`.
+
+Examples
+========
+```julia-repl
+julia> numerator(x/y)
+x
+```
+"""
+function Base.numerator(x::Union{Num, Symbolic})
+    x = unwrap(x)
+    if iscall(x) && operation(x) == /
+        x = arguments(x)[1] # get numerator
+    end
+    return wrap(x)
+end
+
+"""
+    denominator(x)
+
+Return the denominator of the symbolic expression `x`.
+
+Examples
+========
+```julia-repl
+julia> denominator(x/y)
+y
+```
+"""
+function Base.denominator(x::Union{Num, Symbolic})
+    x = unwrap(x)
+    if iscall(x) && operation(x) == /
+        x = arguments(x)[2] # get denominator
+    else
+        x = 1
+    end
+    return wrap(x)
+end

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -297,7 +297,7 @@ SymbolicIndexingInterface.symbolic_type(::Type{<:CallWithMetadata}) = ScalarSymb
 # if the `DestructuredArgs` contains a `CallWithMetadata` the key in the `Dict` will be
 # a `CallWithMetadata` which won't match against the operation of the called symbolic.
 # This is the _only_ hook we have and relies on the `DestructuredArgs` being converted
-# into a list of `Assignment`s before being addded to the `Dict` inside `toexpr(::Let, st)`.
+# into a list of `Assignment`s before being added to the `Dict` inside `toexpr(::Let, st)`.
 # The callable symbolic is unwrapped so it matches the operation of the called version.
 SymbolicUtils.Code.Assignment(f::CallWithMetadata, x) = SymbolicUtils.Code.Assignment(f.f, x)
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -176,3 +176,11 @@ end
     @test isequal(Symbolics.fast_substitute(x[1], Dict(unwrap(x) => collect(unwrap(x)))), x[1])
     @test isequal(Symbolics.fast_substitute(x[1], unwrap(x) => collect(unwrap(x))), x[1])
 end
+
+@testset "numerator and denominator" begin
+    @variables x y
+    num_den(x) = (numerator(x), denominator(x))
+    @test num_den(x) == (x, 1)
+    @test num_den(1/x) == (1, x)
+    @test num_den(x/y) == (x, y)
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -184,3 +184,17 @@ end
     @test num_den(1/x) == (1, x)
     @test num_den(x/y) == (x, y)
 end
+
+@testset "factors and terms" begin
+    @variables x y z
+
+    @test Set(factors(0)) == Set([0])
+    @test Set(factors(1)) == Set([1])
+    @test Set(factors(x)) == Set([x])
+    @test Set(factors(x*y*z)) == Set([x, y, z])
+
+    @test Set(terms(0)) == Set([0])
+    @test Set(terms(x)) == Set([x])
+    @test Set(terms(x + y + z)) == Set([x, y, z])
+    @test Set(terms(-x - y + z)) == Set([-x, -y, z])
+end


### PR DESCRIPTION
I think it is convenient when fiddling around with expressions to easily get numerators/denominators. 

These functions are defined in `Base`, so I think it would be natural to extend them to Symbolics.