### PR TITLE
test: unbreak three now-passing GroebnerExt `@test_broken` cases

### DIFF
--- a/test/extensions/groebner.jl
+++ b/test/extensions/groebner.jl
@@ -51,12 +51,11 @@ truebasis = [
     x5^5 - 1
 ]
 basis = expand.(groebner_basis(system))
-# monomial order can change, returning different but still valid bases
-@test_broken isequal(basis, truebasis)
+@test isequal(basis, truebasis)
 @test Symbolics.is_groebner_basis(basis)
 
 basis = expand.(groebner_basis(system, linalg=:deterministic))
-@test_broken isequal(basis, truebasis)
+@test isequal(basis, truebasis)
 @test Symbolics.is_groebner_basis(basis)
 
 N = 45671930739135174346839766056203605080877915151
@@ -73,7 +72,7 @@ truebasis = [
     x4^4 - N
 ]
 basis = expand.(groebner_basis(system))
-@test_broken isequal(expand.(basis), truebasis)
+@test isequal(expand.(basis), truebasis)
 @test Symbolics.is_groebner_basis(basis)
 
 # issues/1323


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

## Summary

Fixes the `test (GroebnerExt, 1)` CI job, which is **currently red on `master`**.

Three `@test_broken` assertions in `test/extensions/groebner.jl` now *pass*: `groebner_basis` returns the canonical monomial ordering matching the hand-written `truebasis`. This changed with #1860-era commit `fdb8a83` ("refactor: remove usages of `Polyform`"), which rewrote `symbol_to_poly` to use SymbolicUtils's `to_poly!`/`PolyVarT` API and thereby changed the internal variable ordering fed to Groebner. The `@test_broken` markers (added in `6a7fa15` with the comment "monomial order can change, returning different but still valid bases") are now stale, and Julia's `Test` reports an unexpectedly-passing `@test_broken` as an error — failing the whole `GroebnerExt` testset.

This promotes the three now-passing cases to `@test` and drops the obsolete comment. The constant-ideal case `@test_broken groebner_basis([1])` is genuinely still broken and is left as-is.

## Verification

Not a dependency regression — confirmed `isequal(basis, truebasis)` is `true` on both the Groebner.jl compat floor (0.8.2 / AbstractAlgebra 0.43 / Nemo 0.47) and latest (0.10.3 / AbstractAlgebra 0.48 / Nemo 0.54).

Ran the group locally:
```
GROUP=GroebnerExt julia --project=. -e 'using Pkg; Pkg.test("Symbolics")'
# Groebner extension Test | 27 Pass, 1 Broken, 28 Total  ->  Testing Symbolics tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
