### PR TITLE
Map solver-safe functions (ssqrt/scbrt/slog) to math.h names in CTarget

### DIFF
--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -675,6 +675,11 @@ numbered_expr(c,args...;kwargs...) = c
 numbered_expr(c::Num,args...;kwargs...) = error("Num found")
 
 
+# The solver introduces "safe" variants of some math functions that handle
+# negative/complex inputs in Julia. They have no C equivalent, so map them back
+# to the standard math.h names when generating C code.
+const c_safe_function_renames = Dict(:ssqrt => :sqrt, :scbrt => :cbrt, :slog => :log)
+
 # Replace certain multiplication and power expressions so they form valid C code
 # Extra factors of 1 are hopefully eliminated by the C compiler
 function coperators(expr)
@@ -683,6 +688,9 @@ function coperators(expr)
         if e isa Expr
             coperators(e)
         end
+    end
+    if expr.head == :call && expr.args[1] isa Symbol
+        expr.args[1] = get(c_safe_function_renames, expr.args[1], expr.args[1])
     end
     for i in eachindex(expr.args)
         if expr.args[i] isa Rational

--- a/test/build_targets.jl
+++ b/test/build_targets.jl
@@ -70,6 +70,22 @@ let
 end
 
 
+# Safe solver functions (ssqrt/scbrt/slog) must map to their math.h names in C
+# (https://github.com/JuliaSymbolics/Symbolics.jl/issues/1873)
+let
+    @variables y
+    expression = (1//2) * Symbolics.term(Symbolics.ssqrt, 4y) +
+                 Symbolics.term(Symbolics.scbrt, y) + Symbolics.term(Symbolics.slog, y)
+    cfunc = build_function([expression], y; target = Symbolics.CTarget(), expression = Val{true})
+
+    @test occursin("sqrt(", cfunc)
+    @test occursin("cbrt(", cfunc)
+    @test occursin("log(", cfunc)
+    @test !occursin("ssqrt", cfunc)
+    @test !occursin("scbrt", cfunc)
+    @test !occursin("slog", cfunc)
+end
+
 # Matrix StanTarget test
 let
     @variables x[1:4] y[1:4] z[1:4]


### PR DESCRIPTION
## Summary

Fixes #1873.

`symbolic_solve` returns roots built with the solver's "safe" math functions `ssqrt`/`scbrt`/`slog` (defined in `src/solver/solve_helpers.jl`), which handle negative/complex inputs in Julia. When such an expression is passed to `build_function(...; target = CTarget())`, the operator names were emitted verbatim:

```c
#include <math.h>
void diffeqf(double* du, const double RHS1) {
  du[0] = 0.5 * ssqrt(4 * RHS1 * 1);   // ssqrt does not exist in math.h
}
```

`ssqrt`/`scbrt`/`slog` are not part of `math.h`, so the generated C fails to compile.

## Change

In `coperators` (the C-specific expression filter), rename these operators back to their standard `math.h` equivalents `sqrt`/`cbrt`/`log`. After the fix:

```c
#include <math.h>
void diffeqf(double* du, const double RHS1) {
  du[0] = 0.5 * sqrt(4 * RHS1 * 1);
}
```

I verified the generated C compiles with `gcc`, and confirmed the existing `matrix.c` / `scalar2.c` reference outputs are unchanged by this change.

## Tests

Added a regression test in `test/build_targets.jl` building a CTarget function from an expression containing all three safe functions and asserting the output uses `sqrt`/`cbrt`/`log` and none of `ssqrt`/`scbrt`/`slog`.

Note: the unnecessary `* 1` factors are tracked separately per the issue and are not addressed here.

---

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)