### PR TITLE
Fix complex num power  

### DIFF
--- a/src/num.jl
+++ b/src/num.jl
@@ -194,6 +194,31 @@ function Base.:/(x::Complex{Num}, y::Complex{Num})
     Complex((a*c + b*d)/den, (b*c - a*d)/den)
 end
 Base.:^(z::Complex{Num}, n::Integer) = Base.power_by_squaring(z, n)
+
+"""
+    ^(z::Complex{Num}, p::Real)
+
+Compute complex symbolic power using polar form:
+z^p = |z|^p * exp(i*p*arg(z))
+
+This is necessary because Base's complex power implementation uses
+boolean conditionals that fail with symbolic values.
+"""
+function Base.:^(z::Complex{Num}, p::Real)
+    a, b = reim(z)
+    # r = |z| = sqrt(a² + b²)
+    r = sqrt(a^2 + b^2)
+    # θ = arg(z) = atan(b, a)
+    θ = atan(b, a)
+    # z^p = r^p * (cos(pθ) + i*sin(pθ))
+    r_pow = r^p
+    θ_pow = p * θ
+    return Complex(r_pow * cos(θ_pow), r_pow * sin(θ_pow))
+end
+
+# Also add Rational power for completeness
+Base.:^(z::Complex{Num}, p::Rational) = z^float(p)
+
 Base.:^(::Irrational{:ℯ}, x::Num) = exp(x)
 
 function Base.show(io::IO, z::Complex{<:Num})

--- a/src/num.jl
+++ b/src/num.jl
@@ -216,8 +216,17 @@ function Base.:^(z::Complex{Num}, p::Real)
     return Complex(r_pow * cos(θ_pow), r_pow * sin(θ_pow))
 end
 
-# Also add Rational power for completeness
-Base.:^(z::Complex{Num}, p::Rational) = z^float(p)
+# Resolve ambiguity with Base.^(::Complex{T}, ::Rational) where T<:Real
+# This method is needed because both ^(::Complex{Num}, ::Real) and 
+# Base.^(::Complex{T}, ::Rational) where T<:Real match Complex{Num}^Rational
+function Base.:^(z::Complex{Num}, p::Rational)
+    a, b = reim(z)
+    r = sqrt(a^2 + b^2)
+    θ = atan(b, a)
+    r_pow = r^p
+    θ_pow = p * θ
+    return Complex(r_pow * cos(θ_pow), r_pow * sin(θ_pow))
+end
 
 Base.:^(::Irrational{:ℯ}, x::Num) = exp(x)
 

--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -1,7 +1,7 @@
 # Complex{T}^Num where T is a concrete Real type (not Num)
 # This creates a symbolic power term for cases like (1+2im)^x
 Base.:^(a::Complex{T}, b::Num) where {T<:Union{AbstractFloat,Integer,Rational,AbstractIrrational}} = 
-    Symbolics.wrap(SymbolicUtils.term(^, a, Symbolics.unwrap(b)))
+    Complex{Num}(SymbolicUtils.term(^, a, Symbolics.unwrap(b)))
 """
     symbolic_solve(expr, x; dropmultiplicity=true, warns=true)
 

--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -1,4 +1,7 @@
-Base.:^(a::Complex{<:Real}, b::Num) = Symbolics.Pow(a, b)
+# Complex{T}^Num where T is a concrete Real type (not Num)
+# This creates a symbolic power term for cases like (1+2im)^x
+Base.:^(a::Complex{T}, b::Num) where {T<:Union{AbstractFloat,Integer,Rational,AbstractIrrational}} = 
+    Symbolics.wrap(SymbolicUtils.term(^, a, Symbolics.unwrap(b)))
 """
     symbolic_solve(expr, x; dropmultiplicity=true, warns=true)
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -85,6 +85,7 @@ end
     @variables p
     c = (1.0 + 2.0im)^p
     @test c isa Complex{Num}
+    @test SymbolicUtils.shape(Symbolics.unwrap(c)) == UnitRange{Int}[]
     @test SymbolicUtils.shape(Symbolics.unwrap(real(c))) == UnitRange{Int}[]
     @test SymbolicUtils.shape(Symbolics.unwrap(imag(c))) == UnitRange{Int}[]
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -85,4 +85,6 @@ end
     @variables p
     c = (1.0 + 2.0im)^p
     @test c isa Complex{Num}
+    @test SymbolicUtils.shape(Symbolics.unwrap(real(c))) == UnitRange{Int}[]
+    @test SymbolicUtils.shape(Symbolics.unwrap(imag(c))) == UnitRange{Int}[]
 end


### PR DESCRIPTION
As before in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1740, but with the proposal of @AayushSabharwal.

 `Complex{Num}^Real` operations were failing with `UndefVarError: Pow not defined` because the method in `solver/main.jl` referenced non-existent `Symbolics.Pow`.

## Changes

- Add `^(::Complex{Num}, ::Real)` method using polar form in `src/num.jl`
- Fix `^(::Complex{T}, ::Num)` in `solver/main.jl` to use type-stable `Complex{Num}` constructor
- Add tests for `Complex{Num}` power operations including shape inference
- 
## Why polar form?

The polar form implementation `r^p * (cos(p*θ) + i*sin(p*θ))` avoids boolean conditionals that fail with symbolic values.

## Fixes

Enables Cardano's cubic formula and similar operations requiring complex symbolic intermediate values.