### PR TITLE
test: `ifelse_branching` shares one `if`/`else` across references (needs SymbolicUtils 4.36)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -114,7 +114,7 @@ SymPy = "2.2"
 SymPyPythonCall = "0.5"
 SymbolicIndexingInterface = "0.3.14"
 SymbolicLimits = "0.2.2, 1.1"
-SymbolicUtils = "4.36"
+SymbolicUtils = "4.37"
 TermInterface = "2"
 julia = "1.10"
 

--- a/Project.toml
+++ b/Project.toml
@@ -114,7 +114,7 @@ SymPy = "2.2"
 SymPyPythonCall = "0.5"
 SymbolicIndexingInterface = "0.3.14"
 SymbolicLimits = "0.2.2, 1.1"
-SymbolicUtils = "4.35"
+SymbolicUtils = "4.36"
 TermInterface = "2"
 julia = "1.10"
 

--- a/test/conditionals.jl
+++ b/test/conditionals.jl
@@ -49,6 +49,24 @@ end
     end
 end
 
+# Counts how many times it is evaluated; used to detect duplicated computation.
+const FIRE_COUNT = Ref(0)
+fire(v) = (FIRE_COUNT[] += 1; v)
+Symbolics.@register_symbolic fire(v)
+
+@testset "multiply-referenced ifelse_branching is computed once under CSE" begin
+    z = ifelse_branching(x > 0, fire(x)^2, boom(x))
+    f = build_function(sin(z) + cos(z), x; expression = Val{false}, cse = true)
+    FIRE_COUNT[] = 0
+    @test f(2.0) == sin(4.0) + cos(4.0)
+    @test FIRE_COUNT[] == 1     # the shared `if`/`else` ran once; `boom` not at all
+
+    fvec = build_function([sin(z), cos(z)], x; expression = Val{false}, cse = true)[1]
+    FIRE_COUNT[] = 0
+    @test fvec(2.0) == [sin(4.0), cos(4.0)]
+    @test FIRE_COUNT[] == 1
+end
+
 @testset "ifelse_eager evaluates both branches" begin
     for cse in (true, false)
         f = build_function(


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

## Summary

Follow-up to #1887. Adds a regression test that a **multiply-referenced `ifelse_branching` is computed once** under CSE (on both the scalar and array codegen paths), while the untaken branch still never evaluates. The sharing itself is implemented in SymbolicUtils via the new `Code.cse_bind_expr` hook — see the companion SymbolicUtils PR — which binds the conditional node to a shared temporary while leaving its branch interiors un-CSEd (lazy).

Bumps the `SymbolicUtils` compat to `4.36` accordingly.

**Blocked on the SymbolicUtils `cse_bind_expr` PR being merged and released as 4.36** — CI here stays red until then. Verified locally by `dev`-ing that branch: the full `test/conditionals.jl` passes, including the new testset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
