### PR TITLE
ci: test ModelingToolkitBase RegressionI downstream

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -21,7 +21,7 @@ jobs:
           - {user: SciML, repo: ModelingToolkit.jl, group: InterfaceII}
           - {user: SciML, repo: ModelingToolkit.jl, group: Initialization}
           - {user: SciML, repo: ModelingToolkit.jl, group: SymbolicIndexingInterface}
-          - {user: SciML, repo: ModelingToolkit.jl, group: RegressionI}
+          - {user: SciML, repo: ModelingToolkit.jl, group: RegressionI, target: ModelingToolkitBase}
           - {user: SciML, repo: Catalyst.jl, group: Modeling}
           - {user: SciML, repo: Catalyst.jl, group: Simulation}
           - {user: SciML, repo: Catalyst.jl, group: Hybrid}
@@ -59,7 +59,8 @@ jobs:
               Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
             end
             Pkg.update()
-            Pkg.test()  # resolver may fail with test time deps
+            target = "${{ matrix.package.target }}"
+            isempty(target) ? Pkg.test() : Pkg.test(target)  # resolver may fail with test time deps
           catch err
             err isa Pkg.Resolve.ResolverError || rethrow()
             # If we can't resolve that means this is incompatible by SemVer and this is fine


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Route the Symbolics downstream `RegressionI` lane to `ModelingToolkitBase`, which now owns that public test group.

All other downstream matrix entries keep the existing `Pkg.test()` behavior. The optional `target` field is used only by this one lane.

## Root cause

Symbolics still invoked `GROUP=RegressionI` against the root ModelingToolkit package after RegressionI moved to `lib/ModelingToolkitBase`.

ModelingToolkit commit `d647d61ac46f3a5696021f4a0e52769aacb2194c` migrated the root test runner and began rejecting this nonexistent group with `_group_spec(::Nothing)`. Its parent appeared green only because it silently ran zero tests.

This reproduces on clean Symbolics master and is independent of #1922.

## Local verification

I ran the exact downstream develop/update/test flow on Julia 1.12.6:

- clean current master: reproduced `_group_spec(::Nothing)` before any tests;
- patched target: `ModelingToolkitBase tests passed`, exit 0;
- second reference comparison run: `Latexify recipes Test | Pass 5 Total 5`;
- `actionlint .github/workflows/Downstream.yml`: exit 0;
- `git diff --check upstream/master...HEAD`: exit 0.

The first real RegressionI execution also exposed a separate pre-existing MTK test-fixture issue: missing reference files are generated as untracked files, so the first run performs fewer comparisons. This PR does not add those unrelated fixtures; generated files were removed after verification.

There are no changed Julia files. A repository-wide Runic check still reports the upstream repository's existing formatting drift, which this YAML-only PR does not modify.
