### PR TITLE
Release 7.35.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.34.1"
+version = "7.35.0"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]


### PR DESCRIPTION
Publishes the `@public` declarations added in #1938 so downstream packages can import them without tripping strict SciMLTesting QA.

Minor bump because the change widens the public API surface; no behaviour change.

## Why this needs a release

`diff2term` was never declared public, so SciMLTesting 2.4 flags any downstream import of it. The bot handling those QA migrations responded by rewriting the caller — in `SciML/NeuralLyapunov.jl#209` it substituted `operation` for `diff2term`, which is not equivalent: `diff2term` flattens `Differential(t)(x(t))` into a single symbolic variable matching `unknowns(dynamics)`, whereas `operation(x(t))` returns the bare head `x`. `findfirst` then returns `nothing` and the subsequent index throws `ArgumentError: invalid index: nothing of type Nothing`, taking out four Benchmarking lanes and the GPU lane.

Declaring it public removes the pressure to work around it.

## Blocked downstream

- SciML/NeuralLyapunov.jl#209 (`diff2term`)
- SciML/MomentClosure.jl#107 (`map_subscripts`, reimplemented locally as a subscript-digit dict)

Both pin `Symbolics = "7.24"`, which admits this release with no compat change.