### PR TITLE
Add latexify hooks for metadata and ops

### DIFF
--- a/ext/SymbolicsLatexifyExt.jl
+++ b/ext/SymbolicsLatexifyExt.jl
@@ -70,7 +70,15 @@ function latexify_derivatives(ex)
     end
 end
 
-recipe(n) = latexify_derivatives(cleanup_exprs(_toexpr(n)))
+# `latexify_derivatives` can collapse a top-level node into a bare `String` (e.g.
+# `_textbf(...)` -> "\\textbf{...}", reachable both from the array-symbol branch and from
+# a custom `_toexpr_metadata`/`_toexpr_op` hook). Latexify would try to re-parse such a
+# `String` as an expression and fail, so wrap a top-level string as a `LaTeXString`, which
+# is emitted verbatim. Strings nested inside an `Expr` are left untouched.
+_as_latexstring(x) = x
+_as_latexstring(x::AbstractString) = LaTeXString(x)
+
+recipe(n) = _as_latexstring(latexify_derivatives(cleanup_exprs(_toexpr(n))))
 
 @latexrecipe function f(n::Num)
     env --> :equation
@@ -155,37 +163,25 @@ Base.show(io::IO, ::MIME"text/latex", x::Equation) = print(io, "\$\$ " * latexif
 Base.show(io::IO, ::MIME"text/latex", x::Vector{Equation}) = print(io, "\$\$ " * latexify(x) * " \$\$")
 Base.show(io::IO, ::MIME"text/latex", x::AbstractArray{<:Symbolics.RCNum}) = print(io, "\$\$ " * latexify(x) * " \$\$")
 
-"""
-    _toexpr_metadata(O, ::Type{Ctx}, val; latexwrapper) -> Union{Nothing, Any}
-
-Hook for customizing Latexify output based on metadata. Return `nothing` to fall back
-to the default behavior. Use `_toexpr_plain` to bypass this hook when composing output.
-"""
-_toexpr_metadata(::Any, ::DataType, @nospecialize(val); latexwrapper = default_latex_wrapper) = nothing
-
-function _toexpr_metadata(O; latexwrapper = default_latex_wrapper)
+# Iterate a node's metadata, dispatching to the `Symbolics._toexpr_metadata` hook for
+# each context. The per-context hook (and the `Symbolics._toexpr_op` hook used below) is
+# defined in `Symbolics` so downstream packages can extend it via `import Symbolics`
+# without reaching into this extension with `Base.get_extension`.
+function Symbolics._toexpr_metadata(O; latexwrapper = default_latex_wrapper)
     md = SymbolicUtils.metadata(O)
     md isa AbstractDict || return nothing
     for (ctx, val) in md
-        out = _toexpr_metadata(O, ctx, val; latexwrapper)
+        out = Symbolics._toexpr_metadata(O, ctx, val; latexwrapper)
         out === nothing || return out
     end
     return nothing
 end
 
-"""
-    _toexpr_op(op, args; latexwrapper) -> Union{Nothing, Any}
-
-Hook for customizing Latexify output based on the operation of a call. Return `nothing`
-to fall back to the default behavior.
-"""
-_toexpr_op(@nospecialize(op), args; latexwrapper = default_latex_wrapper) = nothing
-
 # `_toexpr` is only used for latexify
 function _toexpr(O; latexwrapper = default_latex_wrapper)
     O = unwrap(O)
     SymbolicUtils.isconst(O) && return value(O)
-    custom = _toexpr_metadata(O; latexwrapper)
+    custom = Symbolics._toexpr_metadata(O; latexwrapper)
     custom === nothing || return custom
     return _toexpr_plain(O; latexwrapper)
 end
@@ -260,7 +256,7 @@ function _toexpr_plain(O; latexwrapper = default_latex_wrapper)
     latexwrapper = hasmetadata(O, SymLatexWrapper) ? getmetadata(O, SymLatexWrapper) :
         default_latex_wrapper
 
-    custom_op = _toexpr_op(op, args; latexwrapper)
+    custom_op = Symbolics._toexpr_op(op, args; latexwrapper)
     custom_op === nothing || return custom_op
 
     if (op === (*)) && (args[1] === -1)

--- a/ext/SymbolicsLatexifyExt.jl
+++ b/ext/SymbolicsLatexifyExt.jl
@@ -155,10 +155,42 @@ Base.show(io::IO, ::MIME"text/latex", x::Equation) = print(io, "\$\$ " * latexif
 Base.show(io::IO, ::MIME"text/latex", x::Vector{Equation}) = print(io, "\$\$ " * latexify(x) * " \$\$")
 Base.show(io::IO, ::MIME"text/latex", x::AbstractArray{<:Symbolics.RCNum}) = print(io, "\$\$ " * latexify(x) * " \$\$")
 
+"""
+    _toexpr_metadata(O, ::Type{Ctx}, val; latexwrapper) -> Union{Nothing, Any}
+
+Hook for customizing Latexify output based on metadata. Return `nothing` to fall back
+to the default behavior. Use `_toexpr_plain` to bypass this hook when composing output.
+"""
+_toexpr_metadata(::Any, ::DataType, @nospecialize(val); latexwrapper = default_latex_wrapper) = nothing
+
+function _toexpr_metadata(O; latexwrapper = default_latex_wrapper)
+    md = SymbolicUtils.metadata(O)
+    md isa AbstractDict || return nothing
+    for (ctx, val) in md
+        out = _toexpr_metadata(O, ctx, val; latexwrapper)
+        out === nothing || return out
+    end
+    return nothing
+end
+
+"""
+    _toexpr_op(op, args; latexwrapper) -> Union{Nothing, Any}
+
+Hook for customizing Latexify output based on the operation of a call. Return `nothing`
+to fall back to the default behavior.
+"""
+_toexpr_op(@nospecialize(op), args; latexwrapper = default_latex_wrapper) = nothing
+
 # `_toexpr` is only used for latexify
 function _toexpr(O; latexwrapper = default_latex_wrapper)
     O = unwrap(O)
     SymbolicUtils.isconst(O) && return value(O)
+    custom = _toexpr_metadata(O; latexwrapper)
+    custom === nothing || return custom
+    return _toexpr_plain(O; latexwrapper)
+end
+
+function _toexpr_plain(O; latexwrapper = default_latex_wrapper)
     if SymbolicUtils.ismul(O)
         m = O
         numer = Any[]
@@ -227,6 +259,9 @@ function _toexpr(O; latexwrapper = default_latex_wrapper)
     args = sorted_arguments(O)
     latexwrapper = hasmetadata(O, SymLatexWrapper) ? getmetadata(O, SymLatexWrapper) :
         default_latex_wrapper
+
+    custom_op = _toexpr_op(op, args; latexwrapper)
+    custom_op === nothing || return custom_op
 
     if (op === (*)) && (args[1] === -1)
         arg_mul = Expr(:call, :(*), _toexpr(args[2:end])...)

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -216,6 +216,8 @@ include("extra_functions.jl")
 using RecipesBase
 include("plot_recipes.jl")
 
+include("latexify_recipes.jl")
+
 include("semipoly.jl")
 
 
@@ -598,6 +600,7 @@ include("discontinuities.jl")
 @public _parse_vars, derivative, gradient, jacobian, sparsejacobian, hessian, sparsehessian
 @public get_variables, get_variables!, get_differential_vars, option_to_metadata_type, scalarize, shape
 @public unwrap, variable, wrap, linear_expansion, LinearExpander
+@public _toexpr_metadata, _toexpr_op
 
 @setup_workload begin
     fold1 = Val{false}()

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -1,0 +1,25 @@
+"""
+    _toexpr_metadata(O, ::Type{Ctx}, val; latexwrapper) -> Union{Nothing, Any}
+
+Hook for customizing Latexify output based on metadata. Return `nothing` to fall back
+to the default behavior.
+
+Defined in `Symbolics` (not in the Latexify extension) so downstream packages can add
+methods via `import Symbolics` without reaching into the extension with
+`Base.get_extension`. The Latexify extension calls this hook while building LaTeX
+expressions and provides the `_toexpr_plain` and `default_latex_wrapper` helpers for
+composing output inside a method.
+"""
+_toexpr_metadata(::Any, ::DataType, @nospecialize(val); kwargs...) = nothing
+
+"""
+    _toexpr_op(op, args; latexwrapper) -> Union{Nothing, Any}
+
+Hook for customizing Latexify output based on the operation of a call. Return `nothing`
+to fall back to the default behavior.
+
+Defined in `Symbolics` (not in the Latexify extension) so downstream packages can add
+methods via `import Symbolics` without reaching into the extension with
+`Base.get_extension`.
+"""
+_toexpr_op(@nospecialize(op), args; kwargs...) = nothing

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -83,6 +83,23 @@ Dy = Differential(y)
 @variables f(..)
 @test_reference "latexify_refs/call_with_metadata.txt" latexify(f)
 
+struct LatexHookCtx end
+function LatexifyExt._toexpr_metadata(O, ::Type{LatexHookCtx}, val; latexwrapper = LatexifyExt.default_latex_wrapper)
+    inner = LatexifyExt._toexpr_plain(O; latexwrapper)
+    return Expr(:call, :_textbf, inner)
+end
+expr = SU.setmetadata(x + y, LatexHookCtx, true)
+@test occursin("\\textbf", latexify(expr).s)
+
+avgf(x) = x
+function LatexifyExt._toexpr_op(::typeof(avgf), args; latexwrapper = LatexifyExt.default_latex_wrapper)
+    inner = LatexifyExt._toexpr_plain(args[1]; latexwrapper)
+    inner_s = strip(latexify(inner).s, '\$')
+    return LaTeXString("\\langle " * inner_s * " \\rangle")
+end
+avg_expr = SU.term(avgf, x + y)
+@test occursin("\\langle", latexify(avg_expr).s)
+
 @test !occursin("identity", latexify(Num(π))) # issue #1254
 
 # issue #1820: hasmetadata should not be called on Vector arguments in getindex

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -1,6 +1,7 @@
 using Symbolics
 using Test
 using Latexify
+using LaTeXStrings
 using ReferenceTests
 import SymbolicUtils as SU
 using Symbolics: VartypeT
@@ -83,8 +84,11 @@ Dy = Differential(y)
 @variables f(..)
 @test_reference "latexify_refs/call_with_metadata.txt" latexify(f)
 
+# The `_toexpr_metadata`/`_toexpr_op` hooks live in `Symbolics`, so downstream code can
+# extend them via `import Symbolics` without `Base.get_extension`. The Latexify-coupled
+# helpers (`_toexpr_plain`, `default_latex_wrapper`) come from the loaded extension.
 struct LatexHookCtx end
-function LatexifyExt._toexpr_metadata(O, ::Type{LatexHookCtx}, val; latexwrapper = LatexifyExt.default_latex_wrapper)
+function Symbolics._toexpr_metadata(O, ::Type{LatexHookCtx}, val; latexwrapper = LatexifyExt.default_latex_wrapper)
     inner = LatexifyExt._toexpr_plain(O; latexwrapper)
     return Expr(:call, :_textbf, inner)
 end
@@ -92,7 +96,7 @@ expr = SU.setmetadata(x + y, LatexHookCtx, true)
 @test occursin("\\textbf", latexify(expr).s)
 
 avgf(x) = x
-function LatexifyExt._toexpr_op(::typeof(avgf), args; latexwrapper = LatexifyExt.default_latex_wrapper)
+function Symbolics._toexpr_op(::typeof(avgf), args; latexwrapper = LatexifyExt.default_latex_wrapper)
     inner = LatexifyExt._toexpr_plain(args[1]; latexwrapper)
     inner_s = strip(latexify(inner).s, '\$')
     return LaTeXString("\\langle " * inner_s * " \\rangle")


### PR DESCRIPTION
## Summary
Add extension points to the Latexify pipeline so downstream packages can customize LaTeX rendering based on:
1) metadata attached to `BasicSymbolic` nodes, and
2) the operator of a call.

This enables non-pirating, opt-in rendering for DSLs (e.g., angle-bracket averages, sum prefixes) without forking Symbolics' LaTeX code.

## What changed
- Introduce `_toexpr_metadata(O, ::Type{Ctx}, val; latexwrapper)` to allow metadata-driven LaTeX overrides.
- Introduce `_toexpr_op(op, args; latexwrapper)` to allow operator-driven LaTeX overrides.
- Add `_toexpr_plain` so hooks can fall back to the default LaTeX formatting.

## Example usage
```julia
function LatexifyExt._toexpr_op(::typeof(avg), args; latexwrapper=LatexifyExt.default_latex_wrapper)
    inner = LatexifyExt._toexpr_plain(args[1]; latexwrapper)
    inner_s = strip(latexify(inner).s, '$')
    return LaTeXString("\\langle " * inner_s * " \\rangle")
end
```

```julia
function LatexifyExt._toexpr_metadata(O, ::Type{SumIndices}, val; latexwrapper=LatexifyExt.default_latex_wrapper)
    # return a LaTeX AST or LaTeXString that prefixes a sum, e.g. "\\Sigma( ... )"
end
```

## Example output
- `avg(x + y)` renders as `\langle x + y \rangle`
- A sum metadata hook can render as `\Sigma(i=1:N) ...`

## Tests
- Added a test in `test/latexify.jl` showing a custom op hook returning a `LaTeXString`.

## Motivation
Downstream packages currently have no hook to customize LaTeX output for custom operators or metadata-rich nodes (e.g., average brackets, sum prefixes). This PR adds general hooks without changing default behavior.
