### PR TITLE
Fix substitute docstring: default is fold=Val(false), not Val(true)

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -111,10 +111,10 @@ include("rewrite-helpers.jl")
 include("complex.jl")
 
 """
-    substitute(expr, s; fold=Val(true))
+    substitute(expr, s; fold=Val(false))
 
 Performs the substitution on `expr` according to rule(s) `s`.
-If `fold=Val(false)`, expressions which can be evaluated won't be evaluated.
+If `fold=Val(true)`, expressions which can be fully evaluated will be evaluated to a number.
 
 !!! warning "Does not penetrate `Differential`"
     As of Symbolics.jl v7 (SymbolicUtils.jl v4), `substitute` does **not** recurse into
@@ -137,8 +137,10 @@ julia> ex = x + y + sin(z)
 (x + y) + sin(z(t))
 julia> substitute(ex, Dict([x => z, sin(z) => z^2]))
 (z(t) + y) + (z(t) ^ 2)
-julia> substitute(sqrt(2x), Dict([x => 1]); fold=Val(false))
+julia> substitute(sqrt(2x), Dict([x => 1]))
 sqrt(2)
+julia> substitute(sqrt(2x), Dict([x => 1]); fold=Val(true))
+1.4142135623730951
 ```
 """
 substitute


### PR DESCRIPTION
## Summary
- Fixed the `substitute` docstring which incorrectly documented `fold=Val(true)` as the default
- The actual default from SymbolicUtils.jl is `fold=Val(false)` — substitution does NOT fold/evaluate by default
- Updated the description to explain what `fold=Val(true)` does (rather than what `fold=Val(false)` does)
- Updated examples to show both default (unfolded) and folded behavior

Fixes #1809

## Test plan
- [x] Verified the actual SymbolicUtils.jl default: `fold::Val{Fold}=Val{false}()` in `substitute.jl:261`
- [x] Verified doctest outputs match current behavior:
  - `substitute(sqrt(2x), Dict([x => 1]))` → `sqrt(2)` (default, no fold)
  - `substitute(sqrt(2x), Dict([x => 1]); fold=Val(true))` → `1.4142135623730951` (with fold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)