### PR TITLE
feat: register `sincospi` and `isinteger` for `Num`

### DIFF
--- a/src/extra_functions.jl
+++ b/src/extra_functions.jl
@@ -57,6 +57,24 @@ end
 
 LinearAlgebra.norm(x::Num, p::Real) = abs(x)
 
+# `Base.sincospi(::Real)` explicitly throws a `MethodError` so that subtypes of
+# `Real` (like `Num`) have to opt in. Fall back to a tuple of `sinpi`/`cospi`,
+# both of which are already registered.
+Base.sincospi(x::Num) = (sinpi(x), cospi(x))
+
+# `Base.sinpi(::Complex)` and `Base.cospi(::Complex)` branch on `isinteger` of
+# the real/imaginary parts, so we need `isinteger(::Num)`. For a wrapped
+# constant we can answer exactly; for a symbolic variable whose `symtype` is an
+# `Integer` we know the value must be an integer; otherwise we conservatively
+# return `false` (an unknown real is not assumed to be an integer).
+function Base.isinteger(x::Num)
+    val = unwrap(x)
+    if SymbolicUtils.isconst(val)
+        return isinteger(SymbolicUtils.unwrap_const(val))
+    end
+    return symtype(val) <: Integer
+end
+
 @register_derivative <(x, y) I COMMON_ZERO
 @register_derivative <=(x, y) I COMMON_ZERO
 @register_derivative >(x, y) I COMMON_ZERO

--- a/test/overloads.jl
+++ b/test/overloads.jl
@@ -21,6 +21,20 @@ vars = @variables a,b,c,d,e,f,g,h,i
 @test isequal(a', a)
 @test isequal(sincos(a), (sin(a), cos(a)))
 
+# https://github.com/JuliaSymbolics/Symbolics.jl/issues/1763
+@test isequal(sincospi(a), (sinpi(a), cospi(a)))
+@test isinteger(Num(2))
+@test !isinteger(Num(2.5))
+@test !isinteger(a)
+@variables nint::Int
+@test isinteger(nint)
+@variables zcplx::Complex
+# `sinpi(::Complex{Num})` / `cospi(::Complex{Num})` go through `Base`'s
+# complex implementations, which dispatch on `isinteger(::Num)`.
+@test sinpi(zcplx) isa Complex{Num}
+@test cospi(zcplx) isa Complex{Num}
+@test sincospi(zcplx) isa Tuple{Complex{Num}, Complex{Num}}
+
 @test substitute(a ~ b, Dict(a=>1, b=>c)) == (1 ~ c)
 
 # test hashing


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until reviewed by @ChrisRackauckas.

## Summary

Closes #1763.

`Base.sincospi(::Real)` explicitly throws a `MethodError` so subtypes of `Real` (like `Num`) must opt in. And `Base.sinpi(::Complex)` / `Base.cospi(::Complex)` dispatch on `isinteger` of the real/imaginary parts of the input, so `Complex{Num}` arguments hit a `MethodError` on `isinteger(::Num)`.

This PR adds fallback definitions so all three call sites work symbolically:

```julia
Base.sincospi(x::Num) = (sinpi(x), cospi(x))

function Base.isinteger(x::Num)
    val = unwrap(x)
    if SymbolicUtils.isconst(val)
        return isinteger(SymbolicUtils.unwrap_const(val))
    end
    return symtype(val) <: Integer
end
```

The `isinteger` rule answers exactly when the `Num` wraps a constant, returns `true` when the symbolic variable was declared with an integer `symtype` (e.g. `@variables n::Int`), and otherwise conservatively returns `false` (an unknown real is not assumed to be an integer). This is the right semantics for the `sinpi(::Complex)` dispatch — it falls through to the general formula in `Base`.

Repro from the issue now works:

```julia
julia> @variables x
1-element Vector{Num}:
 x

julia> sincospi(x)
(sinpi(x), cospi(x))

julia> @variables y::Complex
1-element Vector{Complex{Num}}:
 real(y) + (imag(y))*im

julia> sinpi(y)
sinpi(real(y))*cosh(imag(y)*π) + im*cospi(real(y))*sinh(imag(y)*π)
```

## Test plan

- [x] Reproduced the issue against unmodified master
- [x] Local `Pkg.test` on Julia 1.11 — `Overloading Test` passes with the new cases included (106 pass, 0 fail; 2 pre-existing broken). The other failures in the suite (`Build Targets Test`, `Latexify Test`) are unrelated to these changes.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)