### PR TITLE
Make MATLABTarget a public documented API

### DIFF
--- a/docs/src/manual/build_function.md
+++ b/docs/src/manual/build_function.md
@@ -34,6 +34,12 @@ Symbolics.codegen_function
 
 ## Target-Specific Definitions
 
+### MATLAB
+
+```@docs
+Symbolics.MATLABTarget
+```
+
 ```@docs
 Symbolics._build_function(target::Symbolics.JuliaTarget,rhss::AbstractArray,args...;kwargs...)
 Symbolics._build_function(target::Symbolics.CTarget,eqs::Array{<:Equation},args...;kwargs...)

--- a/src/build_function.jl
+++ b/src/build_function.jl
@@ -5,7 +5,34 @@ abstract type BuildTargets end
 struct JuliaTarget <: BuildTargets end
 struct StanTarget <: BuildTargets end
 struct CTarget <: BuildTargets end
+
+"""
+    MATLABTarget()
+
+A `build_function` target that generates an anonymous function expression for MATLAB and
+GNU Octave.
+
+# Arguments
+
+None.
+
+# Keywords
+
+None. Pass this target as `target` to [`build_function`](@ref).
+
+# Examples
+
+```julia
+julia> @variables x
+1-element Vector{Num}:
+ x
+
+julia> build_function(x^2, x; target = MATLABTarget()) isa String
+true
+```
+"""
 struct MATLABTarget <: BuildTargets end
+@public MATLABTarget
 
 abstract type ParallelForm end
 struct SerialForm <: ParallelForm end

--- a/test/build_targets.jl
+++ b/test/build_targets.jl
@@ -50,6 +50,8 @@ let
 end
 
 # MATLABTarget structural test (was target_functions/1.m)
+@test Base.ispublic(Symbolics, :MATLABTarget)
+
 let
     mfunc = Symbolics.build_function(expr,[x,y],[a],t,target = Symbolics.MATLABTarget())
     @test occursin("diffeqf = @(internal_var___t,internal_var___u)", mfunc)


### PR DESCRIPTION
## Summary
- declare `MATLABTarget` public at its definition site
- add a SciML-style docstring, rendered manual entry, and publicness assertion

## Verification
- `GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` (17,025 passed, 357 existing broken, exit 0)\n- `julia +1.12 --project=docs -e 'include("docs/make.jl")'`\n- direct public API check for `Symbolics.MATLABTarget` and MATLAB code generation\n\nIgnore until reviewed by @ChrisRackauckas.