### PR TITLE
Error hint when symbolics are used in boolean required control flow

### DIFF
--- a/src/error_hints.jl
+++ b/src/error_hints.jl
@@ -84,7 +84,7 @@ const SYMBOLIC_BOOLEAN_CONTROL_FLOW = """
 
     In this function, if `x=5` then the expression is ` x*(x-1)*(x-2)*(x-3)*(x-4)`,
     while if `x=3` then ` x*(x-1)*(x-2)`. Thus the symbolic expression is ill-defined,
-    and thus symbolics is not compatible with this function. If you have this case, you
+    and Symbolics is not compatible with this function. If you have this case, you
     may want to register the symbolic function as a primitive, i.e.
 
     ```julia

--- a/src/error_hints.jl
+++ b/src/error_hints.jl
@@ -50,3 +50,56 @@ Base.Experimental.register_error_hint(MethodError) do io, e, args, kwargs
       println(io, FLOAT_NUM_CONVERSION_ERROR)
   end
 end
+
+const SYMBOLIC_BOOLEAN_CONTROL_FLOW = """
+    Symbolic expression found in a control flow expression that requires a boolean. This can occur
+    for example in a function like:
+
+    ```julia
+    f(x) = if x > 1
+        x^2
+    else
+        2x
+    end
+    ```
+
+    Notice that if `x` is symbolic, then `x > 1` is a symbolic expression and `if x > 1`
+    does not know which branch to take without knowing the value of `x`, and thus we
+    cannot know the mathematical expression. Thus instead of using `if/else`, use the
+    function `ifelse(x>1, x^2, 2x)`.
+
+    Sometimes there are functions that are fundamentally incompatible with symbolic tracing.
+    For example:
+
+    ```julia 
+    function factorial(x)
+        out = x
+        while x > 1
+            x -= 1
+            out *= x
+        end
+        out
+    end
+    ```
+
+    In this function, if `x=5` then the expression is ` x*(x-1)*(x-2)*(x-3)*(x-4)`,
+    while if `x=3` then ` x*(x-1)*(x-2)`. Thus the symbolic expression is ill-defined,
+    and thus symbolics is not compatible with this function. If you have this case, you
+    may want to register the symbolic function as a primitive, i.e.
+
+    ```julia
+    @register_symbolic f(x)
+    ```
+
+    then makes `f(x)` work by not expending this function.
+
+    For more information, see https://docs.sciml.ai/Symbolics/stable/manual/faq/ and
+    https://docs.sciml.ai/Symbolics/stable/manual/functions/ .
+"""
+
+Base.Experimental.register_error_hint(TypeError) do io, e
+    if e.expected === Bool && typeof(e.got) <: Union{Symbolics.Arr, Num, Symbolics.BasicSymbolic}
+        println(io, "\n")
+        println(io, SYMBOLIC_BOOLEAN_CONTROL_FLOW)
+    end
+end

--- a/src/error_hints.jl
+++ b/src/error_hints.jl
@@ -91,7 +91,7 @@ const SYMBOLIC_BOOLEAN_CONTROL_FLOW = """
     @register_symbolic f(x)
     ```
 
-    then makes `f(x)` work by not expending this function.
+    then makes `f(x)` work by not expanding this function.
 
     For more information, see https://docs.sciml.ai/Symbolics/stable/manual/faq/ and
     https://docs.sciml.ai/Symbolics/stable/manual/functions/ .


### PR DESCRIPTION
```julia
using Symbolics
@variables x, y
x == y ? 0 : 1
```

I can't get rid of the base Julia error hint, so it's just below it.

```julia
ERROR: TypeError: non-boolean (Num) used in boolean context
A symbolic expression appeared in a Boolean context. This error arises in situations where Julia expects a Bool, like
if boolean_condition             use ifelse(boolean_condition, then branch, else branch)
x && y                           use x & y
boolean_condition ? a : b        use ifelse(boolean_condition, a, b)
but a symbolic expression appeared instead of a Bool. For help regarding control flow with symbolic variables, see https://docs.sciml.ai/ModelingToolkit/dev/basics/FAQ/#How-do-I-handle-if-statements-in-my-symbolic-forms?

    Symbolic expression found in a control flow expression that requires a boolean. This can occur
    for example in a function like:

    ```julia
    f(x) = if x > 1
        x^2
    else
        2x
    end
    ```

    Notice that if `x` is symbolic, then `x > 1` is a symbolic expression and `if x > 1`
    does not know which branch to take without knowing the value of `x`, and thus we
    cannot know the mathematical expression. Thus instead of using `if/else`, use the
    function `ifelse(x>1, x^2, 2x)`.

    Sometimes there are functions that are fundamentally incompatible with symbolic tracing.
    For example:

    ```julia
    function factorial(x)
        out = x
        while x > 1
            x -= 1
            out *= x
        end
        out
    end
    ```

    In this function, if `x=5` then the expression is ` x*(x-1)*(x-2)*(x-3)*(x-4)`,
    while if `x=3` then ` x*(x-1)*(x-2)`. Thus the symbolic expression is ill-defined,
    and thus symbolics is not compatible with this function. If you have this case, you
    may want to register the symbolic function as a primitive, i.e.

    ```julia
    @register_symbolic f(x)
    ```

    then makes `f(x)` work by not expending this function.

    For more information, see https://docs.sciml.ai/Symbolics/stable/manual/faq/ and
    https://docs.sciml.ai/Symbolics/stable/manual/functions/ .

Stacktrace:
 [1] top-level scope
   @ ~/Desktop/test2.jl:60
```
