### PR TITLE
Register eigmax/eigmin as symbolic terms

### DIFF
--- a/src/array-lib.jl
+++ b/src/array-lib.jl
@@ -179,3 +179,9 @@ end
 end
 
 @register_symbolic LinearAlgebra.tr(x::AbstractMatrix)
+
+# Eigenvalues of a symbolic matrix have no closed form, so `eigmax`/`eigmin`
+# build unevaluated symbolic terms (like `tr`) rather than computing numerically;
+# without this they fall through to `eigvals!`, which errors on a symbolic matrix.
+@register_symbolic LinearAlgebra.eigmax(x::AbstractMatrix)
+@register_symbolic LinearAlgebra.eigmin(x::AbstractMatrix)

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -4,7 +4,7 @@ using Symbolics: symtype, shape, wrap, unwrap, Arr, jacobian, @variables, value,
 using Base: Slice
 using SymbolicUtils: Sym, term, operation, search_variables
 import SymbolicUtils.Code: toexpr
-import LinearAlgebra: dot, Adjoint, cross, diagm
+import LinearAlgebra: dot, Adjoint, cross, diagm, eigmax, eigmin
 import ..limit2
 
 struct TestMetaT end
@@ -535,6 +535,15 @@ end
     @variables x[1:3, 1:3]
     @test isequal(exp(x), wrap(exp(unwrap(x))))
     @test isequal(exp(collect(x)), exp(SConst(collect(unwrap(x)))))
+end
+
+@testset "eigmax/eigmin build symbolic terms" begin
+    @variables x[1:3, 1:3]
+    @test operation(unwrap(eigmax(x))) === eigmax
+    @test operation(unwrap(eigmin(x))) === eigmin
+    # numeric behavior is untouched
+    @test eigmax([2.0 0 0; 0 3 0; 0 0 5]) == 5.0
+    @test eigmin([2.0 0 0; 0 3 0; 0 0 5]) == 2.0
 end
 
 @testset "`transpose(::Arr) * Arr`" begin


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Eigenvalues of a symbolic matrix have no closed form, so `eigmax`/`eigmin` should build unevaluated symbolic terms (exactly like the existing `@register_symbolic LinearAlgebra.tr(x::AbstractMatrix)`) rather than dispatching to numeric `eigvals!`, which errors on a symbolic matrix:

```julia
julia> @variables X[1:3,1:3]; eigmax(X)
ERROR: MethodError: no method matching eigvals!(::Matrix{Num})
```

Adds `@register_symbolic` for both, next to `tr` in `array-lib.jl`.

Motivation: this is the correct home for making a Base/LinearAlgebra function symbolic-aware. SymbolicAnalysis.jl needs `eigmax(X)`/`eigmin(X)` to trace to a term so it can attach DCP curvature rules — today it pirates the registration locally (with an Aqua allowlist entry); with this it just adds the rule, like it already does for `tr`.

Verified locally (Symbolics dev-tracked): `operation(unwrap(eigmax(X))) === eigmax`, same for `eigmin`, numeric `eigmax`/`eigmin` unchanged (5.0 / 2.0 on a diagonal test matrix), clean precompile. Added a testset in `test/arrays.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)