### PR TITLE
Fix missing ifelse docstring in symbolic control flow

### DIFF
--- a/docs/src/manual/variables.md
+++ b/docs/src/manual/variables.md
@@ -73,8 +73,9 @@ This will work for any floating-point input, as well as symbolic input.
 
 Control flow can be expressed in Symbolics.jl in the following way:
 
-- `ifelse(cond,x,y)`: this function allows to encode conditionals in
-  the symbolic branches.
+```@docs
+Base.ifelse(::Num, ::Any, ::Any)
+```
 
 ## Inspection Functions
 

--- a/src/num.jl
+++ b/src/num.jl
@@ -31,6 +31,18 @@ Base.typemin(::Type{Num}) = Num(-Inf)
 Base.typemax(::Type{Num}) = Num(Inf)
 Base.float(x::Num) = x
 
+"""
+    ifelse(cond::Num, x, y)
+
+Symbolic conditional expression. Returns `x` if `cond` evaluates to true, and `y` if `cond` 
+evaluates to false. This allows encoding conditional logic in symbolic expressions.
+
+# Examples
+```julia
+@variables a b c
+ifelse(a > b, c, 0)  # Returns c if a > b, otherwise 0
+```
+"""
 Base.ifelse(x::Num, y, z) = Num(ifelse(value(x), value(y), value(z)))
 
 Base.promote_rule(::Type{Bool}, ::Type{<:Num}) = Num

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -342,6 +342,60 @@ for f in [:iscall, :operation, :arguments]
     @eval SymbolicUtils.$f(x::CallWithMetadata) = $f(x.f)
 end
 
+"""
+    iscall(expr)
+
+Check if a symbolic expression `expr` represents a function call. Returns `true` if the 
+expression is a composite expression with an operation and arguments, `false` otherwise.
+
+This function is fundamental for traversing and analyzing symbolic expressions.
+
+# Examples
+```julia
+@variables x y
+expr = sin(x + y)
+iscall(expr)      # true - it's a function call to sin
+iscall(x)         # false - it's just a variable
+```
+"""
+SymbolicUtils.iscall
+
+"""
+    operation(expr)
+
+Extract the operation (function) from a symbolic function call expression.
+Only valid for expressions where `iscall(expr)` returns `true`.
+
+Returns the function/operator that is being applied in the expression.
+
+# Examples
+```julia
+@variables x y
+expr = sin(x + y)
+operation(expr)   # Returns the sin function
+operation(x + y)  # Returns the + operator
+```
+"""
+SymbolicUtils.operation
+
+"""
+    arguments(expr)
+
+Extract the arguments from a symbolic function call expression.
+Only valid for expressions where `iscall(expr)` returns `true`.
+
+Returns a tuple/vector containing the arguments passed to the operation.
+
+# Examples
+```julia
+@variables x y
+expr = sin(x + y)
+arguments(expr)   # Returns (x + y,)
+arguments(x + y)  # Returns (x, y)
+```
+"""
+SymbolicUtils.arguments
+
 SymbolicUtils.Code.toexpr(x::CallWithMetadata, st) = SymbolicUtils.Code.toexpr(x.f, st)
 
 CallWithMetadata(f) = CallWithMetadata(f, nothing)

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -342,60 +342,6 @@ for f in [:iscall, :operation, :arguments]
     @eval SymbolicUtils.$f(x::CallWithMetadata) = $f(x.f)
 end
 
-"""
-    iscall(expr)
-
-Check if a symbolic expression `expr` represents a function call. Returns `true` if the 
-expression is a composite expression with an operation and arguments, `false` otherwise.
-
-This function is fundamental for traversing and analyzing symbolic expressions.
-
-# Examples
-```julia
-@variables x y
-expr = sin(x + y)
-iscall(expr)      # true - it's a function call to sin
-iscall(x)         # false - it's just a variable
-```
-"""
-SymbolicUtils.iscall
-
-"""
-    operation(expr)
-
-Extract the operation (function) from a symbolic function call expression.
-Only valid for expressions where `iscall(expr)` returns `true`.
-
-Returns the function/operator that is being applied in the expression.
-
-# Examples
-```julia
-@variables x y
-expr = sin(x + y)
-operation(expr)   # Returns the sin function
-operation(x + y)  # Returns the + operator
-```
-"""
-SymbolicUtils.operation
-
-"""
-    arguments(expr)
-
-Extract the arguments from a symbolic function call expression.
-Only valid for expressions where `iscall(expr)` returns `true`.
-
-Returns a tuple/vector containing the arguments passed to the operation.
-
-# Examples
-```julia
-@variables x y
-expr = sin(x + y)
-arguments(expr)   # Returns (x + y,)
-arguments(x + y)  # Returns (x, y)
-```
-"""
-SymbolicUtils.arguments
-
 SymbolicUtils.Code.toexpr(x::CallWithMetadata, st) = SymbolicUtils.Code.toexpr(x.f, st)
 
 CallWithMetadata(f) = CallWithMetadata(f, nothing)


### PR DESCRIPTION
## Summary

Fixes the `ifelse` function docstring part of #1620 by adding comprehensive documentation for symbolic control flow.

## Problem

The documentation build was showing warnings for missing docstring:
- `Base.ifelse(::Num, ::Any, ::Any)` - missing documentation for symbolic control flow

This resulted in incomplete documentation in the control flow section that users rely on for understanding conditional symbolic expressions.

## Solution

### 🔧 Control Flow Section (`ifelse` function)
- **File**: `src/num.jl`
- **Added**: Comprehensive docstring for `Base.ifelse(::Num, ::Any, ::Any)`
- **Updated**: `docs/src/manual/variables.md` with proper `@docs` block
- **Description**: Explains how to encode conditional logic in symbolic expressions with clear examples

## Key Features

✅ **Comprehensive Examples**: Docstring includes practical code examples  
✅ **Clear Explanations**: Function's purpose and usage is clearly documented  
✅ **Julia Conventions**: Follows standard Julia documentation format  
✅ **User-Focused**: Written for developers working with symbolic expressions  

## Testing

- [x] ✅ Verified ifelse docstring resolves correctly in documentation system
- [x] ✅ Confirmed examples work as expected  
- [x] ✅ Tested with `@doc` lookup for the function
- [x] ✅ Function returns substantial docstring content (>400 characters)

## Documentation Impact

**Before**: Missing docstring caused warnings and incomplete control flow documentation  
**After**: Users now have complete documentation for symbolic control flow with `ifelse`

## Note on SymbolicUtils Functions

The missing docstrings for `SymbolicUtils.iscall`, `SymbolicUtils.operation`, and `SymbolicUtils.arguments` identified in #1620 will be addressed in a separate PR to the SymbolicUtils.jl repository, as those functions belong there.

## Files Changed

- `src/num.jl` - Added `ifelse` docstring with examples
- `docs/src/manual/variables.md` - Updated control flow section with `@docs` block

🤖 Generated with [Claude Code](https://claude.ai/code)