### PR TITLE
Use unambiguous variable on `@register` macros

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -40,12 +40,13 @@ macro register_symbolic(expr, define_promotion = true, wrap_arrays = true)
 
     if define_promotion
         type_args = [:($name::$Type) for name in argnames]
+        T = type_T_tag(f,argnames)
         promote_expr = quote
             if $ftype === DataType || $ftype === Union || $ftype === UnionAll
-                function (::$typeof($promote_symtype))(::Type{T}, $(type_args...)) where {T <: $f}
+                function (::$typeof($promote_symtype))(::Type{$T}, $(type_args...)) where {$T <: $f}
                     $ret_type
                 end
-                function (::$(typeof(SymbolicUtils.promote_shape)))(::Type{T}, args::$(SymbolicUtils.ShapeT)...) where {T <: $f}
+                function (::$(typeof(SymbolicUtils.promote_shape)))(::Type{$T}, args::$(SymbolicUtils.ShapeT)...) where {$T <: $f}
                     @nospecialize args
                     $(SymbolicUtils.ShapeVecT)()
                 end
@@ -88,6 +89,18 @@ function destructure_registration_expr(expr)
         :($typeof($f))
     end
     f, ftype, argnames, Ts, ret_type
+end
+
+function type_T_tag(f,argnames)
+    T = :T
+    for i in 1:length(argnames) + 1
+        if T == f || T in argnames
+            T = Symbol(:_,T)
+        else
+            break
+        end
+    end
+    return T
 end
 
 nested_unwrap(x) = unwrap(x)
@@ -184,12 +197,13 @@ function register_array_symbolic(f, ftype, argnames, Ts, ret_type, partial_defs 
             $shape_expr
             return sh
         end
+        T = type_T_tag(f,argnames)
         promote_expr = quote
             if $ftype === DataType || $ftype === Union || $ftype === UnionAll
-                function (::$typeof($promote_symtype))(::Type{T}, $(type_args...)) where {T <: $f}
+                function (::$typeof($promote_symtype))(::Type{$T}, $(type_args...)) where {$T <: $f}
                     $promote_symtype_body
                 end
-                function (::$(typeof(SymbolicUtils.promote_shape)))(::Type{T}, $(shape_args...)) where {T <: $f}
+                function (::$(typeof(SymbolicUtils.promote_shape)))(::Type{$T}, $(shape_args...)) where {$T <: $f}
                     $promote_shape_body
                 end
             else

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -196,9 +196,10 @@ end
 n = 2
 A = randn(n, n)
 foo(x) = A * x # a function to represent symbolically, note, if this function is defined inside the testset, it's not found by the function fun_eval = eval(fun_ex)
-@register_array_symbolic foo(x::Vector{Real}) begin
+#we use T instead of x to test #1882
+@register_array_symbolic foo(T::Vector{Real}) begin
     size = (n,)
-    eltype = eltype(x)
+    eltype = eltype(T)
     ndims = 1
 end
 

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -443,7 +443,7 @@ end
 @testset "`@register_symbolic` edge cases" begin
     @register_symbolic foo1(x::AbstractArray)
     @register_symbolic foo1(x::AbstractArray{Int})
-    @register_symbolic foo1(x::AbstractVector{Int})
+    @register_symbolic foo1(T::AbstractVector{Int})
 end
 
 @testset "`@register_array_symbolic` works without size" begin


### PR DESCRIPTION
https://github.com/JuliaSymbolics/Symbolics.jl/pull/1874 introduced a regression, because a fixed variable `T` was used inside the function declarations. If an user happens to register a function using `T` as a variable, then the register macro fails.

This PR adds a helper function that generates a symbol that does not clash with f or any of the argument names. and uses that symbol for the expressions `f(::T) where T`.


modifies some tests to use `T` as a variable instead of `x`.

should fix #1882 