### PR TITLE
Make order-dependent build-target & latexify reference tests order-invariant

### DIFF
--- a/test/build_targets.jl
+++ b/test/build_targets.jl
@@ -1,15 +1,65 @@
 using Symbolics, Test
 using ReferenceTests
 
+# The ordering of operands within commutative `+` and `*` in the generated code
+# follows SymbolicUtils' argument sorting, which is benign but has changed across
+# versions (e.g. `a * b` vs `b * a`). To keep these tests stable across the CI
+# Julia/SymbolicUtils matrix we compare structure modulo that ordering rather than
+# byte-for-byte against a reference file. This mirrors the scalar Stan/MATLAB
+# tests further down, which were already converted for the same reason.
+function normalize_terms(rhs)
+    summands = map(strip, split(rhs, " + "))
+    canonical = map(summands) do summand
+        join(sort(map(strip, split(summand, " * "))), " * ")
+    end
+    return sort(canonical)
+end
+
 @variables t a x(t) y(t)
 expr = [a*x - x*y,-3y + x*y]
-@test_reference "target_functions/1.stan" Symbolics.build_function(expr,[x,y],[a],t,target = Symbolics.StanTarget())
 
-@test_reference "target_functions/1.c" Symbolics.build_function(expr,[x,y],[a],t,target = Symbolics.CTarget(),
+# StanTarget structural test (was target_functions/1.stan)
+let
+    sfunc = Symbolics.build_function(expr,[x,y],[a],t,target = Symbolics.StanTarget())
+    @test occursin("vector diffeqf(real t,vector internal_var___u,vector internal_var___p)", sfunc)
+    @test occursin("vector[2] internal_var___du;", sfunc)
+    @test occursin("return internal_var___du;", sfunc)
+    m1 = match(r"internal_var___du\[1\] = (.+);", sfunc)
+    m2 = match(r"internal_var___du\[2\] = (.+);", sfunc)
+    @test m1 !== nothing && m2 !== nothing
+    @test normalize_terms(m1[1]) ==
+        normalize_terms("internal_var___p[1] * internal_var___u[1] + -1 * internal_var___u[1] * internal_var___u[2]")
+    @test normalize_terms(m2[1]) ==
+        normalize_terms("-3 * internal_var___u[2] + internal_var___u[1] * internal_var___u[2]")
+end
+
+# CTarget structural test (was target_functions/1.c)
+let
+    cfunc = Symbolics.build_function(expr,[x,y],[a],t,target = Symbolics.CTarget(),
                                      lhsname=:internal_var___du,
                                      rhsnames=[:internal_var___u,:internal_var___p,:t])
+    @test occursin("#include <math.h>", cfunc)
+    @test occursin("void diffeqf(double* internal_var___du, const double* internal_var___u, const double* internal_var___p, const double t)", cfunc)
+    m1 = match(r"internal_var___du\[0\] = (.+);", cfunc)
+    m2 = match(r"internal_var___du\[1\] = (.+);", cfunc)
+    @test m1 !== nothing && m2 !== nothing
+    @test normalize_terms(m1[1]) ==
+        normalize_terms("internal_var___p[0] * internal_var___u[0] + -1 * internal_var___u[0] * internal_var___u[1]")
+    @test normalize_terms(m2[1]) ==
+        normalize_terms("-3 * internal_var___u[1] + internal_var___u[0] * internal_var___u[1]")
+end
 
-@test_reference "target_functions/1.m" Symbolics.build_function(expr,[x,y],[a],t,target = Symbolics.MATLABTarget())
+# MATLABTarget structural test (was target_functions/1.m)
+let
+    mfunc = Symbolics.build_function(expr,[x,y],[a],t,target = Symbolics.MATLABTarget())
+    @test occursin("diffeqf = @(internal_var___t,internal_var___u)", mfunc)
+    rows = [m[1] for m in eachmatch(r"([^\[\];\n]+);", mfunc)]
+    @test length(rows) == 2
+    @test normalize_terms(rows[1]) ==
+        normalize_terms("internal_var___p(1) * internal_var___u(1) + -1 * internal_var___u(1) * internal_var___u(2)")
+    @test normalize_terms(rows[2]) ==
+        normalize_terms("-3 * internal_var___u(2) + internal_var___u(1) * internal_var___u(2)")
+end
 
 @test Symbolics.build_function(expr,[x,y],[a],t,target = Symbolics.CTarget(),
                                      lhsname=:internal_var___du,

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -47,7 +47,21 @@ Dy = Differential(y)
 
 @test_reference "latexify_refs/equation1.txt" latexify(x ~ y + z)
 @test_reference "latexify_refs/equation2.txt" latexify(x ~ Dx(y + z))
-@test_reference "latexify_refs/equation5.txt" latexify(AA^2 + AA + 1 + X₁)
+
+# The relative order of the two degree-1 terms AA(x) and X₁(x) in this sum is
+# decided by SymbolicUtils' hash-based tie-break, which differs across Julia
+# versions, so no single reference string passes on all of them. Compare the set
+# of additive terms instead of the exact rendered string. (was equation5.txt)
+let
+    body = strip(replace(string(latexify(AA^2 + AA + 1 + X₁)),
+                         "\\begin{equation}" => "", "\\end{equation}" => ""))
+    @test sort(strip.(split(body, " + "))) == sort([
+        "1",
+        "AA\\left( x \\right)",
+        "X_1\\left( x \\right)",
+        "\\left( AA\\left( x \\right) \\right)^{2}",
+    ])
+end
 
 @test_reference "latexify_refs/equation_vec1.txt" latexify(
     [

--- a/test/latexify_refs/equation5.txt
+++ b/test/latexify_refs/equation5.txt
@@ -1,3 +1,0 @@
-\begin{equation}
-1 + AA\left( x \right) + X_1\left( x \right) + \left( AA\left( x \right) \right)^{2}
-\end{equation}

--- a/test/target_functions/1.c
+++ b/test/target_functions/1.c
@@ -1,5 +1,0 @@
-#include <math.h>
-void diffeqf(double* internal_var___du, const double* internal_var___u, const double* internal_var___p, const double t) {
-  internal_var___du[0] = internal_var___p[0] * internal_var___u[0] + -1 * internal_var___u[0] * internal_var___u[1];
-  internal_var___du[1] = -3 * internal_var___u[1] + internal_var___u[0] * internal_var___u[1];
-}

--- a/test/target_functions/1.m
+++ b/test/target_functions/1.m
@@ -1,4 +1,0 @@
-diffeqf = @(internal_var___t,internal_var___u) [
-  internal_var___p(1) * internal_var___u(1) + -1 * internal_var___u(1) * internal_var___u(2);
-  -3 * internal_var___u(2) + internal_var___u(1) * internal_var___u(2);
-];

--- a/test/target_functions/1.stan
+++ b/test/target_functions/1.stan
@@ -1,6 +1,0 @@
-vector diffeqf(real t,vector internal_var___u,vector internal_var___p) {
-  vector[2] internal_var___du;
-  internal_var___du[1] = internal_var___p[1] * internal_var___u[1] + -1 * internal_var___u[1] * internal_var___u[2];
-  internal_var___du[2] = -3 * internal_var___u[2] + internal_var___u[1] * internal_var___u[2];
-  return internal_var___du;
-}


### PR DESCRIPTION
## Summary

Fixes order-dependent reference-test failures on current stable CI (Julia 1.12). Two independent reference tests compared generated output byte-for-byte against stored files, but the output's commutative operand ordering comes from SymbolicUtils' (hash-based) argument sort, which differs across Julia versions — so the stored references no longer match.

### 1. `Build Targets Test` — `target_functions/1.{stan,c,m}`

Built from `expr = [a*x - x*y, -3y + x*y]`. The references have `u[1] * u[2]` while current output emits `u[2] * u[1]` (commutative `*` factor order). I confirmed this ordering is deterministic within the current stack (identical across repeated processes and across 1.10/1.11) — the references are simply stale.

Replaced the three `@test_reference` checks with structural checks asserting the function signature, output indices, coefficients, operators, and exact per-equation term sets, normalizing away commutative `+`/`*` ordering via a small `normalize_terms` helper (a stray `* 1` or wrong index/coefficient still fails). This mirrors the scalar Stan/MATLAB tests already converted in this file for the same reason. Orphaned `1.{stan,c,m}` reference files removed.

### 2. `Latexify Test` — `latexify_refs/equation5.txt`

`latexify(AA^2 + AA + 1 + X₁)` orders the two degree-1 terms `AA(x)`/`X₁(x)` by a hash-based tie-break. I reproduced the rendered output locally:

| Julia | output |
|-------|--------|
| 1.10  | `1 + X_1 + AA + AA^2` |
| 1.11  | `1 + AA + X_1 + AA^2` ← stored reference |
| 1.12  | `1 + X_1 + AA + AA^2` |

So **no single reference string passes on all three** — updating the file would just move the failure to 1.11. Replaced it with a comparison of the set of additive terms (still verifies every term renders correctly). Orphaned `equation5.txt` removed. This test was introduced recently in #1874.

The exact-output reference tests with no reorderable operands (`matrix.{c,stan,m}`, `scalar2.c`, and all other latexify refs) are left untouched.

## Verification (run locally)

- `test/build_targets.jl`: **42/42** on Julia 1.10 and 1.11.
- `test/latexify.jl`: **38/38** on Julia 1.10 and 1.12.

(Both files previously aborted on the first stale reference comparison.)

---

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)