### PR TITLE
Register some Array functions

### DIFF
--- a/src/array-lib.jl
+++ b/src/array-lib.jl
@@ -140,3 +140,29 @@ Base.:(/)(x1::Num, x2::Arr{Num, 1}) = Arr{Num, 2}(unwrap(x1) / unwrap(x2))
 
 SymbolicUtils.@map_methods Arr unwrap wrap
 SymbolicUtils.@mapreduce_methods Arr unwrap wrap
+
+#################### REGISTRATION ################
+
+@register_array_symbolic LinearAlgebra.triu(x::AbstractArray) begin
+    size = size(x)
+    eltype = eltype(x)
+end
+
+@register_array_symbolic LinearAlgebra.tril(x::AbstractArray) begin
+    size = size(x)
+    eltype = eltype(x)
+end
+
+@register_array_symbolic LinearAlgebra.normalize(x::AbstractArray) begin
+    size = size(x)
+    eltype = eltype(x)
+end
+
+@register_array_symbolic LinearAlgebra.mul!(x::AbstractArray, y::AbstractArray, z::AbstractArray, α, β) begin
+    size = size(x)
+    eltype = eltype(x)
+end
+@register_array_symbolic Base.copy(x::AbstractArray) begin
+    size = size(x)
+    eltype = eltype(x)
+end


### PR DESCRIPTION
In order to have symbolic manipulation of these functions in generated code, its required to have them registered. This should help with use in generating efficient code involving these methods.