### PR TITLE
perf: improve performance of `jacobian` by making the dependency checks more efficient

### DIFF
--- a/src/diff.jl
+++ b/src/diff.jl
@@ -687,38 +687,34 @@ an array of variable expressions.
 
 All other keyword arguments are forwarded to `expand_derivatives`.
 """
-# Check if any variable in `varset` depends on `v`, either directly or
-# because it is a function whose arguments contain `v`.
-function _depends_on(varset::Set{SymbolicT}, v::SymbolicT)
-    v in varset && return true
-    full = SymbolicUtils.COMPARE_FULL[]
-    for s in varset
-        if SymbolicUtils.iscall(s)
-            for arg in SymbolicUtils.arguments(s)
-                SymbolicUtils.isequal_bsimpl(arg, v, full) && return true
-            end
-        end
-    end
-    return false
-end
-
 function jacobian(ops::AbstractVector, vars::AbstractVector{SymbolicT};
                   simplify=false, scalarize::Union{Val{true}, Val{false}}=Val(true), kwargs...)
     if scalarize isa Val{true}
         ops = Symbolics.scalarize(ops)
         vars = Symbolics.scalarize(vars)
     end
-    # Pre-compute variable sets to skip differentiating trivially zero Jacobian entries
-    op_varsets = Vector{Set{SymbolicT}}(undef, length(ops))
-    for i in eachindex(ops)
-        op_varsets[i] = SymbolicUtils.search_variables(ops[i])
-    end
+    # Pre-compute variable sets to skip differentiating trivially zero Jacobian entries.
+    op_varsets = map(op -> _augment_with_call_args!(SymbolicUtils.search_variables(op)), ops)
     result = fill(COMMON_ZERO, length(ops), length(vars))
     for i in eachindex(ops), j in eachindex(vars)
-        _depends_on(op_varsets[i], vars[j]) || continue
+        (vars[j] in op_varsets[i]) || continue
         result[i, j] = executediff(Differential(vars[j]), ops[i]; simplify, kwargs...)
     end
     return result
+end
+
+function _augment_with_call_args!(vs)
+    extra = SymbolicT[]
+    for s in vs
+        SymbolicUtils.iscall(s) || continue
+        for arg in SymbolicUtils.arguments(s)
+            push!(extra, arg)
+        end
+    end
+    for e in extra
+        push!(vs, e)
+    end
+    return vs
 end
 
 function jacobian(ops, vars; simplify=false, kwargs...)


### PR DESCRIPTION
This avoids many `isequal_bsimpl` calls, which are expensive, and moves it over to a hash lookup in the set (which is cheap). For a benchmark like:

```julia
using Symbolics
using BenchmarkTools

@variables t
n      = 200
window = 40

@variables (x(t))[1:n]
x = collect(x)

ops  = [sum(x[mod1(i + k, n)] for k in 0:window-1) for i in 1:n]
vars = x

J = Symbolics.jacobian(ops, vars)
@info "problem" size(J) nnz = count(!iszero, J) entries = prod(size(J))

@btime Symbolics.jacobian($ops, $vars)
```

This gives

```
# Before
  127.522 ms (1309832 allocations: 26.63 MiB)

# After
  53.320 ms (1310417 allocations: 27.01 MiB)
```