### PR TITLE
ci: test DI in downstream CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -11,20 +11,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GROUP: ${{ matrix.package.group }}
-      JULIA_DI_TEST_GROUP: ${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
         julia-version: [1]
         os: [ubuntu-latest]
         package:
-          - {user: SciML, repo: ModelingToolkit.jl, group: All, subdir: .}
-          - {user: SciML, repo: Catalyst.jl, group: All, subdir: .}
-          - {user: SciML, repo: CellMLToolkit.jl, group: All, subdir: .}
-          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE, subdir: .}
-          - {user: SciML, repo: DataDrivenDiffEq.jl, group: Core, subdir: .}
-          - {user: SciML, repo: ModelOrderReduction.jl, group: All, subdir: .}
-          - {user: JuliaDiff, repo: DifferentiationInterface.jl, group: Back/SymbolicBackends, subdir: DifferentiationInterface}
+          - {user: SciML, repo: ModelingToolkit.jl, group: All}
+          - {user: SciML, repo: Catalyst.jl, group: All}
+          - {user: SciML, repo: CellMLToolkit.jl, group: All}
+          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
+          - {user: SciML, repo: DataDrivenDiffEq.jl, group: Core}
+          - {user: SciML, repo: ModelOrderReduction.jl, group: All}
 
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +37,7 @@ jobs:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Load this and run the downstream tests
-        shell: "julia --color=yes --project=\"downstream/${{ matrix.package.subdir }}\" {0}"
+        shell: julia --color=yes --project=downstream {0}
         run: |
           using Pkg
           try

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -18,13 +18,13 @@ jobs:
         julia-version: [1]
         os: [ubuntu-latest]
         package:
-          - {user: SciML, repo: ModelingToolkit.jl, group: All}
-          - {user: SciML, repo: Catalyst.jl, group: All}
-          - {user: SciML, repo: CellMLToolkit.jl, group: All}
-          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
-          - {user: SciML, repo: DataDrivenDiffEq.jl, group: Core}
-          - {user: SciML, repo: ModelOrderReduction.jl, group: All}
-          - {user: JuliaDiff, repo: DifferentiationInterface.jl, group: Back/SymbolicBackends}
+          - {user: SciML, repo: ModelingToolkit.jl, group: All, subdir: .}
+          - {user: SciML, repo: Catalyst.jl, group: All, subdir: .}
+          - {user: SciML, repo: CellMLToolkit.jl, group: All, subdir: .}
+          - {user: SciML, repo: NeuralPDE.jl, group: NNPDE, subdir: .}
+          - {user: SciML, repo: DataDrivenDiffEq.jl, group: Core, subdir: .}
+          - {user: SciML, repo: ModelOrderReduction.jl, group: All, subdir: .}
+          - {user: JuliaDiff, repo: DifferentiationInterface.jl, group: Back/SymbolicBackends, subdir: DifferentiationInterface}
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
           using Pkg
           try
             # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.develop(PackageSpec(path="${{ matrix.package.subdir }}"))  # resolver may fail with main deps
             Pkg.update()
             Pkg.test()  # resolver may fail with test time deps
           catch err

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GROUP: ${{ matrix.package.group }}
+      JULIA_DI_TEST_GROUP: ${{ matrix.package.group }}
     strategy:
       fail-fast: false
       matrix:
@@ -23,6 +24,7 @@ jobs:
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE}
           - {user: SciML, repo: DataDrivenDiffEq.jl, group: Core}
           - {user: SciML, repo: ModelOrderReduction.jl, group: All}
+          - {user: JuliaDiff, repo: DifferentiationInterface.jl, group: Back/SymbolicBackends}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -24,7 +24,7 @@ jobs:
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE, subdir: .}
           - {user: SciML, repo: DataDrivenDiffEq.jl, group: Core, subdir: .}
           - {user: SciML, repo: ModelOrderReduction.jl, group: All, subdir: .}
-          - {user: JuliaDiff, repo: DifferentiationInterface.jl, group: Back/SymbolicBackends, subdir: DifferentiationInterface}
+          - {user: JuliaDiff, repo: DifferentiationInterface.jl, group: Back/SymbolicBackends, subdir: ./DifferentiationInterface}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -24,7 +24,7 @@ jobs:
           - {user: SciML, repo: NeuralPDE.jl, group: NNPDE, subdir: .}
           - {user: SciML, repo: DataDrivenDiffEq.jl, group: Core, subdir: .}
           - {user: SciML, repo: ModelOrderReduction.jl, group: All, subdir: .}
-          - {user: JuliaDiff, repo: DifferentiationInterface.jl, group: Back/SymbolicBackends, subdir: ./DifferentiationInterface}
+          - {user: JuliaDiff, repo: DifferentiationInterface.jl, group: Back/SymbolicBackends, subdir: DifferentiationInterface}
 
     steps:
       - uses: actions/checkout@v4
@@ -39,12 +39,12 @@ jobs:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
+        shell: julia --color=yes --project="downstream/${{ matrix.package.subdir }}" {0}
         run: |
           using Pkg
           try
             # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="${{ matrix.package.subdir }}"))  # resolver may fail with main deps
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
             Pkg.update()
             Pkg.test()  # resolver may fail with test time deps
           catch err

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -39,7 +39,7 @@ jobs:
           repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
           path: downstream
       - name: Load this and run the downstream tests
-        shell: julia --color=yes --project="downstream/${{ matrix.package.subdir }}" {0}
+        shell: "julia --color=yes --project=\"downstream/${{ matrix.package.subdir }}\" {0}"
         run: |
           using Pkg
           try

--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -1,4 +1,7 @@
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+DifferentiationInterfaceTest = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
@@ -7,6 +10,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+DifferentiationInterface = "0.6"
 KernelAbstractions = "0.9"
 ModelingToolkit = "8.33, 9"
 ParameterizedFunctions = "5.15"

--- a/test/downstream/differentiation_interface.jl
+++ b/test/downstream/differentiation_interface.jl
@@ -2,12 +2,6 @@ using DifferentiationInterface, DifferentiationInterfaceTest
 using Symbolics: Symbolics
 using Test
 
-LOGGING = get(ENV, "CI", "false") == "false"
-
-for backend in [AutoSymbolics(), AutoSparse(AutoSymbolics())]
-    @test check_available(backend)
-    @test check_inplace(backend)
-end
 
 test_differentiation(
     AutoSymbolics(), default_scenarios(; include_constantified=true); logging=LOGGING

--- a/test/downstream/differentiation_interface.jl
+++ b/test/downstream/differentiation_interface.jl
@@ -3,20 +3,4 @@ using Symbolics: Symbolics
 using Test
 
 
-test_differentiation(
-    AutoSymbolics(), default_scenarios(; include_constantified=true); logging=LOGGING
-);
-
-test_differentiation(
-    AutoSymbolics(),
-    default_scenarios(; include_normal=false, include_cachified=true);
-    excluded=[:jacobian],  # TODO: figure out why this fails
-    logging=LOGGING,
-);
-
-test_differentiation(
-    AutoSparse(AutoSymbolics()),
-    sparse_scenarios(; band_sizes=0:-1);
-    sparsity=true,
-    logging=LOGGING,
-);
+test_differentiation(AutoSymbolics())

--- a/test/downstream/differentiation_interface.jl
+++ b/test/downstream/differentiation_interface.jl
@@ -1,0 +1,28 @@
+using DifferentiationInterface, DifferentiationInterfaceTest
+using Symbolics: Symbolics
+using Test
+
+LOGGING = get(ENV, "CI", "false") == "false"
+
+for backend in [AutoSymbolics(), AutoSparse(AutoSymbolics())]
+    @test check_available(backend)
+    @test check_inplace(backend)
+end
+
+test_differentiation(
+    AutoSymbolics(), default_scenarios(; include_constantified=true); logging=LOGGING
+);
+
+test_differentiation(
+    AutoSymbolics(),
+    default_scenarios(; include_normal=false, include_cachified=true);
+    excluded=[:jacobian],  # TODO: figure out why this fails
+    logging=LOGGING,
+);
+
+test_differentiation(
+    AutoSparse(AutoSymbolics()),
+    sparse_scenarios(; band_sizes=0:-1);
+    sparsity=true,
+    logging=LOGGING,
+);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,7 +90,7 @@ if GROUP == "All" || GROUP == "Downstream"
     activate_downstream_env()
     #@time @safetestset "ParameterizedFunctions MATLABDiffEq Regression Test" begin include("downstream/ParameterizedFunctions_MATLAB.jl") end
     @safetestset "ModelingToolkit Variable Utils Test" begin include("downstream/modeling_toolkit_utils.jl") end
-    @safetestset "DI Test" begin include("downstream/differentiation_interface.jl")
+    @safetestset "DI Test" begin include("downstream/differentiation_interface.jl") end
 end
 
 if GROUP == "All" || GROUP == "SymPy"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,7 @@ if GROUP == "All" || GROUP == "Downstream"
     activate_downstream_env()
     #@time @safetestset "ParameterizedFunctions MATLABDiffEq Regression Test" begin include("downstream/ParameterizedFunctions_MATLAB.jl") end
     @safetestset "ModelingToolkit Variable Utils Test" begin include("downstream/modeling_toolkit_utils.jl") end
+    @safetestset "DI Test" begin include("downstream/differentiation_interface.jl")
 end
 
 if GROUP == "All" || GROUP == "SymPy"


### PR DESCRIPTION
DI has good tests for symbolic differentiation, so this adds it to our downstream. It also ends up testing FastDifferentiation, but since the entire testset takes ~15 minutes it's not a big deal.