### PR TITLE
fix expansion of integral derivatives

### DIFF
--- a/src/diff.jl
+++ b/src/diff.jl
@@ -134,7 +134,19 @@ function _occursin_info(x, expr, fail = true)
     if isequal(x, expr)
         true
     else
-        cond = operation(expr) !== getindex
+        op = operation(expr)
+
+        if op isa Integral
+            # check if x occurs in limits
+            domain = op.domain
+            lower, upper = value.(DomainSets.endpoints(domain.domain))
+            occursin_info(x, lower) || occursin_info(x, upper) && return true
+
+            # check if x is shadowed by integration variable in integrand
+            isequal(domain.variables, x) && return false
+        end
+        
+        cond = op !== getindex
         any(a -> occursin_info(x, a, cond), arguments(expr))
     end
 end
@@ -284,21 +296,21 @@ function executediff(D, arg, simplify=false; throw_no_derivative=false)
     elseif isa(op, Integral)
         if isa(op.domain.domain, AbstractInterval)
             domain = op.domain.domain
-            a, b = DomainSets.endpoints(domain)
+            a, b = value.(DomainSets.endpoints(domain))
             c = 0
             inner_function = arguments(arg)[1]
-            if iscall(value(a))
-                t1 = SymbolicUtils.substitute(inner_function, Dict(op.domain.variables => value(a)))
-                t2 = D(a)
+            if iscall(a) || isequal(a, D.x)
+                t1 = SymbolicUtils.substitute(inner_function, Dict(op.domain.variables => a))
+                t2 = executediff(D, a, simplify; throw_no_derivative)
                 c -= t1*t2
             end
-            if iscall(value(b))
-                t1 = SymbolicUtils.substitute(inner_function, Dict(op.domain.variables => value(b)))
-                t2 = D(b)
+            if iscall(b) || isequal(b, D.x)
+                t1 = SymbolicUtils.substitute(inner_function, Dict(op.domain.variables => b))
+                t2 = executediff(D, b, simplify; throw_no_derivative)
                 c += t1*t2
             end
-            inner = executediff(D, arguments(arg)[1]; throw_no_derivative)
-            c += op(inner)
+            inner = executediff(D, inner_function; throw_no_derivative)
+            !isequal(inner, 0) && (c += op(inner))
             return value(c)
         end
     end

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -145,7 +145,7 @@ function _occursin_info(x, expr, fail = true)
             # check if x is shadowed by integration variable in integrand
             isequal(domain.variables, x) && return false
         end
-        
+
         cond = op !== getindex
         any(a -> occursin_info(x, a, cond), arguments(expr))
     end
@@ -310,7 +310,7 @@ function executediff(D, arg, simplify=false; throw_no_derivative=false)
                 c += t1*t2
             end
             inner = executediff(D, inner_function; throw_no_derivative)
-            !isequal(inner, 0) && (c += op(inner))
+            c += op(inner)
             return value(c)
         end
     end

--- a/src/integral.jl
+++ b/src/integral.jl
@@ -4,6 +4,12 @@ struct Integral{T <: Symbolics.VarDomainPairing} <: Function
     Integral(domain) = new{typeof(domain)}(domain)
 end
 
+function (I::Integral)(x::Union{Rational, AbstractIrrational, AbstractFloat, Integer})
+    domain = I.domain.domain
+    a, b = value.(DomainSets.endpoints(domain))
+    wrap((b - a)*x)
+end
+(I::Integral)(x::Complex) = wrap(ComplexTerm{Real}(I(unwrap(real(x))), I(unwrap(imag(x)))))
 (I::Integral)(x) = Term{SymbolicUtils.symtype(x)}(I, [x])
 (I::Integral)(x::Num) = Num(I(Symbolics.value(x)))
 SymbolicUtils.promote_symtype(::Integral, x) = x

--- a/test/integral.jl
+++ b/test/integral.jl
@@ -20,7 +20,7 @@ I = Integral(x in ClosedInterval(a, b))
 @test I(2im) isa Complex{Num}
 @test isequal(I(2im), 2im * (b - a))
 @test isequal(I(1 + 2.1im), (1 + 2.1im)*(b - a))
-@test I(x + imx) isa Complex{Num}
+@test I(x + im*x) isa Complex{Num}
 
 D = Differential(x)
 Dxx = Differential(x)^2

--- a/test/integral.jl
+++ b/test/integral.jl
@@ -6,7 +6,22 @@ I1 = Integral(x in ClosedInterval(1, 5))
 I2 = Integral(x in ClosedInterval(1, 5))
 @test I1 == I2
 
-@variables v(..) u(..) x y
+@variables v(..) u(..) x y a b
+
+# test constant integrand
+I = Integral(x in ClosedInterval(a, b))
+@test isequal(I(0), 0)
+@test isequal(I(2), 2*(b -a))
+@test isequal(I(2.1), 2.1*(b - a))
+@test isequal(I(pi), pi*(b - a))
+@test isequal(I(1//2), 1//2 * (b - a))
+
+# test complex integrand
+@test I(2im) isa Complex{Num}
+@test isequal(I(2im), 2im * (b - a))
+@test isequal(I(1 + 2.1im), (1 + 2.1im)*(b - a))
+@test I(x + imx) isa Complex{Num}
+
 D = Differential(x)
 Dxx = Differential(x)^2
 I = Integral(y in ClosedInterval(1, 5))
@@ -37,11 +52,11 @@ eq_test = I(2D(u(x,y))*u(x,y)) + D(v(x))*u(x, v(x))^2
 # case where limits of integral contain the variable to derive
 # against
 I = Integral(y in ClosedInterval(1, 2x))
-@test isequal(expand_derivatives(D(I(1))), 2 + I(0))
+@test isequal(expand_derivatives(D(I(1))), 2)
 
 # same but case where limit of integral is not a call
 I = Integral(y in ClosedInterval(1, x))
-@test isequal(expand_derivatives(D(I(1))), 1 + I(0))
+@test isequal(expand_derivatives(D(I(1))), 1)
 
 # test shadowing by integration variable 
 # the result of a definite integral over x does not depend on x

--- a/test/integral.jl
+++ b/test/integral.jl
@@ -37,11 +37,11 @@ eq_test = I(2D(u(x,y))*u(x,y)) + D(v(x))*u(x, v(x))^2
 # case where limits of integral contain the variable to derive
 # against
 I = Integral(y in ClosedInterval(1, 2x))
-@test isequal(expand_derivatives(D(I(1))), 2)
+@test isequal(expand_derivatives(D(I(1))), 2 + I(0))
 
 # same but case where limit of integral is not a call
 I = Integral(y in ClosedInterval(1, x))
-@test isequal(expand_derivatives(D(I(1))), 1)
+@test isequal(expand_derivatives(D(I(1))), 1 + I(0))
 
 # test shadowing by integration variable 
 # the result of a definite integral over x does not depend on x

--- a/test/integral.jl
+++ b/test/integral.jl
@@ -33,3 +33,18 @@ eq_test_ = I(D(D(u(x,y)))) + D(D(v(x)))*u(x, v(x)) + 2D(u(x,v(x)))*D(v(x))
 eq = D((I(u(x,y)^2))) ~ 0
 eq_test = I(2D(u(x,y))*u(x,y)) + D(v(x))*u(x, v(x))^2
 @test isequal(expand_derivatives(eq.lhs), Symbolics.value(eq_test))
+
+# case where limits of integral contain the variable to derive
+# against
+I = Integral(y in ClosedInterval(1, 2x))
+@test isequal(expand_derivatives(D(I(1))), 2)
+
+# same but case where limit of integral is not a call
+I = Integral(y in ClosedInterval(1, x))
+@test isequal(expand_derivatives(D(I(1))), 1)
+
+# test shadowing by integration variable 
+# the result of a definite integral over x does not depend on x
+# anymore unless it appears again in the limits
+I = Integral(x in ClosedInterval(1, 2))
+@test isequal(expand_derivatives(D(I(u(x)))), 0)

--- a/test/taylor.jl
+++ b/test/taylor.jl
@@ -1,4 +1,4 @@
-using Symbolics
+using Symbolics, Test
 
 # test all variations of series() input
 ns = 0:3
@@ -68,3 +68,9 @@ eqs = substitute(eqs, Dict(sol))
 eq = y ~ 2*Num(π)*x
 eq = taylor(eq, x, 0, 1; rationalize=false, fold=false)
 @test contains(string(eq), "π") # should not turn 2*π into 6.28...
+
+# integral with symbolic limits
+@variables a
+I = Integral(x in (0, 2a))
+@test isequal(taylor_coeff(I(ϵ^2*x+1), ϵ, 1), I(0))
+


### PR DESCRIPTION
This PR fixes the following issues when expanding integral differentials:
- derivatives of integral limits are not expanded 
  ```julia repl
  julia> expand_derivatives(Differential(x)(Integral(y in (0, 2a))(u(x,y))))
  Integral(y, 0 .. 2a)(Differential(x)(u(x, y))) + u(x, 2a)*Differential(x)(2a)
  ```
- integral limits are not considered in `occurs_info`
  ```julia repl
  julia> expand_derivatives(Differential(x)(Integral(y in (0, x))(u(y))))
  0
  ```
- shadowing by integration variable of variable against which is derived is not handled. For example $\partial_x \int_0^1 dx u(x) = 0$
  ```julia repl
  expand_derivatives(Differential(x)(Integral(x in (0, 1))(u(x))))
  Integral(x, 0 .. 1)(Differential(x)(u(x)))
  ```

Motivation for this fix is `taylor_coeff` failing for the MWE below. (Well, it doesn't fail directly, but it creates a differential with respect to zero).

```julai repl
julia> using Symbolics

julia> @variables a x ϵ
3-element Vector{Num}:
 a
 x
 ϵ

julia> ex = taylor_coeff(Integral(x in (0, 2a))(ϵ^2*x+1), ϵ, 1)
Integral(x, 0 .. 2a)(0) + Differential(0)(2a)

julia> expand_derivatives(ex)
ERROR: MethodError: no method matching occursin_info(::Int64, ::SymbolicUtils.BasicSymbolic{Real})
The function `occursin_info` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  occursin_info(::SymbolicUtils.BasicSymbolic, ::Any, ::Bool)
   @ Symbolics /users/kwessel/.julia/packages/SymbolicUtils/KHJCP/src/cache.jl:354
  occursin_info(::SymbolicUtils.BasicSymbolic, ::Any)
   @ Symbolics /users/kwessel/.julia/packages/SymbolicUtils/KHJCP/src/cache.jl:354

Stacktrace:
  [1] executediff(D::Differential, arg::SymbolicUtils.BasicSymbolic{Real}, simplify::Bool; throw_no_derivative::Bool)
    @ Symbolics /users/kwessel/.julia/packages/Symbolics/M5oEc/src/diff.jl:236
  [2] expand_derivatives(O::SymbolicUtils.BasicSymbolic{Real}, simplify::Bool; throw_no_derivative::Bool)
    @ Symbolics /users/kwessel/.julia/packages/Symbolics/M5oEc/src/diff.jl:390
  [3] expand_derivatives
    @ /users/kwessel/.julia/packages/Symbolics/M5oEc/src/diff.jl:386 [inlined]
  [4] (::Symbolics.var"#281#282"{Bool})(a::SymbolicUtils.BasicSymbolic{Real})
    @ Symbolics /users/kwessel/.julia/packages/Symbolics/M5oEc/src/diff.jl:396
  [5] iterate
    @ ./generator.jl:48 [inlined]
  [6] _collect(c::SymbolicUtils.SmallVec{…}, itr::Base.Generator{…}, ::Base.EltypeUnknown, isz::Base.HasShape{…})
    @ Base ./array.jl:811
  [7] collect_similar(cont::SymbolicUtils.SmallVec{…}, itr::Base.Generator{…})
    @ Base ./array.jl:720
  [8] map(f::Function, A::SymbolicUtils.SmallVec{Any, Vector{Any}})
    @ Base ./abstractarray.jl:3371
  [9] expand_derivatives(O::SymbolicUtils.BasicSymbolic{Real}, simplify::Bool; throw_no_derivative::Bool)
    @ Symbolics /users/kwessel/.julia/packages/Symbolics/M5oEc/src/diff.jl:396
 [10] expand_derivatives(O::SymbolicUtils.BasicSymbolic{Real}, simplify::Bool)
    @ Symbolics /users/kwessel/.julia/packages/Symbolics/M5oEc/src/diff.jl:386
 [11] expand_derivatives(n::Num, simplify::Bool; kwargs::@Kwargs{})
    @ Symbolics /users/kwessel/.julia/packages/Symbolics/M5oEc/src/diff.jl:402
 [12] expand_derivatives
    @ /users/kwessel/.julia/packages/Symbolics/M5oEc/src/diff.jl:401 [inlined]
 [13] expand_derivatives(n::Num)
    @ Symbolics /users/kwessel/.julia/packages/Symbolics/M5oEc/src/diff.jl:401
 [14] top-level scope
    @ REPL[6]:1
Some type information was truncated. Use `show(err)` to see complete types.
```