### PR TITLE
Fix stale undefined exports (`Variable`, `Unknown`)

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -29,7 +29,7 @@ import SymbolicUtils: Term, Add, Mul, Sym, Div, BasicSymbolic, Const,
     FnType, @rule, Rewriters, substitute, symtype, shape, unwrap, unwrap_const,
     promote_symtype, isadd, ismul, ispow, isterm, issym, isdiv, BSImpl, scalarize,
     Operator, _iszero, _isone, search_variables, search_variables!, ArgsT, ROArgsT,
-    ifelse_eager, ifelse_branching
+    ifelse_eager, ifelse_branching, Unknown
 import SymbolicUtils as SU
 
 using SymbolicUtils.Code
@@ -167,7 +167,7 @@ export @register_symbolic, @register_array_symbolic
 include("register.jl")
 
 using SparseArrays
-export @variables, Variable
+export @variables
 include("variable.jl")
 
 function slog end; function ssqrt end; function scbrt end


### PR DESCRIPTION
## Problem

`names(Symbolics)` currently lists two names that do not resolve in the module, so `Aqua.test_undefined_exports(Symbolics)` fails and a blanket `@reexport using Symbolics` leaks an undefined binding into downstream packages (this is what forced the workaround in [SciML/Corleone.jl#86](https://github.com/SciML/Corleone.jl/pull/86)).

On Julia 1.12 with Symbolics v7.28.1 / current master:

```julia
julia> using Symbolics
julia> filter(n -> !isdefined(Symbolics, n), names(Symbolics))
2-element Vector{Symbol}:
 :Unknown
 :Variable

julia> using Aqua
julia> Aqua.test_undefined_exports(Symbolics)   # FAILS
# Evaluated: isempty([Symbolics.Unknown, Symbolics.Variable])
```

## Root cause

- **`Variable`** is `export`ed at `src/Symbolics.jl:170`, but the `struct Variable{T} end` (a deprecated shim that redirected to `variable(name, idx...; T=T)`) was removed in 55a3d1ae9 ("refactor: use `@syms` parsing for `@variables`") without dropping it from the export list. The binding has not existed since.
- **`Unknown`** was marked `@public` in 5d78c7a41 ("refactor: mark `Unknown` as public"), but `SymbolicUtils.Unknown` was never brought into the `Symbolics` namespace, so the public name had nothing to resolve to. `SymbolicUtils` does not export `Unknown`, so `@reexport using SymbolicUtils` does not bring it in either.

## Fix

- Drop `Variable` from the `export` (the public replacement is `variable(...)`).
- Import `Unknown` alongside the other `SymbolicUtils` names so the `@public Unknown` resolves (`Symbolics.Unknown === SymbolicUtils.Unknown`). This matches how `Unknown` is already referenced throughout the source as `SymbolicUtils.Unknown`.

## Verification (Julia 1.12)

- Before: `Aqua.test_undefined_exports(Symbolics)` **fails** (`[Symbolics.Unknown, Symbolics.Variable]`).
- After: `Aqua.test_undefined_exports(Symbolics)` **passes**; `filter(n -> !isdefined(Symbolics, n), names(Symbolics))` is empty; `Symbolics.Unknown === SymbolicUtils.Unknown`; core smoke test (`@variables`, `derivative`, `variable(:z)`, `Unknown(2)`) still works.

Runic: the two changed lines are Runic-clean (sciml style). The file has unrelated pre-existing Runic drift in a precompile block near the bottom, which is left untouched to keep the diff minimal.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)