### PR TITLE
Fix remaining CI failures: downstream MATLAB ordering & SymPy PyCall setup

### DIFF
--- a/src/diffeqs/diffeqs.jl
+++ b/src/diffeqs/diffeqs.jl
@@ -329,7 +329,12 @@ function integrating_factor_solve(eq::SymbolicLinearODE)
     end
     solution = (1 / v) * ((SymbolicUtils._iszero(eq.q) ? 0 : sympy_integrate(eq.q * v, eq.t)) + eq.C[1])
 
-    if !isempty(Symbolics.get_variables(solution, variable(:Integral)))
+    # When SymPy cannot find a closed form it returns an unevaluated `Integral(...)`,
+    # which has no usable symbolic solution. That term comes back as an operation
+    # (not a variable), so the previous `get_variables(:Integral)` check never fired
+    # and the unevaluated integral was silently mangled into a wrong answer by the
+    # `sympy_simplify` below. Detect it on the printed form and bail out instead.
+    if occursin("Integral", string(solution))
         return nothing
     end
     return expand(Symbolics.sympy_simplify(solution))

--- a/test/downstream/ParameterizedFunctions_MATLAB.jl
+++ b/test/downstream/ParameterizedFunctions_MATLAB.jl
@@ -15,6 +15,18 @@ function _matlab_lotka_volterra_expected(sys, a, b, c, d)
         "];\n"
 end
 
+# The order of operands within commutative `*` (and `+`) follows SymbolicUtils'
+# argument sort, which is benign but version-dependent (e.g. `u(1) * u(2)` vs
+# `u(2) * u(1)`). Compare the two RHS rows modulo that ordering so the test is
+# stable across the CI Julia matrix, mirroring the build_targets tests.
+function _normalize_matlab(matstr)
+    rows = [m[1] for m in eachmatch(r"([^\[\];\n]+);", matstr)]
+    return map(rows) do row
+        summands = sort(map(strip, split(row, " + ")))
+        join(map(s -> join(sort(strip.(split(s, " * "))), " * "), summands), " + ")
+    end
+end
+
 ### Capture MATLABDiffEq.jl type issues
 @independent_variables t
 @parameters a b c d
@@ -27,7 +39,7 @@ equations(sys)
 matstr = Symbolics.build_function(map(x->x.rhs,equations(sys)),unknowns(sys),
                                         parameters(sys),ModelingToolkit.get_iv(sys),
                                         target = ModelingToolkit.MATLABTarget())
-@test matstr == _matlab_lotka_volterra_expected(sys, a, b, c, d)
+@test _normalize_matlab(matstr) == _normalize_matlab(_matlab_lotka_volterra_expected(sys, a, b, c, d))
 
 f = @ode_def_bare LotkaVolterra begin
   dx = a*x - b*x*y
@@ -47,5 +59,5 @@ matstr = Symbolics.build_function(map(x->x.rhs,equations(sys)),unknowns(sys),
 # order), so look them up by name from the resulting system.
 let ps = parameters(sys)
     a2, b2, c2, d2 = ps[1], ps[2], ps[3], ps[4]
-    @test matstr == _matlab_lotka_volterra_expected(sys, a2, b2, c2, d2)
+    @test _normalize_matlab(matstr) == _normalize_matlab(_matlab_lotka_volterra_expected(sys, a2, b2, c2, d2))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,19 @@ end
 function activate_sympy_env()
     Pkg.activate("sympy")
     Pkg.develop(PackageSpec(path=dirname(@__DIR__)))
+    # Point PyCall at the Conda.jl Python *before* instantiation precompiles
+    # SymbolicsSymPyExt. SymPy.jl's `pyimport_conda` can then install the `sympy`
+    # module into that Python. Doing this only inside sympy.jl is too late: PyCall
+    # reads its Python config at load/precompile time, so the extension would
+    # already have failed to precompile against a system Python that lacks sympy
+    # (as happens on the CI runners).
+    if get(ENV, "CI", nothing) !== nothing
+        ENV["PYTHON"] = ""
+    end
     Pkg.instantiate()
+    if get(ENV, "CI", nothing) !== nothing
+        Pkg.build("PyCall")
+    end
 end
 
 function activate_sympy_pythoncall_env()


### PR DESCRIPTION
## Summary

Fixes the remaining failing CI jobs on `master` (other than the `Core` reference tests handled in #1878).

### 1. `test (Downstream, 1)` — MATLAB target regression test

`test/downstream/ParameterizedFunctions_MATLAB.jl` compared the generated MATLAB string byte-for-byte. The order of operands within a commutative `*` follows SymbolicUtils' argument sort, which is benign but version-dependent: the expected string has `u(1) * u(2)` while current stable Julia (1.12) emits `u(2) * u(1)`. (The test already looked up parameter indices to stay stable across parameter reorderings — this extends the same robustness to factor ordering.)

Fix: compare the two RHS rows modulo commutative `+`/`*` operand ordering (mirrors the build_targets tests from #1878).

**Verified:** passes locally **2/2 on Julia 1.12**, and the **`Downstream` CI job is green** on this PR.

### 2. `test (SymPy, 1)` — PyCall/sympy precompilation

The SymPy group failed with `ModuleNotFoundError: No module named 'sympy'`. PyCall defaulted to the runner's system Python (`/usr/bin/python3`), which has no sympy, so `SymbolicsSymPyExt` failed to precompile. `sympy.jl` already tried `ENV["PYTHON"]=""` + `Pkg.build("PyCall")` to switch to the Conda.jl Python, but it ran *after* `Pkg.instantiate()` had already precompiled the extension against the system Python — too late, since PyCall's Python is fixed at load time.

Fix: set `ENV["PYTHON"]=""` *before* instantiation in `activate_sympy_env` (CI only), so PyCall builds against the Conda Python and SymPy's `pyimport_conda` installs sympy. CI logs confirm this now works (`Installing sympy via the Conda sympy package... sympy-1.14.0`, extension precompiles).

### 3. SymPy solver bug uncovered by fix #2 (`sympy.jl:97`)

Fixing the precompilation exposed a latent correctness bug that had been masked by the precompile failure. `integrating_factor_solve` guarded against SymPy returning an unevaluated `Integral(...)` with `get_variables(solution, variable(:Integral))` — but the unevaluated integral comes back as an *operation*, not a *variable*, so the guard never fired and `sympy_simplify` mangled it into a **wrong** closed form.

Concretely `symbolic_solve_ode(Dt(x) + sqrt(t)*x ~ sin(4t)*x^3, x, t)` returned `1/sqrt(-2sin(4t) + C₁*exp((4//3)*t^(3//2)))` (which does **not** satisfy the ODE — I verified the residual is non-zero) instead of `nothing`.

Fix: detect the unevaluated integral on the printed form of the solution and return `nothing`, so such ODEs correctly report no closed-form solution.

**Verified:** `test/sympy.jl` passes locally **16 passed / 1 broken (pre-existing) / 0 failed** on Julia 1.12 with sympy 1.14.0, against a dev build of this branch (the solvable Bernoulli cases still solve correctly — no regression).

## Not addressed here

- **`benchmark`**: this job's benchmarks run fine; only the final *PR-comment* step fails with `403 Resource not accessible by integration`, because `GITHUB_TOKEN` is read-only for **fork PRs** (a GitHub security restriction, independent of the `permissions:` block). It does not run on `master` and is not a code/test failure, so I left the workflow unchanged rather than risk masking real benchmark regressions. It will show red on this PR for the same fork-token reason.

---

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)