### PR TITLE
Fix method ambiguity for adjoint multiplication with Symbolics.Arr

### DIFF
--- a/src/array-lib.jl
+++ b/src/array-lib.jl
@@ -315,6 +315,7 @@ function _matvec(A, b)
     end
 end
 @wrapped (*)(A::AbstractMatrix, b::AbstractVector) = _matvec(A, b) false
+@wrapped (*)(x::Adjoint{T, <:AbstractVector} where {T}, A::Symbolics.Arr{<:Any, 2}) = _matmul(x, A) false
 
 # specialize `dot` to dispatch on `Symbolic{<:Number}` to eventually work for
 # arrays of (possibly unwrapped) Symbolic types, see issue #831

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -176,6 +176,12 @@ getdef(v) = getmetadata(v, Symbolics.VariableDefaultValue)
     symvec = [sym3(symT), sym4(symT)]
     @test isequal(symvec'weights, weights'symvec)
 
+    # Issue #575: test adjoint multiplication with Symbolics.Arr to resolve method ambiguity
+    @variables d[1:2] E[1:2, 1:2]
+    # This should not throw a method ambiguity error
+    result = d' * E
+    @test isa(result, Symbolics.Arr)
+
     # ModelingToolkit.jl#1736
     #
     @variables t F(t)[1:1]


### PR DESCRIPTION
## Summary

- Fixes method ambiguity error when multiplying `Adjoint{T, <:AbstractVector}` with `Symbolics.Arr{<:Any, 2}` (issue #575)
- Adds minimal, targeted fix with specific method to resolve dispatch ambiguity
- Includes test case to verify fix and prevent regression

## Details

The issue occurred when trying to compute expressions like `d' * E` where `d` is a symbolic vector and `E` is a symbolic matrix. This caused a method ambiguity between:
- `Base.*(x::Adjoint{T, <:AbstractVector} where T, A::AbstractMatrix)` 
- `Symbolics.*(A::AbstractMatrix, B::Symbolics.Arr{<:Any, 2})`

The fix adds a specific method `@wrapped (*)(x::Adjoint{T, <:AbstractVector} where {T}, A::Symbolics.Arr{<:Any, 2}) = _matmul(x, A) false` that takes precedence and resolves the ambiguity.

## Test plan

- [x] Added test case that reproduces the original error scenario
- [x] Verified the fix resolves the method ambiguity
- [x] Confirmed the result has correct type (`Symbolics.Arr`)
- [x] Tested with multiple vector/matrix sizes

Closes #575

🤖 Generated with [Claude Code](https://claude.ai/code)