### PR TITLE
`_depends_on`: avoid looking up `COMPARE_FULL` in every iteration and directly call `isequal_bsimpl`

### DIFF
--- a/src/diff.jl
+++ b/src/diff.jl
@@ -691,10 +691,11 @@ All other keyword arguments are forwarded to `expand_derivatives`.
 # because it is a function whose arguments contain `v`.
 function _depends_on(varset::Set{SymbolicT}, v::SymbolicT)
     v in varset && return true
+    full = SymbolicUtils.COMPARE_FULL[]
     for s in varset
         if SymbolicUtils.iscall(s)
             for arg in SymbolicUtils.arguments(s)
-                isequal(arg, v) && return true
+                SymbolicUtils.isequal_bsimpl(arg, v, full) && return true
             end
         end
     end


### PR DESCRIPTION
For a benchmark like

```julia
using Symbolics, BenchmarkTools
const SU = SymbolicUtils
@variables t

# Build N distinct time-dependent (call) variables x_i(t), like a search_variables result.
function mkvar(i)
    nm = Symbol("x", i)
    ex = Expr(:macrocall, Symbol("@variables"), LineNumberNode(0, :mwe), Expr(:call, nm, :t))
    Symbolics.unwrap(only(Core.eval(Main, ex)))
end

N = 60
vars   = [mkvar(i) for i in 1:N]
varset = Set{Symbolics.SymbolicT}(vars)

absent  = mkvar(N + 1)   # not in varset  -> full scan (N comparisons; TLV cost amplified)
present = vars[end]      # in varset      -> early `v in varset` return (control)

dep = Symbolics._depends_on
@assert dep(varset, present) == true
@assert dep(varset, absent)  == false

println("N = $N variables in varset")
print("absent probe  (full scan)  : "); @btime dep($varset, $absent)
print("present probe (early ret)  : "); @btime dep($varset, $present)
```

This gives:

```
# Before
N = 60 variables in varset
absent probe  (full scan)  :   1.241 μs (1 allocation: 16 bytes)
present probe (early ret)  :   24.878 ns (1 allocation: 16 bytes)

# After
N = 60 variables in varset
absent probe  (full scan)  :   876.700 ns (1 allocation: 16 bytes)
present probe (early ret)  :   32.774 ns (1 allocation: 16 bytes)
```