### PR TITLE
Add missing SymPy dependency to symbolic ODS solving docs

### DIFF
--- a/src/diffeqs/diffeqs.jl
+++ b/src/diffeqs/diffeqs.jl
@@ -198,7 +198,7 @@ Symbolically solve an ODE
 # Examples
 
 ```jldoctest
-julia> using Symbolics; import Nemo
+julia> using Symbolics; import Nemo, SymPy
 
 julia> @variables x, t
 2-element Vector{Num}:


### PR DESCRIPTION
Symbolic ODE solving uses `sympy_integrate` internally (at least for some of these examples).