### PR TITLE
Add newline in docstring

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -516,6 +516,7 @@ terms(x) = arguments(x, +)
     factors(x)
 
 Get the factors of the symbolic expression `x`.
+
 Examples
 ========
 ```julia-repl


### PR DESCRIPTION
"Examples" not parsed as a header otherwise