### PR TITLE
fix: allow Arr in hasnode

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -1140,6 +1140,8 @@ function inplace_expr(x::ArrayOp, outsym = :_out, intermediates = nothing)
     return loops
 end
 
+hasnode(r::Function, y::Arr) = _hasnode(r, y)
+hasnode(r::Union{Num, Symbolic, Arr}, y::Arr) = occursin(unwrap(r), unwrap(y))
 
 #=
 """

--- a/src/rewrite-helpers.jl
+++ b/src/rewrite-helpers.jl
@@ -52,11 +52,11 @@ D = Differential(t)
 hasnode(Symbolics.is_derivative, X + D(X) + D(X^2)) # returns `true`.
 ```
 """
-function hasnode(r::Function, y::Union{Num, Symbolic})
+function hasnode(r::Function, y::Union{Arr, Num, Symbolic})
     _hasnode(r, y)
 end
-hasnode(r::Num, y::Union{Num, Symbolic}) = occursin(unwrap(r), unwrap(y))
-hasnode(r::Symbolic, y::Union{Num, Symbolic}) = occursin(unwrap(r), unwrap(y))
+hasnode(r::Num, y::Union{Arr, Num, Symbolic}) = occursin(unwrap(r), unwrap(y))
+hasnode(r::Symbolic, y::Union{Arr, Num, Symbolic}) = occursin(unwrap(r), unwrap(y))
 hasnode(r::Union{Num, Symbolic, Function}, y::Number) = false
 
 function _hasnode(r, y)

--- a/src/rewrite-helpers.jl
+++ b/src/rewrite-helpers.jl
@@ -52,11 +52,11 @@ D = Differential(t)
 hasnode(Symbolics.is_derivative, X + D(X) + D(X^2)) # returns `true`.
 ```
 """
-function hasnode(r::Function, y::Union{Arr, Num, Symbolic})
+function hasnode(r::Function, y::Union{Num, Symbolic})
     _hasnode(r, y)
 end
-hasnode(r::Num, y::Union{Arr, Num, Symbolic}) = occursin(unwrap(r), unwrap(y))
-hasnode(r::Symbolic, y::Union{Arr, Num, Symbolic}) = occursin(unwrap(r), unwrap(y))
+hasnode(r::Num, y::Union{Num, Symbolic}) = occursin(unwrap(r), unwrap(y))
+hasnode(r::Symbolic, y::Union{Num, Symbolic}) = occursin(unwrap(r), unwrap(y))
 hasnode(r::Union{Num, Symbolic, Function}, y::Number) = false
 
 function _hasnode(r, y)

--- a/test/downstream/modeling_toolkit_utils.jl
+++ b/test/downstream/modeling_toolkit_utils.jl
@@ -56,3 +56,6 @@ D = Differential(t)
 Symbolics.diff2term(D(x))
 Symbolics.diff2term(D(sqrt(sqrt(sqrt(+(x, y))))))
 Symbolics.diff2term(D(x + y))
+
+@variables x(t)[1:2] p[1:2, 1:2]
+@test ModelingToolkit.is_diff_equation(D(x) ~ p*x)

--- a/test/rewrite_helpers.jl
+++ b/test/rewrite_helpers.jl
@@ -74,6 +74,19 @@ let
     @test !hasnode(X, 1)
     @test !hasnode(a, 1)
     @test !hasnode(is_derivative, 1)
+
+    # Array variables.
+    @variables x(t)[1:2] y(t)[1:2, 1:2]
+    @test hasnode(t, x)
+    ex6 = D(x)
+    @test hasnode(is_derivative, ex6)
+    @test hasnode(x, ex6)
+    ex7 = D(x) + log.(y*x)
+    @test hasnode(is_derivative, ex7)
+    @test hasnode(y, ex7)
+    ex8 = log(a^b) + x[1]
+    @test hasnode(a, ex8)
+    @test hasnode(b, ex8)
 end
 
 # Check `filterchildren` function.


### PR DESCRIPTION
The problem this is trying to fix is allowing `is_diff_equation` in MTK work for equations like `D(x) ~ p*x`, where `x` is a vector and `p` is an array, not sure if this is the way about it though. 