### PR TITLE
fix: remove dead `CallWithParent` reference in `is_singleton`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,7 +26,7 @@ function is_singleton(e)
         op = operation(e)
         op === getindex && return true
         iscall(op) && return is_singleton(op) # recurse to reach getindex for array element variables
-        return issym(op)
+        return issym(op) && !SymbolicUtils.is_function_symbolic(op)
     else
         return issym(e)
     end


### PR DESCRIPTION
`CallWithParent` was removed along with `CallWithMetadata` in 493d76f but this reference was missed, causing an `UndefVarError`.
