### PR TITLE
Latexify fixes and metadata for syms

### DIFF
--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -272,14 +272,16 @@ function getindex_to_symbol(t)
     args = sorted_arguments(t)
     idxs = args[2:end]
     O = args[1]
+    latexwrapper = hasmetadata(O, SymLatexWrapper) ? getmetadata(O, SymLatexWrapper) : 
+        default_latex_wrapper
 
     # this is to ensure X(t)[1] becomes X_1(t) in Latex
     if iscall(O)
-        oop = operation(O)
+        oop = operation(O)        
         oargs = sorted_arguments(O)
-        return :($(_toexpr(oop))[$(idxs...)]($(_toexpr(oargs)...)))
+        return :($(_toexpr(oop; latexwrapper))[$(idxs...)]($(_toexpr(oargs)...)))
     else
-        return :($(_toexpr(args[1]))[$(idxs...)])
+        return :($(_toexpr(args[1]; latexwrapper))[$(idxs...)])
     end
 end
 

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -5,7 +5,7 @@ using ReferenceTests
 
 using DomainSets: Interval
 
-@variables x y z u(x) dx h[1:10,1:10]
+@variables x y z u(x) dx h[1:10,1:10] hh(x,y)[1:10,1:10] gg(x,y)[1:10,1:10] [latexwrapper = (s -> string(s))]
 Dx = Differential(x)
 Dy = Differential(y)
 
@@ -60,5 +60,10 @@ Dy = Differential(y)
 
 @test_reference "latexify_refs/indices1.txt" latexify(h[10,10])
 @test_reference "latexify_refs/indices2.txt" latexify(h[10,10], index=:bracket)
+
+# test for https://github.com/JuliaSymbolics/Symbolics.jl/issues/1167
+# note these tests need updating if/when https://github.com/korsbo/Latexify.jl/issues/331 is fixed
+@test_reference "latexify_refs/indices3.txt" latexify(hh[10,10])
+@test_reference "latexify_refs/indices4.txt" latexify(gg[10,10])
 
 @test !occursin("identity", latexify(Num(π))) # issue #1254

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -6,7 +6,7 @@ using ReferenceTests
 using DomainSets: Interval
 
 @variables x y z u(x) dx h[1:10,1:10] hh(x,y)[1:10,1:10] gg(x,y)[1:10,1:10] [latexwrapper = (s -> string(s))]
-@variables AA(x) [latexwrapper = (s -> string(s))]
+@variables AA(x) [latexwrapper = (s -> string(s))] X₁(x) [latexwrapper = (s -> string(s))]
 Dx = Differential(x)
 Dy = Differential(y)
 
@@ -41,7 +41,7 @@ Dy = Differential(y)
 
 @test_reference "latexify_refs/equation1.txt" latexify(x ~ y + z)
 @test_reference "latexify_refs/equation2.txt" latexify(x ~ Dx(y + z))
-@test_reference "latexify_refs/equation5.txt" latexify(AA^2 + AA + 1 + x)
+@test_reference "latexify_refs/equation5.txt" latexify(AA^2 + AA + 1 + X₁)
 
 @test_reference "latexify_refs/equation_vec1.txt" latexify([
     x ~   y +  z

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -6,6 +6,7 @@ using ReferenceTests
 using DomainSets: Interval
 
 @variables x y z u(x) dx h[1:10,1:10] hh(x,y)[1:10,1:10] gg(x,y)[1:10,1:10] [latexwrapper = (s -> string(s))]
+@variables AA(x) [latexwrapper = (s -> string(s))]
 Dx = Differential(x)
 Dy = Differential(y)
 
@@ -40,6 +41,7 @@ Dy = Differential(y)
 
 @test_reference "latexify_refs/equation1.txt" latexify(x ~ y + z)
 @test_reference "latexify_refs/equation2.txt" latexify(x ~ Dx(y + z))
+@test_reference "latexify_refs/equation5.txt" latexify(AA^2 + AA + 1 + x)
 
 @test_reference "latexify_refs/equation_vec1.txt" latexify([
     x ~   y +  z

--- a/test/latexify_refs/equation5.txt
+++ b/test/latexify_refs/equation5.txt
@@ -1,0 +1,3 @@
+\begin{equation}
+1 + x + AA\left( x \right) + \left( AA\left( x \right) \right)^{2}
+\end{equation}

--- a/test/latexify_refs/equation5.txt
+++ b/test/latexify_refs/equation5.txt
@@ -1,3 +1,3 @@
 \begin{equation}
-1 + x + AA\left( x \right) + \left( AA\left( x \right) \right)^{2}
+1 + AA\left( x \right) + X_1\left( x \right) + \left( AA\left( x \right) \right)^{2}
 \end{equation}

--- a/test/latexify_refs/indices3.txt
+++ b/test/latexify_refs/indices3.txt
@@ -1,0 +1,3 @@
+\begin{equation}
+\mathtt{hh}\_{10,10}\left( x, y \right)
+\end{equation}

--- a/test/latexify_refs/indices4.txt
+++ b/test/latexify_refs/indices4.txt
@@ -1,0 +1,3 @@
+\begin{equation}
+gg\_{10,10}\left( x, y \right)
+\end{equation}


### PR DESCRIPTION
Closes #1167

Removes the warning about `cdot` (which is deprecated in Latexify), by using `mult_symbol`.

Also adds support for a new symbolic metadata option, `latexwrapper`, which can specify a function that applies a text wrapper to a symbolic's underlying symbol to control latex display. For example, 
```julia
@variables gg [latexwrapper = (s -> string(s))]
```
generates
```math
\begin{equation}
1 + AA\left( x \right) + X_1\left( x \right) + \left( AA\left( x \right) \right)^{2}
\end{equation}
```
dropping the (default) wrapping of `\mathtt{AA}`. If no wrapper is specified a default wrapper is applied that is consistent with the current behavior of wrapping symbols with more than one character in `\mathtt{}`.

Note that there is currently a bug in Latexify where 
```julia
@variables x y hh(x,y)[1:10,1:10]
latexify(hh[10,10])
```
generates
```math
\mathtt{hh}\_{10,10}\left( x, y \right)
```
instead of 
```math
\mathtt{hh}_{10,10}\left( x, y \right)
```
I have reported that bug in https://github.com/korsbo/Latexify.jl/issues/331

(Note that currently the display of such function-array symbolics is bugged anyways, but in a different way per #1167.)