### PR TITLE
Fixed ODE Solver(Test case: 8)

### DIFF
--- a/test/sympy.jl
+++ b/test/sympy.jl
@@ -65,7 +65,12 @@ result = sympy_simplify(expr)
 @test isequal(Symbolics.simplify(result), 3x^2)
 
 # Test 8: ODE solver
-# D = Differential(x)
-# ode = D(f) - 2*f
-# sol_ode = sympy_ode_solve(ode, f, x)
-# @test isequal(sol_ode, Symbolics.parse("C1*exp(2*x)", Dict("f"=>f, "x"=>x)))
+D = Symbolics.Differential(x)
+@variables C1 
+ode = D(f) - 2*f
+sol_ode = sympy_ode_solve(ode, f, x)
+sol_vars = Symbolics.get_variables(sol_ode)
+const_sym = only(filter(v -> startswith(string(Symbolics.nameof(v)), "C"), sol_vars))
+expected_sol = C1 * exp(2 * x)
+canonical_sol_ode = Symbolics.substitute(sol_ode, Dict(const_sym => C1))
+@test isequal(canonical_sol_ode, expected_sol)


### PR DESCRIPTION
I have fixed the ODE Solver(Test case: 8). This was supposed to be part of #1560 .

The ODE solver test was failing because the code that translates between `Symbolics.jl` and `SymPy.jl` didn't know how to handle derivatives. This caused the math problem to be sent to SymPy in a broken format.

I fixed this by modifying the `symbolics_to_sympy` to correctly convert a Symbolics.jl derivative into a SymPy derivative. I also fixed the code that translates the answer back, making sure it properly handled all the variables involved without mixing up their data types. 

Finally, I updated the test to check the answer in a more reliable way.

Tests are passing locally. It would be great if you could review it, @ChrisRackauckas .