### PR TITLE
fix: fix registration of struct constructors

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -40,11 +40,21 @@ macro register_symbolic(expr, define_promotion = true, wrap_arrays = true)
 
     if define_promotion
         type_args = [:($name::$Type) for name in argnames]
-        fexpr = :($fexpr; (::$typeof($promote_symtype))(::$ftype, $(type_args...)) = $ret_type)
         promote_expr = quote
-            function (::$(typeof(SymbolicUtils.promote_shape)))(::$ftype, args::$(SymbolicUtils.ShapeT)...)
-                @nospecialize args
-                $(SymbolicUtils.ShapeVecT)()
+            if $ftype === DataType || $ftype === Union || $ftype === UnionAll
+                function (::$typeof($promote_symtype))(::Type{T}, $(type_args...)) where {T <: $f}
+                    $ret_type
+                end
+                function (::$(typeof(SymbolicUtils.promote_shape)))(::Type{T}, args::$(SymbolicUtils.ShapeT)...) where {T <: $f}
+                    @nospecialize args
+                    $(SymbolicUtils.ShapeVecT)()
+                end
+            else
+                (::$typeof($promote_symtype))(::$ftype, $(type_args...)) = $ret_type
+                function (::$(typeof(SymbolicUtils.promote_shape)))(::$ftype, args::$(SymbolicUtils.ShapeT)...)
+                    @nospecialize args
+                    $(SymbolicUtils.ShapeVecT)()
+                end
             end
         end
         fexpr = :($fexpr; $promote_expr)
@@ -157,23 +167,38 @@ function register_array_symbolic(f, ftype, argnames, Ts, ret_type, partial_defs 
 
         shape_args = [:($name::$(SymbolicUtils.ShapeT)) for name in argnames]
         type_args = [:($name::$Type) for name in argnames]
-        promote_expr = quote
-            function (::$typeof($promote_symtype))($fn_arg, $(type_args...))
-                f = $fn_arg_name
-                container_type = $container_type
-                nd = $(get(defs, :ndims, -1))
-                etype = $eltype_expr
-                if nd == -1
-                    return container_type{etype}
-                else
-                    return container_type{etype, nd}
-                end
+        promote_symtype_body = quote
+            f = $fn_arg_name
+            container_type = $container_type
+            nd = $(get(defs, :ndims, -1))
+            etype = $eltype_expr
+            if nd == -1
+                return container_type{etype}
+            else
+                return container_type{etype, nd}
             end
-            function (::$(typeof(SymbolicUtils.promote_shape)))($fn_arg, $(shape_args...))
-                @nospecialize $(argnames...)
-                size = identity
-                $shape_expr
-                return sh
+        end
+        promote_shape_body = quote
+            @nospecialize $(argnames...)
+            size = identity
+            $shape_expr
+            return sh
+        end
+        promote_expr = quote
+            if $ftype === DataType || $ftype === Union || $ftype === UnionAll
+                function (::$typeof($promote_symtype))(::Type{T}, $(type_args...)) where {T <: $f}
+                    $promote_symtype_body
+                end
+                function (::$(typeof(SymbolicUtils.promote_shape)))(::Type{T}, $(shape_args...)) where {T <: $f}
+                    $promote_shape_body
+                end
+            else
+                function (::$typeof($promote_symtype))($fn_arg, $(type_args...))
+                    $promote_symtype_body
+                end
+                function (::$(typeof(SymbolicUtils.promote_shape)))($fn_arg, $(shape_args...))
+                    $promote_shape_body
+                end
             end
         end |> esc
         fexpr = :($fexpr; $promote_expr)

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -455,3 +455,13 @@ end
     @test SU.shape(unwrap(foo3(x))) == SU.Unknown(2)
 end
 
+struct Bar{T} end
+struct Baz{T} end
+
+@register_symbolic Bar(x::Int)::Bar{Int}
+@register_symbolic Baz(x::String)::Baz{String}
+
+@testset "Registration of struct constructors works correctly" begin
+    @test SU.promote_symtype(Bar, Int) === Bar{Int}
+    @test SU.promote_symtype(Baz, String) === Baz{String}
+end


### PR DESCRIPTION
```julia
struct Foo{T} end
@register_symbolic Foo(x::Int)::Foo{Int}
```

Would define
```julia
SU.promote_symtype(::UnionAll, ::SU.TypeT) = Foo{Int}
```

Which is pretty bad.