### PR TITLE
Stabilize Symbolics polynomial variable order

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -481,21 +481,32 @@ function symbol_to_poly(sympolys::AbstractArray)
 
     # standardize input
     stdsympolys = map(unwrap, sympolys)
-    sort!(stdsympolys, lt=(<ₑ))
+    sort!(stdsympolys, lt = (<ₑ))
 
     symidx = findfirst(x -> x isa BasicSymbolic, stdsympolys)
     varT = vartype(stdsympolys[symidx])
 
     poly_to_bs = Bijections.Bijection{SymbolicUtils.PolyVarT, BasicSymbolic{varT}}()
     bs_to_poly = Bijections.active_inv(poly_to_bs)
+
+    vars = BasicSymbolic{varT}[]
+    for f in stdsympolys
+        append!(vars, get_variables(f))
+    end
+    unique!(vars)
+    sort!(vars, lt = (<ₑ))
+    for var in vars
+        SymbolicUtils.to_poly!(poly_to_bs, bs_to_poly, var)
+    end
+
     polyforms = map(f -> as_concrete_polynomial(SymbolicUtils.to_poly!(poly_to_bs, bs_to_poly, f)), stdsympolys)
     # Discover common coefficient type
-    commontype = mapreduce(coefftype, promote_type, polyforms, init=Int)
-    @assert commontype <: Union{Integer,Rational} "Only integer and rational coefficients are supported as input."
+    commontype = mapreduce(coefftype, promote_type, polyforms, init = Int)
+    @assert commontype <: Union{Integer, Rational} "Only integer and rational coefficients are supported as input."
 
     polynoms = map(Base.Fix1(poly_to_coefftype, commontype), polyforms)
 
-    polynoms, poly_to_bs
+    return polynoms, poly_to_bs
 end
 
 #=


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

This stabilizes `symbol_to_poly` by pre-seeding polynomial variables in canonical Symbolics variable order before converting full expressions through SymbolicUtils. That keeps Groebner `InputOrdering()` independent of internal `AddMul` dictionary traversal order.

## Root Cause

`SymbolicUtils` commit `d51e602d` changed `AddMul` storage from `OrderedDict` to `Dict`. The resulting hash-order traversal changed the DynamicPolynomials variable creation order from `[x1, x2, x3, x4, x5]` to `[x4, x2, x5, x3, x1]` for the GroebnerExt symmetric-polynomial test. The computed basis was still a valid Groebner basis, but the exact Symbolics regression checks expected the previous variable ordering.

## Validation

- Reproduced current failure before this change with `GROUP=GroebnerExt`: 24 passed, 3 failed, 1 broken.
- Verified parent/child evidence around `SymbolicUtils d51e602d`: parent `b6ffa200` keeps `[x1, x2, x3, x4, x5]` and matches expected basis; `d51e602d` gives `[x4, x2, x5, x3, x1]` and fails exact basis equality while `is_groebner_basis` passes.
- Ran `GROUP=GroebnerExt` after this change: 27 passed, 1 broken.
- Ran `Runic --check .`; it exits nonzero due existing formatting drift outside this change. The full Runic diff no longer includes `symbol_to_poly` after local formatting cleanup.
