### PR TITLE
Use of the functions numerator and denominator to improve code readability

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -320,9 +320,9 @@ function _linear_expansion(t, x)
         return (0, b₁^b₂, islinear)
     elseif op === (/)
         # (a₁ x + b₁)/(a₂ x + b₂) is linear => a₂ = 0
-        a₂, b₂, islinear = linear_expansion(args[2], x)
+        a₂, b₂, islinear = linear_expansion(denominator(t), x)
         (islinear && _iszero(a₂)) || return (0, 0, false)
-        a₁, b₁, islinear = linear_expansion(args[1], x)
+        a₁, b₁, islinear = linear_expansion(numerator(t), x)
         # (a₁ x + b₁)/b₂
         return islinear ? (a₁ / b₂, b₁ / b₂, islinear) : (0, 0, false)
     elseif op === getindex

--- a/src/solver/ia_helpers.jl
+++ b/src/solver/ia_helpers.jl
@@ -83,8 +83,8 @@ function n_func_occ(expr, var)
 
                 # n(2 / x) = 1; n(x/x^2) = 2?
             elseif oper_arg === (/)
-                n += n_func_occ(args_arg[1], var)
-                n += n_func_occ(args_arg[2], var)
+                n += n_func_occ(numerator(arg), var)
+                n += n_func_occ(denominator(arg), var)
 
                 # multiplication cases
             elseif oper_arg === (*)

--- a/src/solver/ia_main.jl
+++ b/src/solver/ia_main.jl
@@ -79,15 +79,15 @@ function isolate(lhs, var; warns=true, conditions=[], complex_roots = true, peri
             end
 
         elseif oper === (/)
-            var_innumerator = any(isequal(x, var) for x in get_variables(args[1]))
+            var_innumerator = any(isequal(x, var) for x in get_variables(numerator(lhs)))
             if var_innumerator
                 # x / 2 = y
-                lhs = args[1]
-                rhs = map(sol -> sol * args[2], rhs)
+                rhs = map(sol -> sol * denominator(lhs), rhs)
+                lhs = unwrap(numerator(lhs))
             else
                 # 2 / x = y
-                lhs = args[2]
-                rhs = map(sol -> term(/, args[1], sol), rhs)
+                rhs = map(sol -> term(/, numerator(lhs), sol), rhs)
+                lhs = unwrap(denominator(lhs))
             end
 
         elseif oper === (^)

--- a/src/solver/postprocess.jl
+++ b/src/solver/postprocess.jl
@@ -61,7 +61,7 @@ function _postprocess_root(x::SymbolicUtils.BasicSymbolic)
     end
 
     # y / 0 => Inf
-    if oper === (/) && !isequal(args[1], 0) && isequal(args[2], 0)
+    if oper === (/) && !isequal(numerator(x), 0) && isequal(denominator(x), 0)
         return Inf
     end
 

--- a/src/solver/preprocess.jl
+++ b/src/solver/preprocess.jl
@@ -43,10 +43,9 @@ function clean_f(filtered_expr, var, subs)
     assumptions = []
 
     if oper === (/)
-        args = arguments(unwrapped_f)
-        if !all(isequal(var, x) for x in get_variables(args[2]))
-            filtered_expr = args[1]
-            push!(assumptions, substitute(args[2], subs, fold=false))
+        if !all(isequal(var, x) for x in get_variables(denominator(unwrapped_f)))
+            filtered_expr = numerator(unwrapped_f)
+            push!(assumptions, substitute(denominator(unwrapped_f), subs, fold=false))
         end
     end
     return filtered_expr, assumptions


### PR DESCRIPTION
for issue #1460 .

in #1445 functions to find numerator and denomniator of expressions were added. I used them to improve code readability of
- `solver/preprocess.jl` `clean_f` function (i tested it with `symbolic_solve(log(x+1)/y, x)`)
- `solver/postprocess.jl` `_postprocess_root` function (i tested it with `symbolic_solve(x*y-1,x)`)
- `solver/ia_main.jl` `isolate` function (i tested it with `symbolic_solve(log(x^2+1)/(y+1)~2/y, x)`)