### PR TITLE
fix: use AbstractVector in jacobian type assertions

### DIFF
--- a/src/diff.jl
+++ b/src/diff.jl
@@ -648,17 +648,17 @@ end
 
 function jacobian(ops, vars; simplify=false, kwargs...)
     ops = vec(scalarize(ops))
-    if ops isa Vector{Num}
-        ops = unwrap.(ops)::Vector{SymbolicT}
-    elseif ops isa Vector{SymbolicT}
+    if ops isa AbstractVector{Num}
+        ops = unwrap.(ops)::AbstractVector{SymbolicT}
+    elseif ops isa AbstractVector{SymbolicT}
     else
-        ops = ops::Vector{eltype(ops)}
+        ops = ops::AbstractVector{eltype(ops)}
     end
     # Suboptimal, but prevents wrong results on Arr for now. Arr resulting from a symbolic function will fail on this due to unknown size.
     vars = vec(scalarize(vars))
-    if vars isa Vector{Num}
-        vars = unwrap.(vars)::Vector{SymbolicT}
-    elseif vars isa Vector{SymbolicT}
+    if vars isa AbstractVector{Num}
+        vars = unwrap.(vars)::AbstractVector{SymbolicT}
+    elseif vars isa AbstractVector{SymbolicT}
     else
         error("This should not happen!")
     end

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -2,6 +2,7 @@ using Symbolics
 using SymbolicUtils
 using Test
 using LinearAlgebra, SparseArrays
+using StaticArrays
 using Symbolics: value, unwrap
 
 # Derivatives
@@ -64,6 +65,19 @@ test_equal(jac[2,3], -1x)
 test_equal(jac[3,1], y)
 test_equal(jac[3,2], x)
 test_equal(jac[3,3], -1β)
+
+# issue #1691 - jacobian with SVector input
+@testset "jacobian with SVector" begin
+    @variables a b
+    sv_ops = SVector(a^2 + b, a*b)
+    sv_vars = SVector(a, b)
+    sv_jac = Symbolics.jacobian(sv_ops, sv_vars)
+    @test sv_jac isa Matrix{Num}
+    test_equal(sv_jac[1,1], 2a)
+    test_equal(sv_jac[1,2], 1)
+    test_equal(sv_jac[2,1], b)
+    test_equal(sv_jac[2,2], a)
+end
 
 # issue #545
 z = t + t^2


### PR DESCRIPTION
## Summary

- Fix TypeError when calling `jacobian` with non-`Vector` inputs like `SVector`
- Change `Vector` to `AbstractVector` in type checks and assertions in the `jacobian` function

## Problem

The `jacobian` function at `src/diff.jl:649-656` used `Vector` in type assertions:

```julia
if ops isa Vector{Num}
    ops = unwrap.(ops)::Vector{SymbolicT}
```

However, `vec(scalarize(ops))` can return other `AbstractVector` subtypes (e.g., `SVector`), causing a `TypeError: in typeassert, expected Vector{Num}, got a value of type SVector{2, Num}`.

## Solution

Replace `Vector` with `AbstractVector` in all type checks and assertions within the function to properly support all `AbstractVector` subtypes.

## Test

```julia
using Symbolics
using StaticArrays

@variables x y
ops = SVector(x^2 + y, x*y)
vars = SVector(x, y)

J = Symbolics.jacobian(ops, vars)
# Now works correctly, returning:
# 2×2 Matrix{Num}:
#  2x  1
#   y  x
```

Fixes #1691

🤖 Generated with [Claude Code](https://claude.com/claude-code)