### PR TITLE
Clean up symbolic ODE solver exports (fixes #1627)

### DIFF
--- a/docs/src/manual/ode.md
+++ b/docs/src/manual/ode.md
@@ -37,7 +37,7 @@ Symbolics.symbolic_solve_ode
 
 ### Continuous Dynamical Systems
 ```@docs
-Symbolics.solve_linear_system
+Symbolics.solve_linear_ode
 ```
 
 ### SymPy 

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -224,7 +224,7 @@ export symbolic_solve
 include("diffeqs/diffeqs.jl")
 include("diffeqs/systems.jl")
 include("diffeqs/diffeq_helpers.jl")
-export LinearODE, IVP, symbolic_solve_ode, solve_linear_system, solve_IVP
+export LinearODE, symbolic_solve_ode, solve_linear_ode, solve_IVP
 
 # Sympy Functions
 

--- a/src/diffeqs/systems.jl
+++ b/src/diffeqs/systems.jl
@@ -6,7 +6,7 @@ Returns evolution matrix e^(tD)
 evo_mat(D::Matrix{<:Number}, t::Num) = diagm(exp.(t .* diag(D)))
 
 """
-    solve_linear_system(A::Matrix{<:Number}, x0::Vector{<:Number}, t::Num)
+    solve_linear_ode(A::Matrix{<:Number}, x0::Vector{<:Number}, t::Num)
 Solve linear continuous dynamical system of differential equations of the form Ax = x' with initial condition x0
 
 # Arguments
@@ -24,18 +24,18 @@ julia> @variables t
 1-element Vector{Num}:
  t
 
-julia> solve_linear_system([1 0; 0 -1], [1, -1], t) # requires Nemo
+julia> solve_linear_ode([1 0; 0 -1], [1, -1], t) # requires Nemo
 2-element Vector{Num}:
    exp(t)
  -exp(-t)
 
-julia> solve_linear_system([-3 4; -2 3], [7, 2], t) # requires Groebner
+julia> solve_linear_ode([-3 4; -2 3], [7, 2], t) # requires Groebner
 2-element Vector{Num}:
  (10//1)*exp(-t) - (3//1)*exp(t)
   (5//1)*exp(-t) - (3//1)*exp(t)
 ```
 """
-function solve_linear_system(A::Matrix{<:Number}, x0::Vector{<:Number}, t::Num)
+function solve_linear_ode(A::Matrix{<:Number}, x0::Vector{<:Number}, t::Num)
     # Check A is square
     if size(A, 1) != size(A, 2)
         throw(ArgumentError("Matrix A must be square."))
@@ -113,3 +113,6 @@ function symbolic_eigen(A::Matrix{<:Number})
 
     return Eigen(values, S)
 end
+
+# Deprecation alias
+@deprecate solve_linear_system(A::Matrix{<:Number}, x0::Vector{<:Number}, t::Num) solve_linear_ode(A, x0, t)

--- a/test/diffeqs.jl
+++ b/test/diffeqs.jl
@@ -1,5 +1,5 @@
 using Symbolics
-using Symbolics: solve_linear_system, LinearODE, has_const_coeffs, to_homogeneous, symbolic_solve_ode, find_particular_solution, IVP, solve_IVP
+using Symbolics: solve_linear_ode, LinearODE, has_const_coeffs, to_homogeneous, symbolic_solve_ode, find_particular_solution, IVP, solve_IVP
 using Groebner, Nemo
 using Test
 
@@ -8,22 +8,22 @@ Dt = Symbolics.Differential(t)
 
 # Systems
 # ideally, `isapprox` would all be `isequal`, but there seem to be some floating point inaccuracies
-@test isapprox(solve_linear_system([1 0; 0 -1], [1, -1], t), [exp(t), -exp(-t)])
-@test isapprox(solve_linear_system([-3 4; -2 3], [7, 2], t), [10exp(-t) - 3exp(t), 5exp(-t) - 3exp(t)])
-@test isapprox(solve_linear_system([4 -3; 8 -6], [7, 2], t), [18 - 11exp(-2t), 24 - 22exp(-2t)])
+@test isapprox(solve_linear_ode([1 0; 0 -1], [1, -1], t), [exp(t), -exp(-t)])
+@test isapprox(solve_linear_ode([-3 4; -2 3], [7, 2], t), [10exp(-t) - 3exp(t), 5exp(-t) - 3exp(t)])
+@test isapprox(solve_linear_ode([4 -3; 8 -6], [7, 2], t), [18 - 11exp(-2t), 24 - 22exp(-2t)])
 
-@test_broken isapprox(solve_linear_system([-1 -2; 2 -1], [1, -1], t), [exp(-t)*(cos(2t) + sin(2t)), exp(-t)*(sin(2t) - cos(2t))]) # can't handle complex eigenvalues (though it should be able to)
+@test_broken isapprox(solve_linear_ode([-1 -2; 2 -1], [1, -1], t), [exp(-t)*(cos(2t) + sin(2t)), exp(-t)*(sin(2t) - cos(2t))]) # can't handle complex eigenvalues (though it should be able to)
 
-@test isapprox(solve_linear_system([1 -1 0; 1 2 1; -2 1 -1], [7, 2, 3], t), (5//3)*exp(-t)*[-1, -2, 7] - 14exp(t)*[-1, 0, 1] + (16//3)*exp(2t)*[-1, 1, 1])
+@test isapprox(solve_linear_ode([1 -1 0; 1 2 1; -2 1 -1], [7, 2, 3], t), (5//3)*exp(-t)*[-1, -2, 7] - 14exp(t)*[-1, 0, 1] + (16//3)*exp(2t)*[-1, 1, 1])
 
-@test isequal(solve_linear_system([1 0; 0 -1], [1, -1], t), [exp(t), -exp(-t)])
-@test isequal(solve_linear_system([-3 4; -2 3], [7, 2], t), [10exp(-t) - 3exp(t), 5exp(-t) - 3exp(t)])
-@test isapprox(solve_linear_system([4 -3; 8 -6], [7, 2], t), [18 - 11exp(-2t), 24 - 22exp(-2t)])
+@test isequal(solve_linear_ode([1 0; 0 -1], [1, -1], t), [exp(t), -exp(-t)])
+@test isequal(solve_linear_ode([-3 4; -2 3], [7, 2], t), [10exp(-t) - 3exp(t), 5exp(-t) - 3exp(t)])
+@test isapprox(solve_linear_ode([4 -3; 8 -6], [7, 2], t), [18 - 11exp(-2t), 24 - 22exp(-2t)])
 
-@test isequal(solve_linear_system([1 -1 0; 1 2 1; -2 1 -1], [7, 2, 3], t), (5//3)*exp(-t)*[-1, -2, 7] - 14exp(t)*[-1, 0, 1] + (16//3)*exp(2t)*[-1, 1, 1])
+@test isequal(solve_linear_ode([1 -1 0; 1 2 1; -2 1 -1], [7, 2, 3], t), (5//3)*exp(-t)*[-1, -2, 7] - 14exp(t)*[-1, 0, 1] + (16//3)*exp(2t)*[-1, 1, 1])
 
-@test_throws ArgumentError solve_linear_system([1 2; 3 4], [1, 2, 3], t) # mismatch between A and x0
-@test_throws ArgumentError solve_linear_system([1 2 3; 4 5 6], [1, 2], t) # A isn't square
+@test_throws ArgumentError solve_linear_ode([1 2; 3 4], [1, 2, 3], t) # mismatch between A and x0
+@test_throws ArgumentError solve_linear_ode([1 2 3; 4 5 6], [1, 2], t) # A isn't square
 @test_throws ArgumentError Symbolics.solve_uncoupled_system([1 2; 3 4], [1, 2], t) # A isn't diagonal
 
 # LinearODEs


### PR DESCRIPTION
## Summary

This PR addresses the cleanup issues from the symbolic ODE solver merge as requested in #1627.

## Changes Made

### 1. Remove IVP from exports to avoid namespace conflicts
- `IVP` was causing conflicts with other packages that define their own `IVP` struct
- Removed from main exports but still available as `Symbolics.IVP` for internal use
- Resolves the namespace conflict issue reported in #1627

### 2. Rename solve_linear_system to solve_linear_ode for clarity
- More descriptive name - the function solves linear ODE systems, not general linear systems
- Added `@deprecate` alias for backwards compatibility
- Updated all documentation and tests to use the new name

### 3. Keep LinearODE naming as-is
- `LinearODE` is already appropriately named within the `Symbolics` namespace
- Used extensively in user-facing documentation and examples
- No conflicts reported, so no change needed

## Testing

- ✅ Verified `solve_linear_ode` works correctly with existing test cases
- ✅ Confirmed `IVP` is no longer exported but available as `Symbolics.IVP`
- ✅ Backwards compatibility maintained through deprecation alias
- ✅ All documentation updated to reflect new function names

## Breaking Changes

- `IVP` is no longer exported (but available as `Symbolics.IVP`)
- `solve_linear_system` is deprecated in favor of `solve_linear_ode` (with deprecation warning)

Fixes #1627

🤖 Generated with [Claude Code](https://claude.ai/code)