### PR TITLE
Ignore typos CI minor version updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch"]
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
## Summary

This PR extends the dependabot configuration to ignore both patch and minor version updates for crate-ci/typos, preventing unnecessary automated PRs for these updates.

## Changes

- Updated `.github/dependabot.yml` to ignore both patch and minor version updates for the `crate-ci/typos` dependency

## Motivation

Follows the pattern established in:
- https://github.com/SciML/ModelingToolkit.jl/pull/2389 (patch)
- https://github.com/SciML/ModelingToolkit.jl/pull/2452 (minor)

This reduces noise from automated dependency updates for the typos action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)