### PR TITLE
feat: Add `CodegenOptions` struct to avoid kwargs-driven recompilation in `codegen_function`

### DIFF
--- a/src/codegen_fn.jl
+++ b/src/codegen_fn.jl
@@ -37,12 +37,74 @@ function canonicalize_args(args::Vector, inbounds::Bool)
     end
 end
 
-function codegen_function(
-        ir::IRStructure{VartypeT}, expr, args::Vector;
+"""
+    CodegenFunctionOptions(; kwargs...)
+
+Bundle of options controlling code generation in [`codegen_function`](@ref).
+
+Historically `codegen_function` accepted these as a `kwargs...` splat. Threading a
+`kwargs...` bundle means every function that forwards codegen options gets specialized (and
+recompiled) once per distinct *set* of keyword arguments, even when the values it forwards
+are irrelevant to it. `CodegenFunctionOptions` is a single, non-parametric concrete type: no matter
+which options are set, its type is always `CodegenFunctionOptions`, so functions that thread it
+through only need to be compiled once.
+
+The keyword constructor mirrors the historical keyword arguments of `codegen_function`
+exactly, including their defaults. Unknown keyword arguments are ignored (as they were
+previously silently dropped by `codegen_function`), preserving backwards compatibility.
+
+Fields:
+
+- `nanmath`: rewrite math functions to their `NaN`-safe variants.
+- `wrap_code`: a 2-tuple of transformations applied to the out-of-place and in-place
+  `Func`s respectively.
+- `checkbounds`: emit bounds checks (when `false`, generated code is wrapped in
+  `@inbounds`).
+- `iip_config`: a 2-tuple of `Bool`s indicating whether to generate the out-of-place and
+  in-place functions respectively.
+- `sort_addmul`: sort the arguments of `+`/`*` for deterministic codegen.
+- `optimize`: optimization rules to apply, or `nothing`.
+- `similarto`: the array type (or name) to generate for array outputs, or `nothing` to
+  infer it.
+- `outputidxs`: explicit output indices for in-place array codegen, or `nothing`.
+- `skipzeros`: skip writing structural zeros in in-place array codegen.
+"""
+struct CodegenFunctionOptions
+    nanmath::Bool
+    wrap_code::Tuple
+    checkbounds::Bool
+    iip_config::NTuple{2, Bool}
+    sort_addmul::Bool
+    optimize::Any
+    similarto::Any
+    outputidxs::Any
+    skipzeros::Bool
+end
+
+function CodegenFunctionOptions(;
         nanmath::Bool = true, wrap_code::Tuple = (identity, identity),
-        checkbounds = false, iip_config::NTuple{2, Bool} = (true, true), sort_addmul = false,
-        optimize = nothing, kwargs...
+        checkbounds = false, iip_config::NTuple{2, Bool} = (true, true),
+        sort_addmul = false, optimize = nothing, similarto = nothing,
+        outputidxs = nothing, skipzeros = false, kwargs...
     )
+    return CodegenFunctionOptions(
+        nanmath, wrap_code, checkbounds, iip_config, sort_addmul, optimize,
+        similarto, outputidxs, skipzeros
+    )
+end
+
+# Backwards-compatible keyword entry point. Any function that still calls `codegen_function`
+# with keyword arguments continues to work; the options are bundled into a `CodegenFunctionOptions`
+# and dispatched to the struct-based methods below. Unknown keywords are dropped by the
+# `CodegenFunctionOptions` constructor, exactly as they were dropped by the old `kwargs...` sink.
+function codegen_function(ir::IRStructure{VartypeT}, expr, args::Vector; kwargs...)
+    return codegen_function(ir, expr, args, CodegenFunctionOptions(; kwargs...))
+end
+
+function codegen_function(
+        ir::IRStructure{VartypeT}, expr, args::Vector, opts::CodegenFunctionOptions
+    )
+    (; nanmath, wrap_code, checkbounds, iip_config, sort_addmul, optimize) = opts
     args = canonicalize_args(args, !checkbounds)
     rewrites = Dict()
     if nanmath
@@ -92,17 +154,17 @@ end
 
 function codegen_function(
         ir::IRStructure{VartypeT}, expr::Union{Arr, Num, CallAndWrap, SymStruct},
-        args::Vector; kwargs...
+        args::Vector, opts::CodegenFunctionOptions
     )
-    return codegen_function(ir, unwrap(expr), args; kwargs...)
+    return codegen_function(ir, unwrap(expr), args, opts)
 end
 
 function codegen_function(
-        ir::IRStructure{VartypeT}, expr::AbstractArray, args::Vector;
-        similarto = nothing, nanmath::Bool = true, wrap_code::Tuple = (identity, identity),
-        iip_config::NTuple{2, Bool} = (true, true), outputidxs = nothing,
-        skipzeros = false, checkbounds = false, optimize = nothing, sort_addmul = false, kwargs...
+        ir::IRStructure{VartypeT}, expr::AbstractArray, args::Vector,
+        opts::CodegenFunctionOptions
     )
+    (; similarto, nanmath, wrap_code, iip_config, outputidxs, skipzeros, checkbounds,
+        optimize, sort_addmul) = opts
     args = canonicalize_args(args, !checkbounds)
     rewrites = Dict()
     if nanmath

--- a/test/codegen_function.jl
+++ b/test/codegen_function.jl
@@ -286,3 +286,34 @@ end
     @test allequal(iipexprs)
 end
 
+
+@testset "`CodegenFunctionOptions` struct interface" begin
+    @variables a b c1 c2 c3 d e g
+    # `CodegenFunctionOptions` is a single concrete type regardless of which options are set, so
+    # functions that thread it through do not recompile per option-combination.
+    @test isconcretetype(Symbolics.CodegenFunctionOptions)
+    o1 = Symbolics.CodegenFunctionOptions(; nanmath = true)
+    o2 = Symbolics.CodegenFunctionOptions(;
+        nanmath = false, wrap_code = (x -> x, x -> x), checkbounds = true,
+        iip_config = (true, false), sort_addmul = true, skipzeros = true, optimize = nothing)
+    @test typeof(o1) === typeof(o2) === Symbolics.CodegenFunctionOptions
+
+    # scalar/vector path: keyword form and struct form are identical
+    kw = Symbolics.codegen_function(ir, [sqrt(a), sin(b)], [[a, b]]; nanmath = true, sort_addmul = true)
+    st = Symbolics.codegen_function(ir, [sqrt(a), sin(b)], [[a, b]],
+        Symbolics.CodegenFunctionOptions(; nanmath = true, sort_addmul = true))
+    @test string(kw) == string(st)
+
+    # array path: keyword form and struct form are identical
+    h = [a + b, c1 * c2, d / e]
+    args = [[a], [b], [c1, c2, c3], [d], [e], [g]]
+    kw2 = Symbolics.codegen_function(ir, h, args; skipzeros = true, checkbounds = true, sort_addmul = true)
+    st2 = Symbolics.codegen_function(ir, h, args,
+        Symbolics.CodegenFunctionOptions(; skipzeros = true, checkbounds = true, sort_addmul = true))
+    @test string(kw2) == string(st2)
+
+    # unknown keyword arguments are dropped (backwards compatible with the old `kwargs...` sink)
+    with_bogus = Symbolics.codegen_function(ir, [sqrt(a)], [[a]]; nanmath = true, sort_addmul = true, bogus = 42)
+    without = Symbolics.codegen_function(ir, [sqrt(a)], [[a]]; nanmath = true, sort_addmul = true)
+    @test string(with_bogus) == string(without)
+end


### PR DESCRIPTION
`codegen_function` accepted its options as a `kwargs...` splat and silently dropped any unconsumed keywords (a "kwarg leaf function"). Threading a `kwargs...` bundle means every function that forwards codegen options gets specialized and recompiled once per distinct *set* of keyword arguments, even when the forwarded values are irrelevant to it.

Introduce `CodegenOptions`, a single non-parametric concrete type bundling the historical keyword arguments. Functions that thread it through only need to be compiled once regardless of which options are set. Add struct-based primary methods `codegen_function(ir, expr, args, opts::CodegenOptions)`.

The existing keyword signature is retained as a thin, non-breaking wrapper that builds a `CodegenOptions` and forwards. Unknown keywords are still dropped by the constructor, exactly matching the previous behaviour.