### PR TITLE
Fix ComplexTerm symbolic_type to return ScalarSymbolic

### DIFF
--- a/src/complex.jl
+++ b/src/complex.jl
@@ -18,6 +18,9 @@ function wrapper_type(::Type{Complex{T}}) where T
 end
 
 symtype(a::ComplexTerm{T}) where T = Complex{T}
+
+SymbolicUtils.symbolic_type(::ComplexTerm) = SymbolicUtils.ScalarSymbolic()
+
 iscall(a::ComplexTerm) = true
 operation(a::ComplexTerm{T}) where T = Complex{T}
 arguments(a::ComplexTerm) = [a.re, a.im]


### PR DESCRIPTION
ComplexTerm was incorrectly classified as NotSymbolic(), causing code
that checks symbolic_type (like ModelingToolkit's namespace_expr) to
skip processing its .re and .im fields.

This led to namespace bugs where variables inside complex expressions
lost their namespace prefixes during system composition.

Co-authored-by: Claude (Anthropic AI Assistant) <noreply@anthropic.com>