### PR TITLE
Fix SymPyPythonCall integration test assertion

### DIFF
--- a/test/sympy_pythoncall.jl
+++ b/test/sympy_pythoncall.jl
@@ -18,7 +18,7 @@ sol = sympy_pythoncall_algebraic_solve(eq, x)
 # Test 3: Integration
 expr = x^2
 result = sympy_pythoncall_integrate(expr, x)
-@test Symbolics.simplify(result - x^3/3) == 0
+@test isequal(Symbolics.simplify(result), x^3/3)
 
 # Test 4: Simplification
 expr = x^2 + 2x^2


### PR DESCRIPTION
## Summary
- Fix failing SymPyPythonCall test at `test/sympy_pythoncall.jl:21` by using correct symbolic expression comparison

## Problem
The test was failing with:
```
Error During Test at test/sympy_pythoncall.jl:21
  Expression evaluated to non-Boolean
  Expression: Symbolics.simplify(result - x ^ 3 / 3) == 0
       Value: (-(1//3)*(x^3) + (x^3) / 3) == 0
```

The test used `== 0` to compare symbolic expressions:
```julia
@test Symbolics.simplify(result - x^3/3) == 0
```

This doesn't work because:
1. `sympy_pythoncall_integrate(x^2, x)` returns `(x^3)/3` (division operation)
2. The literal `x^3/3` in Julia becomes `(1//3)*x^3` (rational coefficient multiplier)
3. `simplify` doesn't reduce `(-(1//3)*(x^3) + (x^3)/3)` to 0
4. Comparing symbolic expressions with `== 0` returns the comparison expression itself, not a boolean

## Solution
Changed to use `isequal(Symbolics.simplify(result), x^3/3)` which properly compares symbolic expressions for structural equality. This matches the pattern used in `test/sympy.jl:61` and other tests throughout the codebase.

## Test plan
- [x] Verified test passes locally: `Test Summary: SymPyPythonCall Test | Pass 4 | Total 4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)