### PR TITLE
Document public code generation API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.31.2"
+version = "7.32.0"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]

--- a/docs/src/manual/build_function.md
+++ b/docs/src/manual/build_function.md
@@ -22,6 +22,17 @@ give back the function handle.
 build_function
 ```
 
+## Low-Level Code Generation
+
+`codegen_function` generates Julia function expressions from an existing symbolic IR. Most users
+should use `build_function`, while downstream code-generation systems can reuse an existing
+`SymbolicUtils.IRStructure` and bundle options without keyword-driven specialization.
+
+```@docs
+Symbolics.CodegenFunctionOptions
+Symbolics.codegen_function
+```
+
 ## Target-Specific Definitions
 
 ```@docs

--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -610,6 +610,7 @@ include("despecialize.jl")
 @public unwrap, variable, wrap, linear_expansion, LinearExpander
 @public _toexpr_metadata, _toexpr_op
 @public value
+@public CodegenFunctionOptions, codegen_function
 
 @setup_workload begin
     fold1 = Val{false}()

--- a/src/codegen_fn.jl
+++ b/src/codegen_fn.jl
@@ -93,10 +93,20 @@ function CodegenFunctionOptions(;
     )
 end
 
-# Backwards-compatible keyword entry point. Any function that still calls `codegen_function`
-# with keyword arguments continues to work; the options are bundled into a `CodegenFunctionOptions`
-# and dispatched to the struct-based methods below. Unknown keywords are dropped by the
-# `CodegenFunctionOptions` constructor, exactly as they were dropped by the old `kwargs...` sink.
+"""
+    codegen_function(ir, expr, args[, options])
+    codegen_function(ir, expr, args; kwargs...)
+
+Generate out-of-place and in-place Julia function expressions from symbolic code-generation IR.
+
+`ir` is a `SymbolicUtils.IRStructure`, `expr` is the symbolic expression to generate,
+and `args` describes the generated function arguments. Pass a [`CodegenFunctionOptions`](@ref)
+instance or the corresponding keywords to control code generation. The function returns a tuple
+containing the out-of-place and in-place function expressions.
+
+This is the low-level code-generation interface. Prefer [`build_function`](@ref) unless an
+existing `IRStructure` must be reused.
+"""
 function codegen_function(ir::IRStructure{VartypeT}, expr, args::Vector; kwargs...)
     return codegen_function(ir, expr, args, CodegenFunctionOptions(; kwargs...))
 end

--- a/test/codegen_function.jl
+++ b/test/codegen_function.jl
@@ -12,6 +12,15 @@ RuntimeGeneratedFunctions.init(@__MODULE__)
 
 ir = IRStructure{SymReal}()
 
+@testset "Public code-generation API" begin
+    @test (@doc Symbolics.CodegenFunctionOptions) !== nothing
+    @test (@doc Symbolics.codegen_function) !== nothing
+    @static if VERSION >= v"1.11"
+        @test Base.ispublic(Symbolics, :CodegenFunctionOptions)
+        @test Base.ispublic(Symbolics, :codegen_function)
+    end
+end
+
 @testset "NaNMath" begin
     oop, iip = Symbolics.codegen_function(ir, [sqrt(a), sin(b)], [[a, b]]; nanmath = true, sort_addmul = true)
     oop = eval(oop)


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- declare `CodegenFunctionOptions` and `codegen_function` as public owner APIs
- document `codegen_function` and render both low-level APIs in the manual
- test that both declarations are public and documented
- bump the minor version to 7.32.0 for the added public API

## Context

ModelingToolkitBase now consumes these two names directly. The definitions exist in Symbolics 7.31, but neither name was declared public and `codegen_function` was not documented. This owner-package prerequisite makes the downstream dependency explicit before ModelingToolkit raises its Symbolics compatibility floor.

The original ModelingToolkit failure also exposed a separate version-floor mismatch: ModelingToolkit allowed Symbolics 7.30 even though `CodegenFunctionOptions` first shipped in 7.31. The downstream compatibility PR will depend on this 7.32 public-API release.

## Local verification

- `GROUP=Core julia +1.12 --project -e 'using Pkg; Pkg.test(; allow_reresolve=true)'`: passed (`17,030` passed, `393` pre-existing broken, plus all follow-up SymbolicIndexingInterface testsets)
- `julia +1.12 --project=docs docs/make.jl`: passed; both new `@docs` entries expanded, with only unrelated pre-existing warn-only diagnostics
- Runic was run over every tracked Julia file; the repository has extensive pre-existing formatting differences. Runic output for each changed Julia range was compared byte-for-byte with the source and was identical.
- `git diff --check`: passed
