### PR TITLE
fix: stabilize symbolic Groebner ordering

### DIFF
--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -15,10 +15,20 @@ function Symbolics.groebner_basis(polynomials::Vector{Num}; ordering=InputOrderi
     Symbolics.poly_to_symbol(basis, poly_to_bs)
 end
 
-function groebner_basis_poly(polynoms::Vector{<:DP.Polynomial}, poly_to_bs::Bijections.Bijection; ordering=InputOrdering(), kwargs...)
+function groebner_ordering(ordering, poly_to_bs)
     bs_to_poly = Bijections.active_inv(poly_to_bs)
-    ordering = Groebner.ordering_transform(ordering, bs_to_poly)
-    return Groebner.groebner(polynoms; ordering=ordering, kwargs...)
+    if ordering isa InputOrdering
+        variables = collect(Bijections.image(poly_to_bs))
+        variable_names = Symbolics.tosymbol.(variables)
+        allunique(variable_names) || throw(ArgumentError("InputOrdering requires unique symbolic variable names; pass an explicit ordering."))
+        ordering = DegRevLex(variables[sortperm(variable_names)])
+    end
+    return Groebner.ordering_transform(ordering, bs_to_poly)
+end
+
+function groebner_basis_poly(polynoms::Vector{<:DP.Polynomial}, poly_to_bs::Bijections.Bijection; ordering = InputOrdering(), kwargs...)
+    ordering = groebner_ordering(ordering, poly_to_bs)
+    return Groebner.groebner(polynoms; ordering = ordering, kwargs...)
 end
 
 """
@@ -42,9 +52,10 @@ julia> @variables x y;
 julia> is_groebner_basis([x^2 - y^2, x*y^2 + x, y^3 + y])
 ```
 """
-function Symbolics.is_groebner_basis(polynomials::Vector{<:Union{Num, BasicSymbolic}}; kwargs...)
-    polynoms, _ = Symbolics.symbol_to_poly(polynomials)
-    Groebner.isgroebner(polynoms; kwargs...)
+function Symbolics.is_groebner_basis(polynomials::Vector{<:Union{Num, BasicSymbolic}}; ordering = InputOrdering(), kwargs...)
+    polynoms, poly_to_bs = Symbolics.symbol_to_poly(polynomials)
+    ordering = groebner_ordering(ordering, poly_to_bs)
+    return Groebner.isgroebner(polynoms; ordering = ordering, kwargs...)
 end
 
 ### Solver ###

--- a/ext/SymbolicsGroebnerExt.jl
+++ b/ext/SymbolicsGroebnerExt.jl
@@ -21,7 +21,8 @@ function groebner_ordering(ordering, poly_to_bs)
         variables = collect(Bijections.image(poly_to_bs))
         variable_names = Symbolics.tosymbol.(variables)
         allunique(variable_names) || throw(ArgumentError("InputOrdering requires unique symbolic variable names; pass an explicit ordering."))
-        ordering = DegRevLex(variables[sortperm(variable_names)])
+        variables = variables[sortperm(variable_names)]
+        return DegRevLex([bs_to_poly[variable] for variable in variables])
     end
     return Groebner.ordering_transform(ordering, bs_to_poly)
 end

--- a/src/groebner_basis.jl
+++ b/src/groebner_basis.jl
@@ -22,6 +22,10 @@ exactly, `DomainError` is thrown.
 The Groebner.jl backend provides a number of useful keyword arguments, which are
 also available for this function. See `?Groebner.groebner`.
 
+With the default `InputOrdering()`, variables use degree reverse lexicographic
+order after sorting by [`tosymbol`](@ref). Pass an explicit ordering when
+distinct variables have the same symbolic name.
+
 ## Example
 
 ```jldoctest

--- a/test/extensions/groebner.jl
+++ b/test/extensions/groebner.jl
@@ -29,6 +29,18 @@ end
 @variables x1 x2 x3 x4
 @test isequal(expand.(groebner_basis([x1, x, y])), [y, x1, x])
 
+system = [x1 + x2, x1 * x2 - 1]
+@test isequal(expand.(groebner_basis(system)), [x1 + x2, 1 + x2^2])
+@test isequal(expand.(groebner_basis(system, ordering = DegRevLex(x2, x1))), [x1 + x2, 1 + x1^2])
+
+@variables τ q(τ) A(τ)[1:1]
+system = [q + A[1], q * A[1] - 1]
+@test isequal(expand.(groebner_basis(system)), [A[1] + q, 1 + q^2])
+
+@variables f(x)
+named_f = Symbolics.variable(Symbol("f(x)"))
+@test_throws ArgumentError groebner_basis([f + named_f, f * named_f - 1])
+
 # input unchanged
 f1 = [x2, x1, x4, x3]
 f2 = [x2, x1, x4, x3]


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Make the default symbolic Groebner variable order deterministic instead of inheriting hash-table traversal order.

For `InputOrdering()`, Symbolics now:

1. obtains the symbolic variables through the public Bijections image API;
2. sorts their unique public `tosymbol` names;
3. maps them directly to the corresponding DynamicPolynomials variables;
4. constructs an explicit `DegRevLex` ordering.

Explicit user-supplied orderings remain unchanged. `groebner_basis` and `is_groebner_basis` share the same private ordering helper.

## Root cause

SymbolicUtils commit `d51e602d9d3152c5743b486856542deb41d6e156` (first released in v4.35.2) replaced ordered expression containers with `Dict`. Hash traversal then changed DynamicPolynomials variable creation order, so Groebner `InputOrdering()` returned a different basis from one process/version to another.

Dependency bisect using the same Symbolics 7.28 source:

- SymbolicUtils v4.35.1: 27/27 non-broken tests pass.
- SymbolicUtils v4.35.2: 24 pass / 3 fail / 1 pre-existing broken.

Current unmodified Symbolics master reproduces the same 24/3/1 failure. This is independent of #1922.

## Behavior

- Default ordering is canonical by symbolic name and documented in the public `groebner_basis` docstring.
- Distinct variables with an identical symbolic name now receive a deterministic `ArgumentError` asking for an explicit ordering.
- Explicit `Lex`, `DegLex`, and `DegRevLex` behavior is not changed.

The new default path uses public APIs only. The extension's pre-existing `Groebner.ordering_transform` call remains solely in the unchanged explicit-order fallback; this PR does not add or deepen that non-public dependency.

## Local verification

On Julia 1.12.6 with current dependencies (SymbolicUtils v4.40.0, Groebner v0.10.3):

- official `GROUP=GroebnerExt Pkg.test()`: 31 pass / 1 pre-existing broken, exit 0;
- regressions cover default order, reversed explicit order, call/index atoms, and duplicate names;
- changed ranges are Runic-clean;
- `git diff --check upstream/master...HEAD`: exit 0.

Repository-wide Runic still reports unrelated pre-existing formatting drift in the touched legacy files; this PR preserves it.
