### PR TITLE
Expand error message in diff.jl:jacobian()

### DIFF
--- a/src/diff.jl
+++ b/src/diff.jl
@@ -660,7 +660,7 @@ function jacobian(ops, vars; simplify=false, kwargs...)
         vars = unwrap.(vars)::Vector{SymbolicT}
     elseif vars isa Vector{SymbolicT}
     else
-        error("This should not happen!")
+        error("This should not happen! `vars` must be convertible to Vector{SymbolicT}. \nReceived vars = $vars")
     end
     _res = jacobian(ops, vars; simplify=simplify, scalarize=Val(false), kwargs...)
     res = similar(_res, Num)


### PR DESCRIPTION
I was migrating from Symbolics v6 to v7 when I encountered a frustratingly terse error message from `Symbolics.jacobian(ops, var)`:

 > "This should not happen!"

This is a one-commit pull request that merely expands the error message somewhat.