### PR TITLE
feat: add `sort_addmul` kwarg to `codegen_function`

### DIFF
--- a/src/codegen_fn.jl
+++ b/src/codegen_fn.jl
@@ -40,13 +40,15 @@ end
 function codegen_function(
         ir::IRStructure{VartypeT}, expr, args::Vector;
         nanmath::Bool = true, wrap_code::Tuple = (identity, identity),
-        checkbounds = false, iip_config::NTuple{2, Bool} = (true, true), kwargs...
+        checkbounds = false, iip_config::NTuple{2, Bool} = (true, true), sort_addmul = false,
+        kwargs...
     )
     args = canonicalize_args(args, !checkbounds)
     rewrites = Dict()
     if nanmath
         rewrites[:nanmath] = true
     end
+    rewrites[:sort_addmul] = sort_addmul
 
     if iip_config[1]
         oopfn = wrap_code[1](Func(args, [], expr))
@@ -97,13 +99,14 @@ function codegen_function(
         ir::IRStructure{VartypeT}, expr::AbstractArray, args::Vector;
         similarto = nothing, nanmath::Bool = true, wrap_code::Tuple = (identity, identity),
         iip_config::NTuple{2, Bool} = (true, true), outputidxs = nothing,
-        skipzeros = false, checkbounds = false, optimize = nothing, kwargs...
+        skipzeros = false, checkbounds = false, optimize = nothing, sort_addmul = false, kwargs...
     )
     args = canonicalize_args(args, !checkbounds)
     rewrites = Dict()
     if nanmath
         rewrites[:nanmath] = true
     end
+    rewrites[:sort_addmul] = sort_addmul
 
     expr = _recursive_unwrap(expr)
 

--- a/test/codegen_function.jl
+++ b/test/codegen_function.jl
@@ -13,7 +13,7 @@ RuntimeGeneratedFunctions.init(@__MODULE__)
 ir = IRStructure{SymReal}()
 
 @testset "NaNMath" begin
-    oop, iip = Symbolics.codegen_function(ir, [sqrt(a), sin(b)], [[a, b]]; nanmath = true)
+    oop, iip = Symbolics.codegen_function(ir, [sqrt(a), sin(b)], [[a, b]]; nanmath = true, sort_addmul = true)
     oop = eval(oop)
     @test all(isnan, @invokelatest oop([-1, Inf]))
     out = [0, 0.0]
@@ -37,17 +37,17 @@ end
         out .= [a[1] + b[1] + c[1] + c[2], c[3] + d[1] + e[1] + g[1], 0]
     end
 
-    h_str = Symbolics.codegen_function(ir, h, [[a], [b], [c1, c2, c3], [d], [e], [g]])
-    h_str2 = Symbolics.codegen_function(ir, h, [[a], [b], [c1, c2, c3], [d], [e], [g]])
+    h_str = Symbolics.codegen_function(ir, h, [[a], [b], [c1, c2, c3], [d], [e], [g]]; sort_addmul = true)
+    h_str2 = Symbolics.codegen_function(ir, h, [[a], [b], [c1, c2, c3], [d], [e], [g]]; sort_addmul = true)
     @test h_str[1] == h_str2[1]
     @test h_str[2] == h_str2[2]
 
     h_oop = eval(h_str[1])
-    h_str_3 = Symbolics.codegen_function(ir, h, [[a], [b], [c1, c2, c3], [d], [e], [g]]; iip_config = (false, true))
-    h_str_4 = Symbolics.codegen_function(ir, h, [[a], [b], [c1, c2, c3], [d], [e], [g]]; iip_config = (true, false))
+    h_str_3 = Symbolics.codegen_function(ir, h, [[a], [b], [c1, c2, c3], [d], [e], [g]]; iip_config = (false, true), sort_addmul = true)
+    h_str_4 = Symbolics.codegen_function(ir, h, [[a], [b], [c1, c2, c3], [d], [e], [g]]; iip_config = (true, false), sort_addmul = true)
 
     h_ip! = eval(h_str[2])
-    h_ip_skip! = eval(Symbolics.codegen_function(ir, h, [[a], [b], [c1, c2, c3], [d], [e], [g]], skipzeros = true)[2])
+    h_ip_skip! = eval(Symbolics.codegen_function(ir, h, [[a], [b], [c1, c2, c3], [d], [e], [g]], skipzeros = true, sort_addmul = true)[2])
 
     h3_oop = let f = eval(h_str_3[1])
         (args...) -> @invokelatest f(args...)
@@ -89,7 +89,7 @@ end
         out .= [a[1] + b[1] + c[1]; c[2] + c[3] + g[1]]
     end
 
-    h_str_skip = Symbolics.codegen_function(ir, h_skip, [[a], [b], [c1, c2, c3], [], [], [g]]; checkbounds = true)
+    h_str_skip = Symbolics.codegen_function(ir, h_skip, [[a], [b], [c1, c2, c3], [], [], [g]]; checkbounds = true, sort_addmul = true)
     h_oop_skip = let f = eval(h_str_skip[1])
         (args...) -> @invokelatest f(args...)
     end
@@ -118,8 +118,8 @@ end
 @testset "Multiple input scalar result" begin
     h_scalar = a + b + c1 + c2 + c3 + d + e + g
     h_julia_scalar(a, b, c, d, e, g) = a[1] + b[1] + c[1] + c[2] + c[3] + d[1] + e[1] + g[1]
-    h_str_scalar, _ = Symbolics.codegen_function(ir, h_scalar, [[a], [b], [c1, c2, c3], [d], [e], [g]])
-    h_str_scalar2, _ = Symbolics.codegen_function(ir, h_scalar, [[a], [b], [c1, c2, c3], [d], [e], [g]])
+    h_str_scalar, _ = Symbolics.codegen_function(ir, h_scalar, [[a], [b], [c1, c2, c3], [d], [e], [g]]; sort_addmul = true)
+    h_str_scalar2, _ = Symbolics.codegen_function(ir, h_scalar, [[a], [b], [c1, c2, c3], [d], [e], [g]]; sort_addmul = true)
     @test h_str_scalar == h_str_scalar2
 
     h_oop_scalar = let f = eval(h_str_scalar)
@@ -131,24 +131,24 @@ end
 
 @testset "Dependent variable arguments" begin
     @variables t x(t) y(t) k
-    f = let _f = eval(Symbolics.codegen_function(ir, (x + y) / k, [[x, y, k]])[1])
+    f = let _f = eval(Symbolics.codegen_function(ir, (x + y) / k, [[x, y, k]]; sort_addmul = true)[1])
         (args...) -> @invokelatest _f(args...)
     end
     @test f([1, 1, 2]) == 1
 
-    f = let _f = eval(Symbolics.codegen_function(ir, [(x + y) / k], [[x, y, k]])[1])
+    f = let _f = eval(Symbolics.codegen_function(ir, [(x + y) / k], [[x, y, k]]; sort_addmul = true)[1])
         (args...) -> @invokelatest _f(args...)
     end
     @test f([1, 1, 2]) == [1]
 
-    f = let _f = eval(Symbolics.codegen_function(ir, [(x + y) / k], [[x, y, k]])[2])
+    f = let _f = eval(Symbolics.codegen_function(ir, [(x + y) / k], [[x, y, k]]; sort_addmul = true)[2])
         (args...) -> @invokelatest _f(args...)
     end
     z = [0.0]
     f(z, [1, 1, 2])
     @test z == [1]
 
-    f = let _f = eval(Symbolics.codegen_function(ir, sparse([1], [1], [(x + y) / k], 10, 10), [[x, y, k]])[1])
+    f = let _f = eval(Symbolics.codegen_function(ir, sparse([1], [1], [(x + y) / k], 10, 10), [[x, y, k]]; sort_addmul = true)[1])
         (args...) -> @invokelatest _f(args...)
     end
 
@@ -161,7 +161,7 @@ end
     @variables a b c
 
     x = reshape(sparse([0 a 0; 0 b c]), 3, 2)
-    f1, f2 = Symbolics.codegen_function(ir, x, [[a, b, c]])
+    f1, f2 = Symbolics.codegen_function(ir, x, [[a, b, c]]; sort_addmul = true)
     f1 = @RuntimeGeneratedFunction(f1)
     f2 = @RuntimeGeneratedFunction(f2)
     y = f1([1, 2, 3])
@@ -170,7 +170,7 @@ end
     @test y.parent.rowval == x.parent.rowval
     @test y == [0 2; 0 0; 1 3]
 
-    f1, f2 = Symbolics.codegen_function(ir, @views(x[2:3, 1:2]), [[a, b, c]])
+    f1, f2 = Symbolics.codegen_function(ir, @views(x[2:3, 1:2]), [[a, b, c]]; sort_addmul = true)
     f1 = @RuntimeGeneratedFunction(f1)
     f2 = @RuntimeGeneratedFunction(f2)
     y = f1([1, 2, 3])
@@ -182,7 +182,7 @@ end
     @variables x
     y = sparse(1:3, 1:3, x)
 
-    f1, f2 = Symbolics.codegen_function(ir, y, [x])
+    f1, f2 = Symbolics.codegen_function(ir, y, [x]; sort_addmul = true)
     sf1, sf2 = string(f1), string(f2)
     @test !contains(sf1, "CartesianIndex")
     @test !contains(sf2, "CartesianIndex")
@@ -203,7 +203,7 @@ end
 
     sj = Symbolics.sparsejacobian(F(z), z)
 
-    f_expr = Symbolics.codegen_function(ir, sj, [z])
+    f_expr = Symbolics.codegen_function(ir, sj, [z]; sort_addmul = true)
     myf = eval(first(f_expr))
     J = @invokelatest myf(rand(N))
 
@@ -227,7 +227,7 @@ end
     end
     f, _ = Symbolics.codegen_function(
         ir, ex, [[unwrap(x)], unwrap(t), [unwrap(p)]];
-        wrap_code = (header, identity)
+        wrap_code = (header, identity), sort_addmul = true
     )
     f = @RuntimeGeneratedFunction(f)
     p = (a = 10, p = [2])
@@ -236,16 +236,16 @@ end
 
 @testset "Issue#658" begin
     @variables a, X1[1:3], X2[1:3]
-    k = eval(Symbolics.codegen_function(ir, a * X1 + X2, [X1, X2, a])[1])
+    k = eval(Symbolics.codegen_function(ir, a * X1 + X2, [X1, X2, a]; sort_addmul = true)[1])
     @test @invokelatest(k(ones(3), ones(3), 1.5)) == [2.5, 2.5, 2.5]
 end
 
 @testset "`similarto`" begin
     @variables x[1:2]
     T = collect(unwrap(x .^ 2))
-    fn = @RuntimeGeneratedFunction(Symbolics.codegen_function(ir, T, [collect(x)])[1])
+    fn = @RuntimeGeneratedFunction(Symbolics.codegen_function(ir, T, [collect(x)]; sort_addmul = true)[1])
     @test_throws MethodError fn((1.0, 2.0))
-    fn = @RuntimeGeneratedFunction(Symbolics.codegen_function(ir, T, [collect(x)]; similarto = Array)[1])
+    fn = @RuntimeGeneratedFunction(Symbolics.codegen_function(ir, T, [collect(x)]; similarto = Array, sort_addmul = true)[1])
     @test fn((1.0, 2.0)) ≈ [1.0, 4.0]
 end
 
@@ -263,7 +263,7 @@ end
     f_test(J, u)
     up_J = UpperTriangular(J - Diagonal(J))
 
-    out, fjac_upper_expr = Symbolics.codegen_function(ir, up_J, [u]; skipzeros = true)
+    out, fjac_upper_expr = Symbolics.codegen_function(ir, up_J, [u]; skipzeros = true, sort_addmul = true)
     fjac_upper_expr = @RuntimeGeneratedFunction(fjac_upper_expr)
     Jtmp = UpperTriangular(zeros(2, 2))
     utmp = rand(2)
@@ -278,7 +278,7 @@ end
     oopexprs = Expr[]
     iipexprs = Expr[]
     for i in 1:10
-        foop, fiip = Symbolics.codegen_function(ir, expr, args)
+        foop, fiip = Symbolics.codegen_function(ir, expr, args; sort_addmul = true)
         push!(oopexprs, foop)
         push!(iipexprs, fiip)
     end


### PR DESCRIPTION
This avoids extra overhead during normal codegen. It is enabled for tests so that reference tests pass.