### PR TITLE
Allow for usage of array variables for parse_expr_to_symbolic

### DIFF
--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -83,6 +83,8 @@ function parse_expr_to_symbolic(ex, mod::Module)
             ys = parse_expr_to_symbolic.(ex.args[2:end],(mod,))
             return Term{Real}(x,[ys...])
         end
+    elseif ex.head == :ref
+        return ex
     end
 end
 


### PR DESCRIPTION
Add a conditional branch in parse_expr_to_symbolic for :rep heads. Address issue #1534 