### PR TITLE
perf: avoid re-hashconsing unchanged addends in linear_expansion

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -347,19 +347,37 @@ function (lex::LinearExpander)(t::SymbolicT)
         BSImpl.AddMul(; coeff, dict, variant, type, shape) => begin
             cf = Const{VartypeT}(coeff)
             if variant === SymbolicUtils.AddMulVariant.ADD
+                # `t = coeff + Σ v*k` with each `k = a_k*x + b_k`. Addends free of
+                # `x` have `a_k == 0` and `b_k === k`, so keep them in the original
+                # dict and only splice in the ones that change, instead of re-summing
+                # (re-hashconsing) every addend.
                 a_buffer = SArgsT()
-                b_buffer = SArgsT()
+                b_newdict = dict
+                b_extras = SArgsT()
+                b_dirty = false
                 for (k, v) in dict
                     a, b, islin = _linear_expansion_recurse(lex, k)
                     islin || return (COMMON_ZERO, COMMON_ZERO, false)
-                    push!(a_buffer, a * v)
-                    push!(b_buffer, b * v)
+                    if _iszero(a) && isequal(b, k)
+                        continue
+                    end
+                    if !b_dirty
+                        b_newdict = copy(dict)
+                        b_dirty = true
+                    end
+                    delete!(b_newdict, k)
+                    _iszero(a) || push!(a_buffer, a * v)
+                    _iszero(b) || push!(b_extras, b * v)
                 end
-                if !_iszero(coeff)
-                    push!(b_buffer, cf)
+                a = isempty(a_buffer) ? COMMON_ZERO : SymbolicUtils.add_worker(VartypeT, a_buffer)
+                if !b_dirty
+                    return a, t, true
                 end
-                a = SymbolicUtils.add_worker(VartypeT, a_buffer)
-                b = SymbolicUtils.add_worker(VartypeT, b_buffer)
+                b = SymbolicUtils.Add{VartypeT}(coeff, b_newdict; type, shape)
+                if !isempty(b_extras)
+                    push!(b_extras, b)
+                    b = SymbolicUtils.add_worker(VartypeT, b_extras)
+                end
                 return a, b, true
             else
                 a = COMMON_ZERO


### PR DESCRIPTION
Mostly made by Claude

When expanding an `Add` w.r.t. `x`, keep addends that don't contain `x`
in the original dict instead of recomputing `v*k` and re-summing every
term.

A benchmark (with before and after numbers) is:

```julia
using Symbolics, BenchmarkTools

const N = 1000
@variables x y[1:N]

# 1000 terms with no x, plus a single 3x term and a constant
big_sum = sum(i * y[i] for i in 1:N) + 3x + 5

a, b, islin = Symbolics.linear_expansion(big_sum, x)   # a == 3, b ==
big_sum - 3x

@btime Symbolics.linear_expansion($big_sum, $x)

# Before
#  2.999 ms (60971 allocations: 2.10 MiB)
# After
#  574.185 μs (7105 allocations: 467.55 KiB)
```