### PR TITLE
fix: fix `getname` on array symbolic functions with interpolated names

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -227,7 +227,7 @@ function construct_dep_array_vars(macroname, lhs, type, call_args, indices, val,
     if val !== nothing
         ex = :($setdefaultval($ex, $val))
     end
-    ex = setprops_expr(ex, prop, macroname, Meta.quot(vname))
+    ex = setprops_expr(ex, prop, macroname, _vname)
     #ex = :($scalarize_getindex($ex))
 
     ex = :($wrap($ex))

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -435,3 +435,10 @@ end
     @test isequal(f, ff)
     @test hash(f) == hash(ff)
 end
+
+# https://github.com/SciML/ModelingToolkitNeuralNets.jl/issues/58
+@testset "`getname` on symbolic functions returning arrays with interpolated names" begin
+    name1 = :f1
+    vs = @variables $name1(..)[1:3]
+    @test getname(vs[1]) == name1
+end


### PR DESCRIPTION
Close https://github.com/SciML/ModelingToolkitNeuralNets.jl/issues/58