### PR TITLE
Apply compiler passes to OOP exprs as well

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -370,6 +370,7 @@ function _build_function(target::JuliaTarget, rhss::AbstractArray, args...;
 
     if !isnothing(optimize) 
         iip_expr = apply_optimization_rules(iip_expr, states, optimize)
+        oop_expr = apply_optimization_rules(oop_expr, states, optimize)
     end
 
     oop_expr = conv(oop_expr, states)


### PR DESCRIPTION
Required in case we want the OOP expressions to also have compiler passes applied.

This can interact poorly with systems that assume the OOP expressions are in fact out of place, since the passes can and do use caches etc to preallocate and mutate buffers when proven to be safe. cc @AayushSabharwal 