### PR TITLE
Document public code generation API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.31.2"
+version = "7.32.0"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]

--- a/docs/src/manual/build_function.md
+++ b/docs/src/manual/build_function.md
@@ -22,6 +22,16 @@ give back the function handle.
 build_function
 ```
 
+## Low-Level Code Generation
+
+Consumers that already maintain a symbolic `IRStructure` can generate Julia function
+expressions directly with `codegen_function`.
+
+```@docs
+Symbolics.CodegenFunctionOptions
+Symbolics.codegen_function
+```
+
 ## Target-Specific Definitions
 
 ```@docs

--- a/docs/src/manual/build_function.md
+++ b/docs/src/manual/build_function.md
@@ -24,7 +24,7 @@ build_function
 
 ## Low-Level Code Generation
 
-Consumers that already maintain a symbolic `IRStructure` can generate Julia function
+Consumers that already maintain a `SymbolicUtils.IRStructure` can generate Julia function
 expressions directly with `codegen_function`.
 
 ```@docs

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -610,6 +610,7 @@ include("despecialize.jl")
 @public unwrap, variable, wrap, linear_expansion, LinearExpander
 @public _toexpr_metadata, _toexpr_op
 @public value
+@public CodegenFunctionOptions, codegen_function
 
 @setup_workload begin
     fold1 = Val{false}()

--- a/src/codegen_fn.jl
+++ b/src/codegen_fn.jl
@@ -93,10 +93,23 @@ function CodegenFunctionOptions(;
     )
 end
 
-# Backwards-compatible keyword entry point. Any function that still calls `codegen_function`
-# with keyword arguments continues to work; the options are bundled into a `CodegenFunctionOptions`
-# and dispatched to the struct-based methods below. Unknown keywords are dropped by the
-# `CodegenFunctionOptions` constructor, exactly as they were dropped by the old `kwargs...` sink.
+"""
+    codegen_function(ir, expr, args[, options])
+    codegen_function(ir, expr, args; kwargs...)
+
+Generate out-of-place and in-place Julia function expressions for `expr` using the symbolic
+`IRStructure`. `args` is a vector whose elements describe each generated function
+argument as either a scalar symbolic value or a collection of symbolic values.
+
+Pass a [`CodegenFunctionOptions`](@ref) as `options`, or pass the same settings as keyword
+arguments. The result is a 2-tuple containing the out-of-place and in-place function
+expressions. The requested `iip_config` and the shape of `expr` determine which variants are
+implemented.
+
+This is the low-level code-generation interface for consumers that already maintain an
+`IRStructure`. Prefer [`build_function`](@ref) when starting from ordinary symbolic
+expressions.
+"""
 function codegen_function(ir::IRStructure{VartypeT}, expr, args::Vector; kwargs...)
     return codegen_function(ir, expr, args, CodegenFunctionOptions(; kwargs...))
 end

--- a/src/codegen_fn.jl
+++ b/src/codegen_fn.jl
@@ -97,8 +97,8 @@ end
     codegen_function(ir, expr, args[, options])
     codegen_function(ir, expr, args; kwargs...)
 
-Generate out-of-place and in-place Julia function expressions for `expr` using the symbolic
-`IRStructure`. `args` is a vector whose elements describe each generated function
+Generate out-of-place and in-place Julia function expressions for `expr` using a
+`SymbolicUtils.IRStructure`. `args` is a vector whose elements describe each generated function
 argument as either a scalar symbolic value or a collection of symbolic values.
 
 Pass a [`CodegenFunctionOptions`](@ref) as `options`, or pass the same settings as keyword
@@ -106,8 +106,8 @@ arguments. The result is a 2-tuple containing the out-of-place and in-place func
 expressions. The requested `iip_config` and the shape of `expr` determine which variants are
 implemented.
 
-This is the low-level code-generation interface for consumers that already maintain an
-`IRStructure`. Prefer [`build_function`](@ref) when starting from ordinary symbolic
+This is the low-level code-generation interface for consumers that already maintain a
+`SymbolicUtils.IRStructure`. Prefer [`build_function`](@ref) when starting from ordinary symbolic
 expressions.
 """
 function codegen_function(ir::IRStructure{VartypeT}, expr, args::Vector; kwargs...)

--- a/test/codegen_function.jl
+++ b/test/codegen_function.jl
@@ -289,6 +289,8 @@ end
 
 @testset "`CodegenFunctionOptions` struct interface" begin
     @variables a b c1 c2 c3 d e g
+    @test (@doc Symbolics.CodegenFunctionOptions) !== nothing
+    @test (@doc Symbolics.codegen_function) !== nothing
     @static if VERSION >= v"1.11"
         @test Base.ispublic(Symbolics, :CodegenFunctionOptions)
         @test Base.ispublic(Symbolics, :codegen_function)

--- a/test/codegen_function.jl
+++ b/test/codegen_function.jl
@@ -289,6 +289,10 @@ end
 
 @testset "`CodegenFunctionOptions` struct interface" begin
     @variables a b c1 c2 c3 d e g
+    @static if VERSION >= v"1.11"
+        @test Base.ispublic(Symbolics, :CodegenFunctionOptions)
+        @test Base.ispublic(Symbolics, :codegen_function)
+    end
     # `CodegenFunctionOptions` is a single concrete type regardless of which options are set, so
     # functions that thread it through do not recompile per option-combination.
     @test isconcretetype(Symbolics.CodegenFunctionOptions)


### PR DESCRIPTION
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- declare `CodegenFunctionOptions` and `codegen_function` as public Symbolics API
- document `codegen_function` and render both low-level code-generation entries in the manual
- direct consumers to the owning public `SymbolicUtils.IRStructure` type rather than its Symbolics reexport
- test that both new public bindings retain docstrings
- bump Symbolics from 7.31.2 to 7.32.0 because this adds public API

## Motivation

ModelingToolkit now uses these low-level code-generation entries, but Symbolics 7.31 introduced them without declaring them public. Publishing and documenting them at their owning package lets downstream code avoid relying on internals. The documentation also names `SymbolicUtils.IRStructure` through its owner module, where that type is declared public.

## Local verification

- `julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.instantiate(); using Test; include("test/codegen_function.jl")'` — passed, including 9/9 `CodegenFunctionOptions` interface/public/documentation checks
- `GROUP=Core julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test(; allow_reresolve=true)'` — passed (17,061 passed; 351 pre-existing broken checks), followed by 12/12, 12/12, and 14/14 passing SymbolicIndexingInterface testsets
- `julia +1.12 --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(path = pwd()); Pkg.instantiate(); include("docs/make.jl")'` — passed; both low-level API entries and the `SymbolicUtils.IRStructure` owner qualification rendered without docstring or cross-reference warnings
- Runic 1.7 was checked across all 128 tracked Julia files; the existing repository is not Runic-clean across many unchanged files, while formatting each modified Julia range produced no changes
- `git diff --check` — passed
