### PR TITLE
Declare diff2term and map_subscripts public

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -615,6 +615,7 @@ include("despecialize.jl")
 @public _toexpr_metadata, _toexpr_op
 @public value
 @public CodegenFunctionOptions, codegen_function
+@public diff2term, map_subscripts
 
 @setup_workload begin
     fold1 = Val{false}()


### PR DESCRIPTION
Marks two Symbolics-owned functions as public API. Both are already relied on by downstream SciML packages, but neither was exported nor covered by the `@public` block, so under strict SciMLTesting 2.4 QA (which errors on importing a binding its owning package has not declared public) consumers cannot import them.

The failure mode this fixes is not hypothetical: rather than the binding being declared public here, consumers have been rewriting their call sites to dodge it, and those rewrites are not behavior-preserving.

## `diff2term`

**What it is.** Defined at `src/utils.jl:166` (plus `Num` and `Arr` methods at :222/:223). It flattens a derivative expression into a single variable symbol — `Dx(Dt(u))` becomes `uˍtx(x, t)`. `parentmodule` is `Symbolics`; it is not re-exported from a dependency.

**Why it is interface, not an implementation detail.** It is already documented as user-facing API in `docs/src/manual/expression_manipulation.md:36`, with a doctest in its docstring. It is also the only way to perform this transformation — there is no public equivalent.

**Blocked downstream PR.** SciML/NeuralLyapunov.jl#209. That PR dropped `diff2term` from its imports and substituted `operation`:

```julia
-    domains = map(d -> operation(diff2term(d.variables)) ∈ d.domain, bounds)
+    domains = map(d -> operation(d.variables) ∈ d.domain, bounds)
-    bound_vars = map(b -> diff2term(b.variables), bounds)
+    bound_vars = map(b -> operation(b.variables), bounds)
```

These are not equivalent — `operation` returns the head of the expression, it does not flatten a derivative into a variable symbol — and the swap broke five CI lanes. That PR also carries the workaround `explicit_imports_public_ignore = (:diff2term, :sample)`, which can be dropped once this lands.

## `map_subscripts`

**What it is.** Defined at `src/variable.jl:48`. Maps the characters of an index into Unicode subscripts via the `IndexMap` table at `src/variable.jl:4`. Symbolics uses it internally at `src/variable.jl:563` to name scalarized array-element variables:

```julia
name_ij = Symbol(name, join(map_subscripts.(idx), "ˏ"))
```

**Why it is interface, not an implementation detail.** It defines the scalarized-variable *naming convention*. Any package that constructs variables whose names must line up with the ones Symbolics generates has to produce byte-identical names, so it needs this function rather than its own copy.

**Blocked downstream PR.** SciML/MomentClosure.jl#107, which uses it to name moment variables (`Symbol('μ', join(map_subscripts(indices[i])))`). Having lost the import, that PR forked the table locally:

```julia
+const SUBSCRIPT_DIGITS = Dict(
+    '0' => '₀', '1' => '₁', ... '9' => '₉',
+)
+subscript_indices(indices) = join(SUBSCRIPT_DIGITS[c] for c in string(indices))
```

That fork drops `'-' => '₋'`, which Symbolics' `IndexMap` has, so it throws `KeyError('-')` on any negative index where the real function returns `₋₁₂`. This is the exact class of bug that copying an internal table downstream produces.

Note that `map_subscripts` is not currently documented, unlike `diff2term`. The case for it rests on it being the definition of a naming convention that downstream packages must match rather than reimplement.

## Change

One line, placed in the existing `@public` block:

```julia
@public diff2term, map_subscripts
```

`SciMLPublic` is already a dependency and `@public` is already imported at `src/Symbolics.jl:55`, so no `Project.toml` change is needed.

## Verification

- `using Symbolics` succeeds after the edit.
- `length(names(Symbolics))`: 146 before → 148 after.
- `:diff2term in names(Symbolics)` and `:map_subscripts in names(Symbolics)` are both `true`; both were `false` before.
- Neither is exported (`Base.isexported` remains `false`), so this adds no namespace pollution — callers still write `Symbolics.diff2term`.
- Smoke-tested: `Symbolics.diff2term(Symbolics.value(Dx(Dt(u))))` → `uˍxt(x, t)`; `Symbolics.map_subscripts(-12)` → `₋₁₂`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
