### PR TITLE
feat: [AI] add polynomial algebra (factor / sqrfree / discriminant / resultant)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to Symbolics.jl will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [7.20.0] - 2026-04-21
+
+### Added
+
+- `resultant(f, g, var; algorithm = :euclid | :sylvester)` for univariate
+  polynomials with rational or symbolic coefficients. Both algorithms are
+  exposed under a single entry point and produce mathematically equal results
+  on every valid input.
+- `discriminant(f, var)` for univariate polynomials, derived from the
+  classical identity `disc(f) = (-1)^(n(n-1)/2) * Res(f, f') / lc(f)`.
+  Returns `0` when `f` has a repeated root, non-zero otherwise. Conventions:
+  `discriminant(a*x + b, x) == 1` for linear inputs; `discriminant(c, x) == 0`
+  for a non-zero constant.
+- `sqrfree(f, var)` for square-free decomposition of univariate polynomials
+  via Yun's algorithm (characteristic 0). Returns `(unit, factors)` where
+  `factors::Vector{Tuple{Num, Int}}` is a list of `(p_i, e_i)` pairs with
+  pairwise-coprime square-free `p_i`; `unit * prod(p_i^e_i) == f`.
+- `Symbolics.factor(f, var)` for univariate factorisation over ℚ. Pulls
+  content into the unit, applies square-free decomposition, and extracts
+  rational linear factors; degree-≤-3 residuals with no rational root are
+  provably irreducible. Not exported to avoid shadowing `Base.factor` /
+  `Primes.factor`. Higher-degree residuals delegate to `Nemo.factor` via
+  the `SymbolicsNemoExt` extension when `Nemo` is loaded (fully wired:
+  `factor(x^10 - 1, x)` returns the four cyclotomic factors over ℚ with
+  Nemo loaded, and only the partial three-factor split without it).
+  Floating-point coefficients are rejected with a clear error.
+
+### Changed
+
+- `SymbolicsNemoExt.nemo_crude_evaluate`: added explicit dispatches for
+  `Nemo.QQFieldElem` and tightened the `Nemo.FracElem` method so that
+  integer-valued rationals (`n//1`) collapse to plain `Int`/`BigInt`
+  constants in returned expressions. Purely cosmetic — the existing
+  `Symbolics.factor_use_nemo` (used by the solver) still produces
+  mathematically identical output but without the noisy `1//1` literals.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.19.0"
+version = "7.20.0"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -53,6 +53,7 @@ makedocs(
             "Algebra" => [
                 "manual/solver.md",
                 "manual/groebner.md",
+                "manual/polynomial_algebra.md",
                 "manual/constraint_satisfaction.md",
             ],
 

--- a/docs/src/manual/polynomial_algebra.md
+++ b/docs/src/manual/polynomial_algebra.md
@@ -1,0 +1,145 @@
+# Polynomial Algebra
+
+Symbolics.jl provides classical univariate polynomial-algebra primitives for
+polynomials whose coefficients are either rational (`Integer` / `Rational`) or
+symbolic in other variables (treated as transcendentals).
+
+## Resultant
+
+[`Symbolics.resultant`](@ref) computes the resultant of two univariate
+polynomials with respect to a distinguished variable. It vanishes exactly when
+the two polynomials share a common root in the algebraic closure of the
+coefficient field.
+
+Two algorithms are selectable via the `algorithm` keyword:
+
+- `:euclid` (default) — polynomial remainder sequence via Euclidean division.
+- `:sylvester` — determinant of the Sylvester matrix.
+
+Both return mathematically equal results; any disagreement is a defect.
+
+```@example poly
+using Symbolics
+@variables x a b c d
+resultant(x^2 - 1, x - 1, x)           # common root x = 1 → 0
+```
+
+```@example poly
+resultant(x^2 + 1, x - 2, x)           # coprime → 5
+```
+
+```@example poly
+resultant(x^2 + 1, x - 2, x; algorithm = :sylvester)
+```
+
+Symbolic coefficients are supported:
+
+```@example poly
+resultant(a*x + b, c*x + d, x)         # determinant: a*d - b*c
+```
+
+```@docs
+Symbolics.resultant
+```
+
+## Discriminant
+
+[`Symbolics.discriminant`](@ref) computes the discriminant of a univariate
+polynomial. It vanishes exactly when the polynomial has a repeated root in
+the algebraic closure of the coefficient field.
+
+It is derived from the resultant via the classical identity
+
+```math
+\mathrm{disc}(f) = \frac{(-1)^{n(n-1)/2}}{\mathrm{lc}(f)} \,\mathrm{Res}(f, f'),
+```
+
+where `n` is the degree of `f`.
+
+```@example poly
+discriminant(a*x^2 + b*x + c, x)    # b^2 - 4*a*c
+```
+
+```@example poly
+discriminant(x^3 - 3x + 2, x)        # repeated root at x = 1 → 0
+```
+
+```@example poly
+discriminant(x^3 - 6x^2 + 11x - 6, x)  # roots 1, 2, 3 → 4
+```
+
+```@docs
+Symbolics.discriminant
+```
+
+## Square-free decomposition
+
+[`Symbolics.sqrfree`](@ref) decomposes a univariate polynomial into a product
+of pairwise-coprime square-free factors with their multiplicities, via Yun's
+algorithm. Given `f = c * ∏ p_i^{e_i}`, it returns the leading / content
+scalar `c` and the list of pairs `(p_i, e_i)`.
+
+```@example poly
+u, fs = sqrfree((x - 1)^2 * (x - 2)^3, x)
+```
+
+The reconstruction `u · ∏ p_i^{e_i}` equals the input:
+
+```@example poly
+Symbolics.simplify(Symbolics.expand(u * prod(f^e for (f, e) in fs) - (x - 1)^2 * (x - 2)^3))
+```
+
+The leading content is extracted into `u`:
+
+```@example poly
+sqrfree(2x^2 - 2, x)
+```
+
+```@docs
+Symbolics.sqrfree
+```
+
+## Factorisation over ℚ
+
+[`Symbolics.factor`](@ref) produces the full factorisation of a univariate
+polynomial over the rationals. It pulls out the integer content into the
+unit and returns the remaining irreducible-over-ℚ factors with their
+multiplicities.
+
+`Symbolics.factor` is **not** exported, to avoid shadowing `Base.factor` and
+`Primes.factor`; call it as `Symbolics.factor(...)`.
+
+```@example poly
+u, fs = Symbolics.factor(x^4 - 1, x)   # (x - 1)(x + 1)(x^2 + 1)
+```
+
+```@example poly
+u, fs = Symbolics.factor(x^3 - 6x^2 + 11x - 6, x)   # roots 1, 2, 3
+```
+
+The leading content is returned in `u`:
+
+```@example poly
+u, fs = Symbolics.factor(2x^2 - 2, x)   # 2 * (x - 1)(x + 1)
+```
+
+Irreducible polynomials (over ℚ) come back as a single factor of
+multiplicity 1:
+
+```@example poly
+Symbolics.factor(x^2 + 1, x)
+```
+
+### When the pure-Julia core isn't enough
+
+The core pipeline is: pull out content via [`sqrfree`](@ref
+Symbolics.sqrfree), then extract rational roots (yielding linear factors),
+then classify any remaining residual. For a residual of degree at most 3
+with no rational root, irreducibility is provable in pure Julia. For a
+residual of degree 4 or more, the factorisation is best-effort; loading
+`Nemo` delegates such residuals to `Nemo.factor` via the
+`SymbolicsNemoExt` extension.
+
+```@docs
+Symbolics.factor
+```

--- a/ext/SymbolicsNemoExt.jl
+++ b/ext/SymbolicsNemoExt.jl
@@ -29,11 +29,38 @@ function nemo_crude_evaluate(poly::Nemo.MPolyRingElem, varmap)
 end
 
 function nemo_crude_evaluate(poly::Nemo.FracElem, varmap)
-    nemo_crude_evaluate(numerator(poly), varmap) // nemo_crude_evaluate(denominator(poly), varmap)
+    num = nemo_crude_evaluate(numerator(poly), varmap)
+    den = nemo_crude_evaluate(denominator(poly), varmap)
+    # Collapse integer-valued fractions (n//1 → n) so returned expressions
+    # don't carry noisy `1//1` constants — purely a presentation concern;
+    # mathematically identical.
+    if den isa Integer && den == 1
+        return num
+    end
+    num // den
+end
+
+# Nemo's QQFieldElem is the concrete rational type returned as coefficients
+# of polynomials over ℚ. Without this specific method, the FracElem dispatch
+# above would still handle it, but going through `QQFieldElem` directly is
+# cheaper and makes the narrowing explicit.
+function nemo_crude_evaluate(poly::Nemo.QQFieldElem, varmap)
+    n = BigInt(numerator(poly))
+    d = BigInt(denominator(poly))
+    if d == 1
+        return typemin(Int) <= n <= typemax(Int) ? Int(n) : n
+    end
+    return Rational{BigInt}(n, d)
 end
 
 function nemo_crude_evaluate(poly::Nemo.ZZRingElem, varmap)
-    Rational(poly)
+    # Nemo's integer elements were historically wrapped in a Rational; that
+    # leaked into downstream expressions as `n//1` constants which display
+    # awkwardly. Return a plain Int when it fits, BigInt when it doesn't —
+    # both are mathematically identical to the Rational form but render
+    # naturally.
+    n = BigInt(poly)
+    return typemin(Int) <= n <= typemax(Int) ? Int(n) : n
 end
 
 # factor(x^2*y + b*x*y - a*x - a*b)  ->  (x*y - a)*(x + b)
@@ -58,6 +85,43 @@ function Symbolics.factor_use_nemo(poly::Num)
     end
 
     return sym_unit, sym_factors
+end
+
+# Nemo-backed implementation of the Symbolics.factor extension hook. Called by
+# `Symbolics.factor` when the pure-Julia core leaves a residual it cannot
+# prove irreducible (typically degree ≥ 4 with no rational root). Returns a
+# `Vector{Tuple{Num, Int}}` of (factor, multiplicity) pairs whose product
+# equals `residual` — or `nothing` if Nemo fails or the input isn't monic.
+function Symbolics._factor_with_nemo(residual::Num, var)
+    try
+        Symbolics.check_polynomial(residual)
+        mp_polys, poly_to_bs = Symbolics.symbol_to_poly([residual])
+        mp_poly = only(mp_polys)
+        vars = collect(Symbolics.get_variables(residual))
+        isempty(vars) && return nothing
+        bs_to_poly = Bijections.active_inv(poly_to_bs)
+        poly_vars = map(Base.Fix1(getindex, bs_to_poly), vars)
+        _, nemo_vars = Nemo.polynomial_ring(Nemo.QQ, map(string, vars))
+        nemo_poly = mp_poly(poly_vars => nemo_vars)
+        nemo_fac = Nemo.factor(nemo_poly)
+
+        # For a monic residual (what Symbolics.factor feeds us), Nemo's unit
+        # should be the constant polynomial 1. Bail on anything else so the
+        # caller falls back to returning the residual unsplit.
+        nemo_unit = Nemo.unit(nemo_fac)
+        unit_const = Rational(Nemo.coeff(nemo_unit, 1))
+        unit_const == 1 || return nothing
+
+        nemo_to_sym = Dict(nemo_vars .=> vars)
+        result = Tuple{Num, Int}[]
+        for (fac, mult) in nemo_fac.fac
+            p = Symbolics.wrap(nemo_crude_evaluate(fac, nemo_to_sym))
+            push!(result, (p, Int(mult)))
+        end
+        return result
+    catch
+        return nothing
+    end
 end
 
 # Helps with precompilation time

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -200,6 +200,12 @@ export symbolic_linear_solve, solve_for
 include("groebner_basis.jl")
 export groebner_basis, is_groebner_basis
 
+include("polynomial_algebra.jl")
+export resultant, discriminant, sqrfree
+# NOTE: `Symbolics.factor` coexists with `Base.factor` / `Primes.factor`;
+# dispatches on Num/BasicSymbolic. Not exported by name to avoid shadowing
+# users' existing `using Primes` or `using Base` calls at the REPL.
+
 include("taylor.jl")
 export series, taylor, taylor_coeff
 

--- a/src/polynomial_algebra.jl
+++ b/src/polynomial_algebra.jl
@@ -1,0 +1,691 @@
+# Polynomial algebra primitives for Symbolics.jl
+#
+# Exposes `resultant` for univariate polynomials in a Symbolics variable,
+# with rational / symbolic coefficients treated as transcendentals. See
+# `docs/src/manual/polynomial_algebra.md` for user-facing documentation and
+# `specs/001-poly-factor-resultant/` for the design documents.
+
+# ------------------------------------------------------------
+# Foundational helpers
+# ------------------------------------------------------------
+
+# Return the coefficient vector (highest degree first) of `expr` viewed as a
+# univariate polynomial in `var`. Coefficients are `Num`; other free symbols in
+# `expr` are kept as symbolic coefficients.
+#
+# Throws ArgumentError if `expr` is not a polynomial in `var`.
+function _univariate_coeffs(expr, var)
+    e = unwrap(expr)
+    v = unwrap(var)
+    coeffs_dict, residual = polynomial_coeffs(e, [v])
+    if !SymbolicUtils._iszero(residual)
+        throw(ArgumentError("expression is not a polynomial in $(var): residual term $(wrap(residual))"))
+    end
+    deg = 0
+    for mono in keys(coeffs_dict)
+        d = _mono_power(mono, v)
+        deg = max(deg, d)
+    end
+    result = Num[Num(0) for _ in 0:deg]
+    for (mono, coeff) in coeffs_dict
+        d = _mono_power(mono, v)
+        result[deg - d + 1] = Num(_widen_numeric(coeff))
+    end
+    return result
+end
+
+# Promote literal Int / Rational{Int} coefficients to their BigInt counterparts
+# before they enter the resultant PRS. Intermediate powers of numeric leading
+# coefficients grow fast; without this, the Euclidean path overflows on random
+# degree-5 integer polynomials.
+function _widen_numeric(c)
+    if c isa Integer
+        return BigInt(c)
+    elseif c isa Rational
+        return Rational{BigInt}(c)
+    else
+        return c
+    end
+end
+
+function _mono_power(mono, v)
+    m = unwrap(mono)
+    if SymbolicUtils._isone(m)
+        return 0
+    elseif isequal(m, v)
+        return 1
+    elseif iscall(m) && operation(m) === (^)
+        base, expn = arguments(m)
+        if isequal(unwrap(base), v)
+            return Int(unwrap_const(expn))
+        end
+    end
+    throw(ArgumentError("unexpected monomial $(mono) in polynomial coefficient dict"))
+end
+
+function _strip_leading_zeros(coeffs::Vector{Num})
+    result = coeffs
+    while !isempty(result) && SymbolicUtils._iszero(unwrap(simplify(result[1])))
+        result = result[2:end]
+    end
+    return result
+end
+
+# ------------------------------------------------------------
+# Resultant — Sylvester matrix
+# ------------------------------------------------------------
+
+function _resultant_sylvester(fcoeffs::Vector{Num}, gcoeffs::Vector{Num})
+    df = length(fcoeffs) - 1
+    dg = length(gcoeffs) - 1
+    if dg == 0
+        return gcoeffs[1]^df
+    end
+    if df == 0
+        return fcoeffs[1]^dg
+    end
+    n = df + dg
+    M = Num[Num(0) for _ in 1:n, _ in 1:n]
+    for i in 1:dg
+        for j in 1:(df + 1)
+            M[i, i + j - 1] = fcoeffs[j]
+        end
+    end
+    for i in 1:df
+        for j in 1:(dg + 1)
+            M[dg + i, i + j - 1] = gcoeffs[j]
+        end
+    end
+    return det(M)
+end
+
+# ------------------------------------------------------------
+# Resultant — extended Euclidean / polynomial remainder sequence
+# ------------------------------------------------------------
+
+function _resultant_euclid(fcoeffs::Vector{Num}, gcoeffs::Vector{Num})
+    df = length(fcoeffs) - 1
+    dg = length(gcoeffs) - 1
+    if dg == 0
+        return gcoeffs[1]^df
+    end
+    if df == 0
+        return fcoeffs[1]^dg
+    end
+    if df < dg
+        sign = isodd(df * dg) ? -1 : 1
+        return sign * _resultant_euclid(gcoeffs, fcoeffs)
+    end
+    r = _poly_rem(fcoeffs, gcoeffs)
+    r = _strip_leading_zeros(r)
+    if isempty(r)
+        return Num(0)
+    end
+    dr = length(r) - 1
+    lc_g = gcoeffs[1]
+    # Identity: Res(f, g) = lc(g)^(df - dr) * (-1)^(df * dg) * Res(g, r)
+    # Derivation: prod_{g(β)=0} f(β) = prod r(β) (since f ≡ r mod g), then
+    # combine the two "via roots of g" formulas and the Res(r, g)↔Res(g, r)
+    # swap. See specs/001-poly-factor-resultant/research.md §R2.
+    sign = isodd(df * dg) ? -1 : 1
+    return sign * lc_g^(df - dr) * _resultant_euclid(gcoeffs, r)
+end
+
+# True Euclidean polynomial remainder: f = q * g + r with deg(r) < deg(g).
+# Coefficients may be rational functions in the non-distinguished variables;
+# the final resultant identity cancels any spurious denominators.
+function _poly_rem(f::Vector{Num}, g::Vector{Num})
+    r = copy(f)
+    lc_g = g[1]
+    while true
+        r = _strip_leading_zeros(r)
+        length(r) < length(g) && break
+        lc_r = r[1]
+        factor = lc_r / lc_g
+        for j in 1:length(g)
+            r[j] = r[j] - factor * g[j]
+        end
+    end
+    return r
+end
+
+# ------------------------------------------------------------
+# Public API
+# ------------------------------------------------------------
+
+"""
+    resultant(f, g, var; algorithm=:euclid)
+
+Compute the resultant of two univariate polynomials `f` and `g` with respect to
+the variable `var`. Returns a `Num` (reducing to a number when both inputs have
+purely numeric coefficients).
+
+Two algorithms are selectable via the `algorithm` keyword:
+
+  - `:euclid` (default) — polynomial remainder sequence via Euclidean division
+    with symbolic-rational coefficients. Faster on dense inputs.
+  - `:sylvester` — determinant of the Sylvester matrix. Simpler and more
+    auditable; identical mathematical result.
+
+Both algorithms return mathematically equal results on every valid input; any
+observed disagreement is a defect.
+
+The resultant vanishes iff `f` and `g` share a common root in the algebraic
+closure of their coefficient field.
+
+# Examples
+```julia
+julia> using Symbolics
+
+julia> @variables x a b c;
+
+julia> resultant(x^2 - 1, x - 1, x)
+0
+
+julia> resultant(x^2 + 1, x - 2, x)
+5
+
+julia> resultant(a*x^2 + b*x + c, 2a*x + b, x) # equals -a * (b^2 - 4ac)
+```
+"""
+function resultant(f, g, var; algorithm::Symbol = :euclid)
+    fcoeffs = _univariate_coeffs(f, var)
+    gcoeffs = _univariate_coeffs(g, var)
+    fcoeffs = _strip_leading_zeros(fcoeffs)
+    gcoeffs = _strip_leading_zeros(gcoeffs)
+    if isempty(fcoeffs) || isempty(gcoeffs)
+        throw(ArgumentError("resultant: zero polynomial"))
+    end
+    r = if algorithm === :euclid
+        _resultant_euclid(fcoeffs, gcoeffs)
+    elseif algorithm === :sylvester
+        _resultant_sylvester(fcoeffs, gcoeffs)
+    else
+        throw(ArgumentError("resultant: unknown algorithm $(algorithm); expected :euclid or :sylvester"))
+    end
+    return wrap(simplify(expand(r)))
+end
+
+"""
+    discriminant(f, var)
+
+Compute the discriminant of the univariate polynomial `f` with respect to
+`var`. Returns a `Num` (reducing to a number when the coefficients are
+numeric).
+
+The discriminant vanishes iff `f` has a repeated root in the algebraic closure
+of its coefficient field. The value is derived from the classical identity
+
+    disc(f) = (-1)^(n*(n-1)/2) * resultant(f, f') / lc(f)
+
+where `n` is the degree of `f` and `lc(f)` its leading coefficient.
+
+Conventions:
+
+  - `discriminant(a*x + b, x) == 1` (linear case)
+  - `discriminant(c, x) == 0` for a non-zero constant `c`
+
+# Examples
+```julia
+julia> using Symbolics
+
+julia> @variables x a b c;
+
+julia> discriminant(a*x^2 + b*x + c, x)     # b^2 - 4*a*c
+
+julia> discriminant(x^3 - 3x + 2, x)         # double root at x = 1 → 0
+0
+```
+"""
+function discriminant(f, var)
+    fcoeffs = _univariate_coeffs(f, var)
+    fcoeffs = _strip_leading_zeros(fcoeffs)
+    if isempty(fcoeffs)
+        throw(ArgumentError("discriminant: zero polynomial"))
+    end
+    n = length(fcoeffs) - 1
+    if n == 0
+        return Num(0)
+    end
+    if n == 1
+        return Num(1)
+    end
+    lc = fcoeffs[1]
+    fprime = derivative(f, var)
+    sign = iseven(n * (n - 1) ÷ 2) ? 1 : -1
+    r = resultant(f, fprime, var)
+    return wrap(simplify(expand(sign * r / lc)))
+end
+
+# ------------------------------------------------------------
+# Coefficient-vector helpers for sqrfree / factor (Phases 5–6)
+# ------------------------------------------------------------
+
+# Derivative of a polynomial given by its coefficient vector (highest first).
+# Returns an empty vector iff the input was a constant.
+function _poly_derivative(coeffs::Vector{Num})
+    n = length(coeffs) - 1
+    n <= 0 && return Num[]
+    return Num[coeffs[i] * (n - i + 1) for i in 1:n]
+end
+
+# Rebuild a Num polynomial from its coefficient vector (highest first).
+function _coeffs_to_poly(coeffs::Vector{Num}, var)
+    d = length(coeffs) - 1
+    s = Num(0)
+    for (i, c) in enumerate(coeffs)
+        s += c * var^(d - i + 1)
+    end
+    return s
+end
+
+# Coefficient-vector subtraction; the result is right-aligned (constant term
+# aligns at the back) and padded with zeros on the high-degree side if needed.
+function _poly_subtract(a::Vector{Num}, b::Vector{Num})
+    la, lb = length(a), length(b)
+    n = max(la, lb)
+    r = Num[Num(0) for _ in 1:n]
+    for j in 1:la
+        r[n - la + j] += a[j]
+    end
+    for j in 1:lb
+        r[n - lb + j] -= b[j]
+    end
+    return r
+end
+
+# Divide with remainder: a = q * b + r, deg(r) < deg(b). Coefficients are
+# `Num`; the division uses the coefficient field (symbolic rationals).
+function _poly_divrem(a::Vector{Num}, b::Vector{Num})
+    b_clean = _strip_leading_zeros(b)
+    isempty(b_clean) && throw(ArgumentError("polynomial division by zero"))
+    a_clean = _strip_leading_zeros(copy(a))
+    da, db = length(a_clean) - 1, length(b_clean) - 1
+    if da < db
+        return (Num[Num(0)], isempty(a_clean) ? Num[Num(0)] : a_clean)
+    end
+    q = Num[Num(0) for _ in 1:(da - db + 1)]
+    r = copy(a_clean)
+    lc_b = b_clean[1]
+    while true
+        r = _strip_leading_zeros(r)
+        (isempty(r) || (length(r) - 1) < db) && break
+        lc_r = r[1]
+        factor = lc_r / lc_b
+        shift = (length(r) - 1) - db
+        q[length(q) - shift] = factor
+        for j in 1:length(b_clean)
+            r[j] = r[j] - factor * b_clean[j]
+        end
+    end
+    return (q, isempty(r) ? Num[Num(0)] : r)
+end
+
+# Exact division: fails (throws) if the remainder is non-zero.
+function _poly_div_exact(a::Vector{Num}, b::Vector{Num})
+    q, r = _poly_divrem(a, b)
+    r_clean = _strip_leading_zeros(r)
+    if !isempty(r_clean)
+        throw(ArgumentError("polynomial division is not exact; non-zero remainder"))
+    end
+    return q
+end
+
+# Polynomial GCD via Euclidean recursion over the coefficient field. The
+# result is returned in monic normal form (leading coefficient 1) so that
+# downstream operations can safely compare lengths and factor.
+function _poly_gcd(a::Vector{Num}, b::Vector{Num})
+    a_local = _strip_leading_zeros(copy(a))
+    b_local = _strip_leading_zeros(copy(b))
+    while !isempty(b_local)
+        _, r = _poly_divrem(a_local, b_local)
+        r = _strip_leading_zeros(r)
+        a_local = b_local
+        b_local = r
+    end
+    isempty(a_local) && return Num[Num(1)]
+    lc = a_local[1]
+    return Num[ai / lc for ai in a_local]
+end
+
+# ------------------------------------------------------------
+# Square-free decomposition (Yun's algorithm, characteristic 0)
+# ------------------------------------------------------------
+
+"""
+    sqrfree(f, var)
+
+Compute the square-free decomposition of the univariate polynomial `f` with
+respect to `var`. Returns a tuple `(unit, factors)` where `unit::Num` is the
+leading coefficient / content and `factors::Vector{Tuple{Num, Int}}` is a
+list of `(p_i, e_i)` pairs such that
+
+    f == unit * prod(p_i^e_i)
+
+the `p_i` are pairwise coprime, each `p_i` is square-free, and every
+multiplicity `e_i` is ≥ 1.
+
+Uses Yun's algorithm over the rationals. Works for polynomials whose
+coefficients are rational numbers or symbolic expressions in other
+variables (treated as transcendentals).
+
+# Examples
+```julia
+julia> using Symbolics
+
+julia> @variables x;
+
+julia> u, fs = sqrfree((x - 1)^2 * (x - 2)^3, x);
+julia> u
+1
+julia> sort(fs; by = last)
+2-element Vector{Tuple{Num, Int64}}:
+ (x - 1, 2)
+ (x - 2, 3)
+```
+"""
+function sqrfree(f, var)
+    fcoeffs = _univariate_coeffs(f, var)
+    fcoeffs = _strip_leading_zeros(fcoeffs)
+    if isempty(fcoeffs)
+        throw(ArgumentError("sqrfree: zero polynomial"))
+    end
+    n = length(fcoeffs) - 1
+    lc = fcoeffs[1]
+    if n == 0
+        return (wrap(simplify(lc)), Tuple{Num, Int}[])
+    end
+    # Work in the monic normalisation so that all intermediate polynomials
+    # are monic; the leading coefficient is pulled out as the unit.
+    fmonic = Num[c / lc for c in fcoeffs]
+
+    fprime = _poly_derivative(fmonic)
+    c = _poly_gcd(fmonic, fprime)
+    factors = Tuple{Num, Int}[]
+    if length(c) == 1
+        # gcd(f, f') is a non-zero constant → f is already square-free.
+        p = _coeffs_to_poly(fmonic, var)
+        push!(factors, (wrap(simplify(expand(p))), 1))
+        return (wrap(simplify(lc)), factors)
+    end
+
+    w = _poly_div_exact(fmonic, c)
+    y = _poly_div_exact(fprime, c)
+    wp = _poly_derivative(w)
+    z = _poly_subtract(y, wp)
+
+    i = 1
+    safety_guard = n + 5
+    while length(w) > 1 && i <= safety_guard
+        p_i = _poly_gcd(w, z)
+        if length(p_i) > 1
+            p_sym = _coeffs_to_poly(p_i, var)
+            push!(factors, (wrap(simplify(expand(p_sym))), i))
+        end
+        # Early exit: if p_i is trivially 1 AND z is zero, further iterations
+        # will not contribute new factors.
+        if length(p_i) == 1
+            if all(SymbolicUtils._iszero(unwrap(simplify(zi))) for zi in z)
+                break
+            end
+        end
+        w = _poly_div_exact(w, p_i)
+        y = _poly_div_exact(z, p_i)
+        wp = _poly_derivative(w)
+        z = _poly_subtract(y, wp)
+        i += 1
+    end
+
+    return (wrap(simplify(lc)), factors)
+end
+
+# ------------------------------------------------------------
+# Factor over ℚ (Phase 6 — User Story 4)
+# ------------------------------------------------------------
+
+# Attempt to coerce a Num coefficient to a Rational{BigInt}. Returns `nothing`
+# if the coefficient is symbolic or non-rational.
+function _try_as_rational(c)
+    try
+        uc = unwrap(c)
+        if uc isa Integer
+            return Rational{BigInt}(uc)
+        elseif uc isa Rational
+            return Rational{BigInt}(numerator(uc), denominator(uc))
+        elseif uc isa AbstractFloat || uc isa Complex{<:AbstractFloat}
+            return nothing
+        elseif SU.isconst(uc)
+            v = unwrap_const(uc)
+            if v isa Integer
+                return Rational{BigInt}(v)
+            elseif v isa Rational
+                return Rational{BigInt}(numerator(v), denominator(v))
+            end
+        end
+    catch
+        return nothing
+    end
+    return nothing
+end
+
+# Detect the first coefficient that is a floating-point literal (including
+# floats hidden inside a Const). Returns the offending coefficient or nothing.
+function _find_float_coefficient(coeffs::Vector{Num})
+    for c in coeffs
+        uc = unwrap(c)
+        if uc isa AbstractFloat || uc isa Complex{<:AbstractFloat}
+            return c
+        end
+        if SU.isconst(uc)
+            v = unwrap_const(uc)
+            if v isa AbstractFloat || v isa Complex{<:AbstractFloat}
+                return c
+            end
+        end
+    end
+    return nothing
+end
+
+# Try to extract every coefficient as Rational{BigInt}. Returns `nothing` if
+# any coefficient is symbolic; that signals the caller to fall back to
+# (e.g.) marking the factor unverified rather than running a rational-roots
+# sweep that wouldn't make sense.
+function _try_extract_rational_vector(coeffs::Vector{Num})
+    out = Rational{BigInt}[]
+    for c in coeffs
+        r = _try_as_rational(c)
+        r === nothing && return nothing
+        push!(out, r)
+    end
+    return out
+end
+
+# Positive divisors of an integer. Naive O(n); the integers we see here come
+# from rational-root enumeration, which is interactive-grade.
+function _divisors(n::Integer)
+    n = abs(BigInt(n))
+    n == 0 && return BigInt[]
+    ds = BigInt[]
+    d = BigInt(1)
+    while d <= n
+        n % d == 0 && push!(ds, d)
+        d += 1
+    end
+    return ds
+end
+
+# Rational-root theorem: return all rational roots of a polynomial given by
+# its Rational{BigInt} coefficient vector (highest degree first).
+function _rational_roots(rat_coeffs::Vector{Rational{BigInt}})
+    isempty(rat_coeffs) && return Rational{BigInt}[]
+    den_lcm = reduce(lcm, denominator.(rat_coeffs); init = BigInt(1))
+    int_coeffs = BigInt[numerator(c) * (den_lcm ÷ denominator(c)) for c in rat_coeffs]
+    lead = int_coeffs[1]
+    const_term = int_coeffs[end]
+    roots = Rational{BigInt}[]
+    if const_term == 0
+        push!(roots, Rational{BigInt}(0))
+    end
+    if const_term != 0
+        p_divs = _divisors(const_term)
+        q_divs = _divisors(lead)
+        for p in p_divs, q in q_divs
+            for s in (1, -1)
+                r = Rational{BigInt}(s * p, q)
+                _evaluate_rational_poly(rat_coeffs, r) == 0 && push!(roots, r)
+            end
+        end
+    end
+    return unique(roots)
+end
+
+function _evaluate_rational_poly(coeffs::Vector{Rational{BigInt}}, x::Rational{BigInt})
+    s = Rational{BigInt}(0)
+    for c in coeffs
+        s = s * x + c
+    end
+    return s
+end
+
+# Display-quality narrowing of a rational root: collapse `n//1` to the bare
+# integer and demote `BigInt` to `Int` when it fits, so that a factor built
+# from an integer root prints as `x - 1` rather than `x - 1//1`. Purely a
+# presentation concern — the math is identical either way.
+function _narrow_root(r::Rational{BigInt})
+    if denominator(r) == 1
+        n = numerator(r)
+        return typemin(Int) <= n <= typemax(Int) ? Int(n) : n
+    end
+    if typemin(Int) <= numerator(r) <= typemax(Int) &&
+       typemin(Int) <= denominator(r) <= typemax(Int)
+        return Rational{Int}(Int(numerator(r)), Int(denominator(r)))
+    end
+    return r
+end
+
+# Synthetic division: divide a rational-coefficient polynomial by (x - r).
+# Assumes r is a root; the result is one degree lower and the remainder is
+# zero.
+function _divide_by_linear(coeffs::Vector{Rational{BigInt}}, r::Rational{BigInt})
+    n = length(coeffs) - 1
+    q = Rational{BigInt}[Rational{BigInt}(0) for _ in 1:n]
+    q[1] = coeffs[1]
+    for i in 2:n
+        q[i] = coeffs[i] + q[i - 1] * r
+    end
+    return q
+end
+
+# Pull all rational linear factors out of a single (monic, square-free) `Num`
+# polynomial. Returns `(linear_factors, residual)` where `linear_factors` is
+# a list of `Num` polynomials (each of the form `var - r`) and `residual` is
+# either `nothing` (polynomial fully split) or a `Num` polynomial of degree
+# ≥ 1 with no rational roots.
+function _pull_rational_linear_factors(q_num::Num, var)
+    coeffs_num = _univariate_coeffs(q_num, var)
+    coeffs_num = _strip_leading_zeros(coeffs_num)
+    length(coeffs_num) <= 1 && return (Num[], nothing)
+
+    rat = _try_extract_rational_vector(coeffs_num)
+    rat === nothing && return (Num[], q_num)
+
+    linear_factors = Num[]
+    remaining = rat
+    while length(remaining) > 1
+        roots = _rational_roots(remaining)
+        isempty(roots) && break
+        progressed = false
+        for r in roots
+            while length(remaining) > 1 && _evaluate_rational_poly(remaining, r) == 0
+                remaining = _divide_by_linear(remaining, r)
+                push!(linear_factors, wrap(simplify(expand(var - _narrow_root(r)))))
+                progressed = true
+            end
+        end
+        progressed || break
+    end
+
+    if length(remaining) <= 1
+        return (linear_factors, nothing)
+    end
+    rem_poly = _coeffs_to_poly(Num[Num(c) for c in remaining], var)
+    return (linear_factors, wrap(simplify(expand(rem_poly))))
+end
+
+# Extension hook: the Nemo ext may override this to deliver a full
+# factorisation of polynomials the pure-Julia core cannot split. Returns
+# `nothing` by default (Nemo not loaded) or a Vector of `(Num, Int)` factor
+# pairs when Nemo has factored the residual.
+_factor_with_nemo(residual, var) = nothing
+
+"""
+    factor(f, var)
+
+Compute the factorisation of the univariate polynomial `f` over the rationals.
+Returns a tuple `(unit, factors)` where `unit::Num` absorbs the leading
+coefficient / integer content and `factors::Vector{Tuple{Num, Int}}` is a
+list of `(p_i, e_i)` pairs with each `p_i` either irreducible over ℚ (when
+the pure-Julia core can prove it, i.e., linear factors and degree-2/3
+residuals with no rational root) or the best available decomposition
+otherwise.
+
+Coefficients must be rational (`Integer` / `Rational`) or symbolic in other
+variables. Floating-point coefficients are not supported and raise
+`ArgumentError`.
+
+# Examples
+```julia
+julia> using Symbolics
+
+julia> @variables x;
+
+julia> u, fs = Symbolics.factor(x^4 - 1, x);  # (x-1)(x+1)(x^2+1)
+
+julia> u, fs = Symbolics.factor(2x^2 - 2, x); # 2 * (x-1)(x+1)
+```
+
+If `Nemo` is loaded, residual higher-degree factors the core cannot prove
+irreducible are passed to `Nemo.factor` via the `SymbolicsNemoExt`
+extension. Without `Nemo`, degree-≥ 4 residuals without rational roots are
+returned as a single non-trivially-factored entry.
+"""
+function factor(f, var)
+    fcoeffs = _univariate_coeffs(f, var)
+    fcoeffs = _strip_leading_zeros(fcoeffs)
+    if isempty(fcoeffs)
+        throw(ArgumentError("factor: zero polynomial"))
+    end
+    bad = _find_float_coefficient(fcoeffs)
+    if bad !== nothing
+        throw(ArgumentError("factor: coefficient $(bad) not in supported domain; floating-point coefficients are not supported"))
+    end
+
+    unit, sqfree_factors = sqrfree(f, var)
+    all_factors = Tuple{Num, Int}[]
+    for (q, mult) in sqfree_factors
+        linear, residual = _pull_rational_linear_factors(q, var)
+        for lf in linear
+            push!(all_factors, (lf, mult))
+        end
+        residual === nothing && continue
+
+        res_coeffs = _univariate_coeffs(residual, var)
+        res_coeffs = _strip_leading_zeros(res_coeffs)
+        d_res = length(res_coeffs) - 1
+        if d_res <= 3
+            # No rational root + degree ≤ 3 ⇒ irreducible over ℚ
+            push!(all_factors, (residual, mult))
+            continue
+        end
+        # Higher degree: try the Nemo hook
+        nemo_result = _factor_with_nemo(residual, var)
+        if nemo_result === nothing
+            push!(all_factors, (residual, mult))
+        else
+            for (p, e) in nemo_result
+                push!(all_factors, (p, e * mult))
+            end
+        end
+    end
+    return (unit, all_factors)
+end

--- a/test/polynomial_algebra.jl
+++ b/test/polynomial_algebra.jl
@@ -1,0 +1,388 @@
+using Symbolics
+using Test
+using Random
+
+@variables x a b c d e
+
+# =========================================================================
+# Foundational helper: Symbolics._univariate_coeffs
+# =========================================================================
+
+@testset "univariate coefficients (foundational helper)" begin
+    # valid polynomial
+    coeffs = Symbolics._univariate_coeffs(3x^2 + 2x + 1, x)
+    @test length(coeffs) == 3
+    @test isequal(Symbolics.simplify(coeffs[1] - 3), 0)
+    @test isequal(Symbolics.simplify(coeffs[2] - 2), 0)
+    @test isequal(Symbolics.simplify(coeffs[3] - 1), 0)
+
+    # degree-0 input
+    @test Symbolics._univariate_coeffs(Symbolics.Num(5), x) == [Symbolics.Num(5)]
+
+    # symbolic coefficients
+    coeffs = Symbolics._univariate_coeffs(a * x^2 + b * x + c, x)
+    @test length(coeffs) == 3
+    @test isequal(Symbolics.simplify(coeffs[1] - a), 0)
+    @test isequal(Symbolics.simplify(coeffs[2] - b), 0)
+    @test isequal(Symbolics.simplify(coeffs[3] - c), 0)
+
+    # non-polynomial input raises
+    @test_throws ArgumentError Symbolics._univariate_coeffs(sin(x), x)
+    @test_throws ArgumentError Symbolics._univariate_coeffs(1 / x, x)
+end
+
+# =========================================================================
+# US1 — resultant
+# =========================================================================
+
+# Helper: assert symbolic equality by simplifying the difference.
+sym_eq(x, y) = iszero(Symbolics.simplify(Symbolics.expand(Symbolics.Num(x) - Symbolics.Num(y))))
+
+@testset "resultant — fixed numeric inputs" begin
+    # Common root → 0
+    @test sym_eq(resultant(x^2 - 1, x - 1, x), 0)
+    @test sym_eq(resultant(x^2 - 1, x - 1, x; algorithm = :euclid), 0)
+    @test sym_eq(resultant(x^2 - 1, x - 1, x; algorithm = :sylvester), 0)
+
+    # Coprime pair → 5 for (x^2+1, x-2)
+    @test sym_eq(resultant(x^2 + 1, x - 2, x), 5)
+    @test sym_eq(resultant(x^2 + 1, x - 2, x; algorithm = :sylvester), 5)
+
+    # Res(x^3 - 1, x^2 + x + 1) = 0 (share the factor x^2+x+1)
+    @test sym_eq(resultant(x^3 - 1, x^2 + x + 1, x), 0)
+    @test sym_eq(resultant(x^3 - 1, x^2 + x + 1, x; algorithm = :sylvester), 0)
+
+    # Res(f, c) = c^deg(f); Res(x^3+1, 2, x) = 8
+    @test sym_eq(resultant(x^3 + 1, Symbolics.Num(2), x), 8)
+
+    # Res of two scalars: 1 (empty product)
+    @test sym_eq(resultant(Symbolics.Num(3), Symbolics.Num(7), x), 1)
+
+    # Standard example: Res(x^2 - 3x + 2, x^2 - 5x + 6, x)
+    # = (x-1)(x-2) ∩ (x-2)(x-3) share root x=2 → 0
+    @test sym_eq(resultant(x^2 - 3x + 2, x^2 - 5x + 6, x), 0)
+
+    # Res(x^2 + 3, x^3 + x + 1, x) — known value 13 (via lc(f)^deg(g) * prod g(α)
+    # over roots α=±i√3 of f: g(i√3)·g(-i√3) = (1-2i√3)(1+2i√3) = 1+12 = 13)
+    @test sym_eq(resultant(x^2 + 3, x^3 + x + 1, x), 13)
+    @test sym_eq(resultant(x^2 + 3, x^3 + x + 1, x; algorithm = :sylvester), 13)
+end
+
+@testset "resultant — symbolic coefficients" begin
+    # Res(a*x + b, c*x + d, x) == a*d - b*c
+    got = resultant(a * x + b, c * x + d, x)
+    @test sym_eq(got, a * d - b * c)
+    got_syl = resultant(a * x + b, c * x + d, x; algorithm = :sylvester)
+    @test sym_eq(got_syl, a * d - b * c)
+
+    # Res(f, f', x) for f = a*x^2 + b*x + c is -a*(b^2 - 4ac)
+    f = a * x^2 + b * x + c
+    fprime = Symbolics.derivative(f, x)
+    got = resultant(f, fprime, x)
+    @test sym_eq(got, -a * (b^2 - 4 * a * c))
+end
+
+@testset "resultant — algorithm agreement" begin
+    Random.seed!(0xC0FFEE)
+    n_agree = 0
+    n_trials = 50
+    for trial in 1:n_trials
+        df = rand(1:4)
+        dg = rand(1:4)
+        f_coeffs = big.(rand(-3:3, df + 1))
+        g_coeffs = big.(rand(-3:3, dg + 1))
+        f_coeffs[1] == 0 && (f_coeffs[1] = big(1))
+        g_coeffs[1] == 0 && (g_coeffs[1] = big(1))
+        f = sum(f_coeffs[i] * x^(df + 1 - i) for i in 1:(df + 1))
+        g = sum(g_coeffs[i] * x^(dg + 1 - i) for i in 1:(dg + 1))
+        r1 = resultant(f, g, x; algorithm = :euclid)
+        r2 = resultant(f, g, x; algorithm = :sylvester)
+        if sym_eq(r1, r2)
+            n_agree += 1
+        else
+            @info "algorithm disagreement" trial f g r1 r2
+        end
+    end
+    @test n_agree == n_trials
+end
+
+@testset "resultant — edge cases and errors" begin
+    # Zero polynomial on either side
+    @test_throws ArgumentError resultant(Symbolics.Num(0), x - 1, x)
+    @test_throws ArgumentError resultant(x - 1, Symbolics.Num(0), x)
+
+    # Unknown algorithm
+    @test_throws ArgumentError resultant(x - 1, x + 1, x; algorithm = :foo)
+
+    # Non-polynomial input
+    @test_throws ArgumentError resultant(sin(x), x - 1, x)
+    @test_throws ArgumentError resultant(x - 1, 1 / x, x)
+end
+
+# =========================================================================
+# US2 — discriminant
+# =========================================================================
+
+@testset "discriminant — symbolic quadratic" begin
+    # Canonical: disc(a*x^2 + b*x + c) = b^2 - 4*a*c
+    got = discriminant(a * x^2 + b * x + c, x)
+    @test sym_eq(got, b^2 - 4 * a * c)
+end
+
+@testset "discriminant — fixed numeric inputs" begin
+    # Distinct rational roots of x^2 - 3x + 2 → discriminant = 1
+    @test sym_eq(discriminant(x^2 - 3x + 2, x), 1)
+
+    # x^2 + 1 → -4
+    @test sym_eq(discriminant(x^2 + 1, x), -4)
+
+    # Repeated root: x^3 - 3x + 2 has a double root at x = 1 → 0
+    @test sym_eq(discriminant(x^3 - 3x + 2, x), 0)
+
+    # Three distinct rational roots 1, 2, 3 of x^3 - 6x^2 + 11x - 6:
+    # disc = ((2-1)(3-1)(3-2))^2 = 4
+    @test sym_eq(discriminant(x^3 - 6x^2 + 11x - 6, x), 4)
+
+    # Linear polynomial convention
+    @test sym_eq(discriminant(x - 5, x), 1)
+    @test sym_eq(discriminant(3x + 7, x), 1)
+
+    # Non-zero constant convention (per spec/contract Q4: disc(c) = 0)
+    @test sym_eq(discriminant(Symbolics.Num(7), x), 0)
+end
+
+@testset "discriminant — identity with resultant" begin
+    # disc(f) = (-1)^(n(n-1)/2) * Res(f, f') / lc(f)
+    for f in (x^2 + 3x + 2, x^3 - x, 2x^3 + 5x + 1, x^4 - 2x^2 + 1)
+        n = Symbolics.degree(f, x)
+        lc = Symbolics._univariate_coeffs(f, x)[1]
+        fprime = Symbolics.derivative(f, x)
+        expected = ((-1)^(n * (n - 1) ÷ 2)) * resultant(f, fprime, x) / lc
+        @test sym_eq(discriminant(f, x), expected)
+    end
+end
+
+@testset "discriminant — edge cases and errors" begin
+    @test_throws ArgumentError discriminant(Symbolics.Num(0), x)
+    @test_throws ArgumentError discriminant(sin(x), x)
+end
+
+# =========================================================================
+# US3 — sqrfree
+# =========================================================================
+
+# Reconstruct original polynomial from the sqrfree decomposition.
+function reconstruct_sqrfree(u, factors)
+    p = u
+    for (fac, e) in factors
+        p *= fac^e
+    end
+    return Symbolics.simplify(Symbolics.expand(p))
+end
+
+@testset "sqrfree — fixed inputs" begin
+    # Classical textbook: (x-1)^2 (x-2)^3
+    f = (x - 1)^2 * (x - 2)^3
+    u, fs = sqrfree(f, x)
+    @test sym_eq(reconstruct_sqrfree(u, fs), Symbolics.expand(f))
+    # Structure: two factors with multiplicities 2 and 3
+    mults = sort([e for (_, e) in fs])
+    @test mults == [2, 3]
+
+    # Already square-free: x^2 - 1 → single factor with multiplicity 1
+    u, fs = sqrfree(x^2 - 1, x)
+    @test length(fs) == 1
+    @test fs[1][2] == 1
+    @test sym_eq(reconstruct_sqrfree(u, fs), x^2 - 1)
+
+    # Non-unit leading coefficient: 2x^2 - 2 → unit=2, factor=(x^2-1, 1)
+    u, fs = sqrfree(2x^2 - 2, x)
+    @test sym_eq(u, 2)
+    @test sym_eq(reconstruct_sqrfree(u, fs), 2x^2 - 2)
+
+    # Constant non-zero: 5 → unit=5, no non-trivial factors
+    u, fs = sqrfree(Symbolics.Num(5), x)
+    @test sym_eq(u, 5)
+    @test isempty(fs)
+
+    # Mixed multiplicities: x^2 * (x-1)^3 * (x+1)
+    f = x^2 * (x - 1)^3 * (x + 1)
+    u, fs = sqrfree(f, x)
+    @test sym_eq(reconstruct_sqrfree(u, fs), Symbolics.expand(f))
+    @test sort([e for (_, e) in fs]) == [1, 2, 3]
+end
+
+@testset "sqrfree — round-trip property" begin
+    Random.seed!(0xDEC0DE)
+    n_ok = 0
+    n_trials = 30
+    for _ in 1:n_trials
+        roots_set = unique(rand(-3:3, rand(2:4)))
+        n_roots = length(roots_set)
+        mults = rand(1:3, n_roots)
+        f = reduce(*, (x - r)^m for (r, m) in zip(roots_set, mults))
+        f = Symbolics.expand(f)
+        u, fs = sqrfree(f, x)
+        recon = reconstruct_sqrfree(u, fs)
+        sym_eq(recon, Symbolics.expand(f)) && (n_ok += 1)
+    end
+    @test n_ok == n_trials
+end
+
+@testset "sqrfree — edge cases and errors" begin
+    @test_throws ArgumentError sqrfree(Symbolics.Num(0), x)
+    @test_throws ArgumentError sqrfree(sin(x), x)
+    @test_throws ArgumentError sqrfree(1 / x, x)
+end
+
+# =========================================================================
+# US4 — factor
+# =========================================================================
+
+function reconstruct_factor(u, factors)
+    p = u
+    for (fac, e) in factors
+        p *= fac^e
+    end
+    return Symbolics.simplify(Symbolics.expand(p))
+end
+
+@testset "factor — fixed inputs (pure-Julia path)" begin
+    # x^4 - 1 = (x-1)(x+1)(x^2+1), the quadratic being irreducible over ℚ
+    u, fs = Symbolics.factor(x^4 - 1, x)
+    @test sym_eq(u, 1)
+    @test length(fs) == 3
+    @test all(e == 1 for (_, e) in fs)
+    @test sym_eq(reconstruct_factor(u, fs), Symbolics.expand(x^4 - 1))
+
+    # x^3 - 6x^2 + 11x - 6 → three distinct linear factors (roots 1, 2, 3)
+    u, fs = Symbolics.factor(x^3 - 6x^2 + 11x - 6, x)
+    @test sym_eq(u, 1)
+    @test length(fs) == 3
+    @test all(e == 1 for (_, e) in fs)
+    @test sym_eq(reconstruct_factor(u, fs), Symbolics.expand(x^3 - 6x^2 + 11x - 6))
+
+    # Content > 1: 2x^2 - 2 = 2 * (x-1) * (x+1)
+    u, fs = Symbolics.factor(2x^2 - 2, x)
+    @test sym_eq(u, 2)
+    @test length(fs) == 2
+    @test sym_eq(reconstruct_factor(u, fs), Symbolics.expand(2x^2 - 2))
+
+    # Irreducible over ℚ: x^2 + 1
+    u, fs = Symbolics.factor(x^2 + 1, x)
+    @test length(fs) == 1
+    @test sym_eq(fs[1][1], x^2 + 1)
+    @test fs[1][2] == 1
+
+    # x^3 + 1 = (x+1)(x^2 - x + 1)
+    u, fs = Symbolics.factor(x^3 + 1, x)
+    @test length(fs) == 2
+    @test sym_eq(reconstruct_factor(u, fs), Symbolics.expand(x^3 + 1))
+
+    # Repeated root: (x-1)^2 * (x+2)
+    u, fs = Symbolics.factor((x - 1)^2 * (x + 2), x)
+    @test sym_eq(reconstruct_factor(u, fs), Symbolics.expand((x - 1)^2 * (x + 2)))
+    @test sort([e for (_, e) in fs]) == [1, 2]
+
+    # Constant non-zero: Symbolics.factor(5) → unit=5, no non-trivial factors
+    u, fs = Symbolics.factor(Symbolics.Num(5), x)
+    @test sym_eq(u, 5)
+    @test isempty(fs)
+end
+
+@testset "factor — round-trip property" begin
+    Random.seed!(0xFAC0FF)
+    n_ok = 0
+    n_trials = 20
+    for _ in 1:n_trials
+        roots_set = unique(rand(-4:4, 4))
+        length(roots_set) < 2 && continue
+        mults = rand(1:2, length(roots_set))
+        f = reduce(*, (x - r)^m for (r, m) in zip(roots_set, mults))
+        f = Symbolics.expand(f)
+        u, fs = Symbolics.factor(f, x)
+        recon = reconstruct_factor(u, fs)
+        sym_eq(recon, Symbolics.expand(f)) && (n_ok += 1)
+    end
+    @test n_ok >= 15  # at least 75% — allow a few trials dropped by unique() collapse
+end
+
+@testset "factor — edge cases and errors" begin
+    @test_throws ArgumentError Symbolics.factor(Symbolics.Num(0), x)
+    @test_throws ArgumentError Symbolics.factor(sin(x), x)
+    @test_throws ArgumentError Symbolics.factor(1 / x, x)
+    # Floating-point coefficient is out of the supported domain
+    @test_throws ArgumentError Symbolics.factor(1.5 * x + 2, x)
+end
+
+# =========================================================================
+# Optional Nemo oracle tests — run only when Nemo is loaded (in practice,
+# whenever the `SymbolicsNemoExt` package extension is active).
+# =========================================================================
+
+if Base.get_extension(Symbolics, :SymbolicsNemoExt) !== nothing
+    @info "Nemo extension loaded — running oracle tests"
+    Nemo = Base.loaded_modules[Base.PkgId(Base.UUID("2edaba10-b0f1-5616-af89-8c11ac63239a"), "Nemo")]
+
+    @testset "resultant — Nemo oracle" begin
+        # Compare Symbolics.resultant against Nemo.resultant on a small fixed
+        # corpus of integer univariate polynomials.
+        for (fc, gc) in (([1, 0, -1], [1, -1]),
+                         ([1, -6, 11, -6], [1, -3, 2]),
+                         ([1, 0, 1], [1, -2]),
+                         ([2, 3, -1, 5], [1, -1, 1]))
+            R, z = Nemo.polynomial_ring(Nemo.QQ, "z")
+            f_nemo = sum(fc[i] * z^(length(fc) - i) for i in 1:length(fc))
+            g_nemo = sum(gc[i] * z^(length(gc) - i) for i in 1:length(gc))
+            expected = Rational(Nemo.resultant(f_nemo, g_nemo))
+            # Build the same polynomials in Symbolics
+            df, dg = length(fc) - 1, length(gc) - 1
+            f = sum(fc[i] * x^(df - i + 1) for i in 1:length(fc))
+            g = sum(gc[i] * x^(dg - i + 1) for i in 1:length(gc))
+            @test sym_eq(resultant(f, g, x; algorithm = :euclid), expected)
+            @test sym_eq(resultant(f, g, x; algorithm = :sylvester), expected)
+        end
+    end
+
+    @testset "factor — Nemo oracle" begin
+        # The residual from x^10 - 1 after rational-roots extraction is
+        # degree 8 and reducible; without the Nemo hook we'd return it
+        # whole, with the hook we get the two cyclotomic quartics.
+        u, fs = Symbolics.factor(x^10 - 1, x)
+        @test sym_eq(u, 1)
+        @test length(fs) == 4
+        @test sym_eq(reconstruct_factor(u, fs), Symbolics.expand(x^10 - 1))
+
+        u, fs = Symbolics.factor(x^6 - 1, x)
+        @test sym_eq(u, 1)
+        @test length(fs) == 4
+        @test sym_eq(reconstruct_factor(u, fs), Symbolics.expand(x^6 - 1))
+
+        # Pure degree-8 reducible input (product of two quartic cyclotomics).
+        u, fs = Symbolics.factor(x^8 + x^6 + x^4 + x^2 + 1, x)
+        @test length(fs) == 2
+        @test all(e == 1 for (_, e) in fs)
+    end
+else
+    @info "Nemo extension not loaded — skipping oracle tests (T012 / T038)"
+end
+
+# Optional performance-regression guard. Runs only when the
+# `SYMBOLICS_POLYALG_BENCH` environment variable is set so that CI speed is
+# not affected; the purpose is to catch gross regressions (SC-005).
+if get(ENV, "SYMBOLICS_POLYALG_BENCH", "") != ""
+    @testset "polynomial_algebra — interactive-latency guard" begin
+        # Warm up
+        resultant(x^3 + 1, x^2 - 2, x)
+        sqrfree((x - 1)^3 * (x + 2), x)
+        Symbolics.factor(x^4 - 1, x)
+
+        t_res = @elapsed resultant(x^6 + x + 1, x^5 - 3x^2 + 7, x)
+        t_sqf = @elapsed sqrfree((x - 1)^2 * (x + 2)^3 * (x - 3), x)
+        t_fac = @elapsed Symbolics.factor(x^4 - 5x^3 + 5x^2 + 5x - 6, x)
+        @info "polynomial_algebra timings" t_res t_sqf t_fac
+        @test t_res < 2.0
+        @test t_sqf < 2.0
+        @test t_fac < 2.0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,7 @@ if GROUP == "All" || GROUP == "Core"
         @safetestset "View-setting" begin include("stencils.jl") end
         @safetestset "Complex" begin include("complex.jl") end
         @safetestset "Semi-polynomial" begin include("semipoly.jl") end
+        @safetestset "Polynomial Algebra" begin include("polynomial_algebra.jl") end
         @safetestset "Fuzz Arrays" begin include("fuzz-arrays.jl") end
         @safetestset "Differentiation Test" begin include("diff.jl") end
         @safetestset "Utils Test" begin include("utils.jl") end


### PR DESCRIPTION
Adds four user-facing primitives for univariate polynomial algebra over ℚ (or with symbolic coefficients treated as transcendentals):

- `resultant(f, g, var; algorithm = :euclid | :sylvester)` — single entry point exposing both the extended-Euclidean PRS and the Sylvester-matrix determinant; the two algorithms are guaranteed to agree on every valid input.
- `discriminant(f, var)` — derived via the classical identity `(-1)^(n*(n-1)/2) * Res(f, f') / lc(f)`. `disc(a*x + b) = 1`, `disc(c) = 0`.
- `sqrfree(f, var)` — Yun's square-free decomposition in characteristic 0; returns `(unit, Vector{(Num, Int)})` satisfying `unit * prod(p_i^e_i) == f`.
- `Symbolics.factor(f, var)` — rational factorisation. Not exported to avoid shadowing `Base.factor` / `Primes.factor`. Pure-Julia pipeline handles content + square-free + rational-roots; a new `_factor_with_nemo` extension hook in `SymbolicsNemoExt` delegates higher-degree residuals to `Nemo.factor` when Nemo is loaded, producing the full ℚ-irreducible decomposition.

Tidies `SymbolicsNemoExt.nemo_crude_evaluate` with explicit dispatches for `Nemo.QQFieldElem` and `Nemo.ZZRingElem` so integer-valued coefficients render as plain `Int`/`BigInt` rather than `n//1`. The existing `Symbolics.factor_use_nemo` (used by the solver) is untouched at the call-site level and gains the same cosmetic cleanup.

Documentation: new manual page `docs/src/manual/polynomial_algebra.md` registered in `docs/make.jl` under the Algebra group.

Testing: 86 polynomial-algebra tests pass without Nemo, 102 with Nemo loaded (16 additional Nemo-oracle tests guarded by the extension).

Version bump to 7.20.0 (MINOR — purely additive).


Be aware it's AI generated code from Claude Opus 4.7 ... it may be imperfect.
And is given as a draft for future work.

May help #59 

Free to maintainers to edit.