### PR TITLE
Fix missing docstrings for ifelse in control flow section

### DIFF
--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -73,8 +73,9 @@ This will work for any floating-point input, as well as symbolic input.
 
 Control flow can be expressed in Symbolics.jl in the following way:
 
-- `ifelse(cond,x,y)`: this function allows to encode conditionals in
-  the symbolic branches.
+```@docs
+Base.ifelse(::Num, ::Any, ::Any)
+```
 
 ## Inspection Functions
 

--- a/src/num.jl
+++ b/src/num.jl
@@ -31,6 +31,18 @@ Base.typemin(::Type{Num}) = Num(-Inf)
 Base.typemax(::Type{Num}) = Num(Inf)
 Base.float(x::Num) = x
 
+"""
+    ifelse(cond::Num, x, y)
+
+Symbolic conditional expression. Returns `x` if `cond` evaluates to true, and `y` if `cond` 
+evaluates to false. This allows encoding conditional logic in symbolic expressions.
+
+# Examples
+```julia
+@variables a b c
+ifelse(a > b, c, 0)  # Returns c if a > b, otherwise 0
+```
+"""
 Base.ifelse(x::Num, y, z) = Num(ifelse(value(x), value(y), value(z)))
 
 Base.promote_rule(::Type{Bool}, ::Type{<:Num}) = Num


### PR DESCRIPTION
## Summary

Fixes #1620 by adding proper documentation for the `ifelse` function in the Symbolic Control Flow section.

## Changes Made

- Added comprehensive docstring to `Base.ifelse(::Num, ::Any, ::Any)` in `src/num.jl` with usage examples and detailed description
- Updated `docs/src/manual/variables.md` to include `@docs` block for the ifelse function 
- The docstring explains how `ifelse` allows encoding conditional logic in symbolic expressions

## Test Plan

- [x] Verified that the documentation build process can now find the ifelse function docstring 
- [x] Confirmed that the docstring provides clear examples and usage information
- [x] Ensured the documentation follows the existing patterns in the codebase

The `ifelse` function is essential for symbolic control flow operations, and now users will have proper documentation when viewing the control flow section of the manual.

🤖 Generated with [Claude Code](https://claude.ai/code)