### PR TITLE
LinearExpander: removed unused variable

### DIFF
--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -345,7 +345,6 @@ function (lex::LinearExpander)(t::SymbolicT)
     @match t begin
         BSImpl.Term(; f) && if f isa Operator end => throw_bad_expansion()
         BSImpl.AddMul(; coeff, dict, variant, type, shape) => begin
-            cf = Const{VartypeT}(coeff)
             if variant === SymbolicUtils.AddMulVariant.ADD
                 # `t = coeff + Σ v*k` with each `k = a_k*x + b_k`. Addends free of
                 # `x` have `a_k == 0` and `b_k === k`, so keep them in the original


### PR DESCRIPTION
This causes some unnecessary allocations