### PR TITLE
add fastpaths for `zero`/`one` for `Num`

### DIFF
--- a/src/num.jl
+++ b/src/num.jl
@@ -216,6 +216,13 @@ Base.nameof(n::Num) = nameof(value(n))
 Base.iszero(x::Num) = SymbolicUtils._iszero(unwrap(x))
 Base.isone(x::Num) = SymbolicUtils._isone(unwrap(x))
 
+const COMMON_ZERO_NUM = Num(COMMON_ZERO)
+const COMMON_ONE_NUM = Num(COMMON_ONE)
+Base.zero(::Num) = COMMON_ZERO_NUM
+Base.zero(::Type{Num}) = COMMON_ZERO_NUM
+Base.one(::Num) = COMMON_ONE_NUM
+Base.one(::Type{Num}) = COMMON_ONE_NUM
+
 import SymbolicUtils: <ₑ, Term, operation, arguments
 
 function Base.show(io::IO, n::Num)


### PR DESCRIPTION
I saw this in a profile where `zero(Num)` was recomputed over and over:

```
╎    ╎     49   @StateSelection/src/math/sparsematrixclil.jl:357  getindex
    ╎    ╎    ╎ 49   @Base/number.jl:314  zero
    ╎    ╎    ╎  49   @Base/number.jl:7  convert
    ╎    ╎    ╎   49   @Symbolics/src/num.jl:16  Num
    ╎    ╎    ╎    49   @SymbolicUtils/src/safe_ctors.jl:15  Const
```