### PR TITLE
Add comprehensive API reference documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -63,6 +63,7 @@ makedocs(
                 "manual/limits.md",
             ],  
         ],
+        "API Reference" => "manual/api.md",
         "Comparison Against SymPy" => "comparison.md",
     ]
 )

--- a/docs/src/manual/api.md
+++ b/docs/src/manual/api.md
@@ -1,0 +1,118 @@
+# API Reference
+
+This page contains the complete API reference for Symbolics.jl, organized by category. Some functions are documented in their respective manual sections and are linked here for completeness.
+
+## Variable Creation and Manipulation
+
+### Variable Creation
+See [Variable and Equation Types](variables.md) for:
+- `@variables`
+- `Symbolics.variable`
+- `Symbolics.variables`
+
+### Variable Utilities
+See [Expression Manipulation](expression_manipulation.md) for:
+- `Symbolics.get_variables`
+
+Additional utilities:
+```@docs
+Symbolics.get_variables!
+Symbolics.getparent
+```
+
+### Variable Parsing
+```@docs
+Symbolics._parse_vars
+```
+
+### Variable Metadata
+```@docs
+Symbolics.VariableDefaultValue
+Symbolics.VariableSource
+Symbolics.option_to_metadata_type
+```
+
+## Type Wrappers and Utilities
+
+See [Supported types and dispatch in Symbolics](types.md) for:
+- `Symbolics.wrap`
+- `Symbolics.unwrap`
+
+## Array Operations
+
+See [Symbolic Arrays](arrays.md) for:
+- `Symbolics.Arr`
+- `Symbolics.scalarize`
+- `Symbolics.shape`
+
+## Symbolic Differentiation
+
+See [Derivatives and Differentials](derivatives.md) for:
+- `Symbolics.derivative`
+- `Symbolics.gradient`
+- `Symbolics.jacobian`
+- `Symbolics.sparsejacobian`
+- `Symbolics.sparsejacobian_vals`
+- `Symbolics.hessian`
+- `Symbolics.sparsehessian`
+- `Symbolics.sparsehessian_vals`
+
+## Internal Types and Constants
+
+```@docs
+Symbolics.CallWithMetadata
+Symbolics.NAMESPACE_SEPARATOR
+Symbolics.Unknown
+```
+
+## Equations
+
+See [Variable and Equation Types](variables.md) for:
+- `Equation`
+- `Base.:~(::Num, ::Num)`
+
+## Expression Manipulation
+
+See [Expression Manipulation](expression_manipulation.md) for documented functions.
+
+## Function Building
+
+See [Build Function](build_function.md) for:
+- `Symbolics.build_function`
+- `Symbolics._build_function`
+
+## Parsing
+
+See [Parsing](parsing.md) for:
+- `Symbolics.parse_expr_to_symbolic`
+
+## Integration
+
+See [Integration](integration.md) for integration functions.
+
+## Solving
+
+See [Solver](solver.md) for solving functions.
+
+## Limits
+
+See [Limits](limits.md) for limit functions.
+
+## Groebner Basis
+
+See [Groebner Basis](groebner.md) for Groebner basis functions.
+
+## Taylor Series
+
+See [Taylor Series](taylor.md) for Taylor series functions.
+
+## Sparsity Detection
+
+See [Sparsity Detection](sparsity_detection.md) for sparsity detection functions.
+
+## SymbolicUtils Re-exports
+
+See [Variable and Equation Types](variables.md) for:
+- `SymbolicUtils.iscall`
+- `SymbolicUtils.operation`
+- `SymbolicUtils.arguments`

--- a/docs/src/manual/arrays.md
+++ b/docs/src/manual/arrays.md
@@ -208,3 +208,11 @@ In general, any scalar expression which is derived from array expressions can be
 ```julia
 Symbolics.scalarize(sum(A[:,1]) + sum(A[2,:]))
 ```
+
+## Array API Reference
+
+```@docs
+Symbolics.Arr
+Symbolics.scalarize
+Symbolics.shape
+```

--- a/docs/src/manual/types.md
+++ b/docs/src/manual/types.md
@@ -42,3 +42,10 @@ typeof(Z)
 typeof(s)
 ```
 
+## Type Wrapper API
+
+```@docs
+Symbolics.wrap
+Symbolics.unwrap
+```
+


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for all public functions marked in PR #1614, ensuring complete API coverage in the Symbolics.jl documentation.

## Changes
- Added new API reference page (`docs/src/manual/api.md`) organizing all public functions by category
- Added formal documentation blocks for array functions (`Arr`, `scalarize`, `shape`) in `arrays.md`
- Added formal documentation blocks for wrapper functions (`wrap`, `unwrap`) in `types.md`
- Updated `docs/make.jl` to include the new API reference page in the navigation structure

## Details
The API reference page serves as a central index that:
- Links to existing documentation where functions are already documented in other manual pages
- Provides `@docs` blocks for functions that were marked as public but not yet formally documented
- Organizes functions by logical categories (Variables, Types, Arrays, Differentiation, etc.)

This addresses the requirement to ensure all public functions from PR #1614 are properly documented in the API section.

## Functions documented from PR #1614
The following functions were marked as `@public` in PR #1614 and are now documented:
- `Arr` - Array wrapper type
- `CallWithMetadata` - Internal metadata type
- `NAMESPACE_SEPARATOR` - Internal constant
- `Unknown` - Internal type
- `VariableDefaultValue` - Variable metadata type
- `VariableSource` - Variable metadata type
- `_parse_vars` - Variable parsing function
- `derivative`, `gradient`, `jacobian`, `sparsejacobian`, `hessian`, `sparsehessian` - Already documented in derivatives.md
- `get_variables`, `get_variables\!` - Variable utility functions
- `getparent` - Get parent array of indexed variable
- `option_to_metadata_type` - Metadata type registration
- `scalarize` - Array scalarization function
- `shape` - Array shape function
- `unwrap`, `wrap` - Type wrapper utilities
- `variable` - Variable creation function

🤖 Generated with [Claude Code](https://claude.ai/code)