### PR TITLE
docs: document the public names MTK reexports; deprecate broken `infimum`/`supremum`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.35.0"
+version = "7.36.0"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]

--- a/docs/src/manual/misc.md
+++ b/docs/src/manual/misc.md
@@ -14,3 +14,13 @@ Symbolics.NAMESPACE_SEPARATOR
 Symbolics.linear_expansion
 Symbolics.LinearExpander
 ```
+
+## Deprecated
+
+These names are still exported so that existing code keeps working, but each one warns on
+use and will be removed in the next breaking release.
+
+```@docs
+Symbolics.infimum
+Symbolics.supremum
+```

--- a/docs/src/manual/solver.md
+++ b/docs/src/manual/solver.md
@@ -14,6 +14,13 @@ One other symbolic solver is `symbolic_linear_solve` which is limited compared t
 Symbolics.symbolic_linear_solve
 ```
 
+`symbolic_linear_solve` was previously called `solve_for`, which is still exported but
+deprecated.
+
+```@docs
+Symbolics.solve_for
+```
+
 `symbolic_solve` only supports symbolic, i.e. non-floating point computations, and thus prefers equations
 where the coefficients are integer, rational, or symbolic. Floating point coefficients are transformed into
 rational values and BigInt values are used internally with a potential performance loss, and thus it is recommended

--- a/docs/src/manual/types.md
+++ b/docs/src/manual/types.md
@@ -49,3 +49,14 @@ Symbolics.wrap
 Symbolics.unwrap
 ```
 
+### Defining your own wrapper
+
+A package that introduces a new symbolic type registers a wrapper for it with
+`@symbolic_wrap`, and then uses `@wrapped` to make its functions accept both the wrapper and
+raw expression trees in place of the concrete type.
+
+```@docs
+@symbolic_wrap
+@wrapped
+```
+

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -65,6 +65,54 @@ function SymbolicUtils.operator_to_term(::Differential, ex::BasicSymbolic{Vartyp
     return diff2term(ex)
 end
 
+"""
+    is_derivative(x)
+
+Return `true` if `x` is an unapplied derivative term, i.e. an unwrapped symbolic expression
+whose operation is a [`Differential`](@ref). Return `false` for everything else.
+
+Applying a `Differential` does not differentiate immediately: `D(x^2)` is stored as the
+symbolic application of `D` to `x^2` until [`expand_derivatives`](@ref) is called. This
+predicate is the test for "this node is still an unapplied derivative", and is the usual
+building block for finding them inside an expression.
+
+Two things to be aware of when calling it:
+
+  - It only inspects the top node. `D(x) + y` is not a derivative term even though it
+    contains one. Combine it with `Symbolics.hasnode` or `Symbolics.filterchildren` to ask
+    about a whole tree.
+  - It operates on the unwrapped expression tree, so a wrapper such as `Num` must be
+    unwrapped first. `D(x)` returns a `Num`, and `is_derivative` of a `Num` falls through to
+    the catch-all and returns `false`; call `is_derivative(Symbolics.unwrap(D(x)))`
+    instead. Tree walkers like `hasnode` and `filterchildren` unwrap for you, so the common
+    case needs no special handling.
+
+```julia
+julia> using Symbolics
+
+julia> @variables t x(t);
+
+julia> D = Differential(t);
+
+julia> is_derivative(Symbolics.unwrap(D(x)))
+true
+
+julia> is_derivative(D(x))   # a `Num`, not an expression tree
+false
+
+julia> is_derivative(Symbolics.unwrap(D(x) + x))
+false
+
+julia> is_derivative(Symbolics.unwrap(expand_derivatives(D(x^2))))
+false
+
+julia> Symbolics.hasnode(is_derivative, D(x) + x)
+true
+```
+
+See also: [`Differential`](@ref), [`expand_derivatives`](@ref), [`Symbolics.hasnode`](@ref),
+[`Symbolics.filterchildren`](@ref), [`Symbolics.unwrap`](@ref).
+"""
 function is_derivative(x::SymbolicT)
     @match x begin
         BSImpl.Term(; f) && if f isa Differential end => true

--- a/src/domains.jl
+++ b/src/domains.jl
@@ -17,10 +17,54 @@ Base.:∈(variable::DomainedVar,domain::NTuple{2,Real}) = VarDomainPairing(varia
 # Multiple variables
 Base.:∈(variables::NTuple{N,DomainedVar},domain::Domain) where N = VarDomainPairing(unwrap.(variables),domain)
 
-function infimum(d::AbstractInterval{<:Num})
-    leftendpoint(d)
+"""
+    Symbolics.infimum(d::AbstractInterval)
+
+Deprecated. Use `IntervalSets.infimum` (also re-exported by DomainSets) instead.
+
+Return the left endpoint of the interval domain `d`.
+
+This function was added so that an interval with `Num` endpoints, such as the domain of a
+PDE variable written `x ∈ Interval(a, b)`, could be queried for its lower bound. That
+turned out to be unnecessary: `IntervalSets.infimum` is generic over the endpoint type and
+already handles `Num`, so the only effect of a separate `Symbolics.infimum` is to shadow it
+whenever both Symbolics and DomainSets are in scope.
+
+`Symbolics.infimum` now forwards to `IntervalSets.infimum` and warns; it will be removed in
+the next breaking release. Callers should switch to
+
+```julia
+using DomainSets   # or IntervalSets
+infimum(d)
+```
+
+See also: [`Symbolics.supremum`](@ref).
+"""
+function infimum(d::AbstractInterval)
+    Base.depwarn(
+        "`Symbolics.infimum` is deprecated, use `IntervalSets.infimum` (re-exported by " *
+            "DomainSets) instead.", :infimum
+    )
+    return IntervalSets.infimum(d)
 end
 
-function supremum(d::AbstractInterval{<:Num})
-    rightendpoint(d)
+"""
+    Symbolics.supremum(d::AbstractInterval)
+
+Deprecated. Use `IntervalSets.supremum` (also re-exported by DomainSets) instead.
+
+Return the right endpoint of the interval domain `d`. This is the counterpart of
+[`Symbolics.infimum`](@ref) and is deprecated for the same reason: `IntervalSets.supremum`
+is generic over the endpoint type and already handles `Num`, so a separate Symbolics
+function only shadows it.
+
+`Symbolics.supremum` now forwards to `IntervalSets.supremum` and warns; it will be removed
+in the next breaking release.
+"""
+function supremum(d::AbstractInterval)
+    Base.depwarn(
+        "`Symbolics.supremum` is deprecated, use `IntervalSets.supremum` (re-exported by " *
+            "DomainSets) instead.", :supremum
+    )
+    return IntervalSets.supremum(d)
 end

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -55,6 +55,21 @@ function sym_lu(A::AbstractMatrix{Num}; check=true)
     LU(F, p, convert(LinearAlgebra.BlasInt, info))
 end
 
+"""
+    solve_for(eqs, vars; simplify = false, check = true)
+
+Deprecated. Use [`Symbolics.symbolic_linear_solve`](@ref) instead, which takes the same
+arguments and returns the same result.
+
+`solve_for` was the original name for Symbolics' linear equation solver. It was renamed to
+`symbolic_linear_solve` when [`Symbolics.symbolic_solve`](@ref) was added, so that the two
+solvers have names that say how they differ: `symbolic_solve` handles nonlinear (polynomial)
+systems and returns all roots, while `symbolic_linear_solve` solves a linear system by
+factorization and returns the single solution.
+
+Calling `solve_for` forwards to `symbolic_linear_solve` and emits a deprecation warning. It
+will be removed in the next breaking release.
+"""
 function solve_for(eq::Any, var::Any; simplify=false, check=true)
     Base.depwarn("solve_for is deprecated, please use symbolic_linear_solve instead.", :solve_for)
     return symbolic_linear_solve(eq, var; simplify=simplify, check=check)

--- a/src/wrapper-types.jl
+++ b/src/wrapper-types.jl
@@ -23,6 +23,66 @@ function _get_type_name(x::Union{Symbol, Expr})
     return x.args[1]
 end
 
+"""
+    @symbolic_wrap struct W <: T
+        ...
+    end
+
+Define `W` as the symbolic wrapper type for the symbolic type `T`, and register the
+correspondence between the two with Symbolics.
+
+Symbolic expressions are stored as untyped expression trees (`BasicSymbolic`), but Julia
+code dispatches on types: a function written for `Real` will not accept an expression tree.
+Symbolics bridges the two by *wrapping* an expression tree in a struct that subtypes the
+type the expression stands for. `Num <: Real` is the built-in example — it holds an
+expression tree whose `symtype` is `Real` and can therefore be passed anywhere a `Real` is
+expected. `@symbolic_wrap` is how a package declares its own such pairing, so that
+Symbolics knows to wrap results of that symbolic type in `W` and to unwrap `W` back to the
+expression tree at the boundaries.
+
+The macro takes a struct definition whose supertype is the symbolic type being wrapped. It
+emits the struct unchanged, plus the trait methods that tie `W` and `T` together:
+`Symbolics.has_symwrapper(::Type{<:T})`, `Symbolics.wrapper_type(::Type{<:T}) = W`,
+`Symbolics.is_wrapper_type(::Type{<:W})`, `Symbolics.wraps_type(::Type{W}) = T` and
+`Symbolics.iswrapped(::W)`. Once those exist, [`Symbolics.wrap`](@ref) maps a value of
+symbolic type `T` to a `W`, [`Symbolics.unwrap`](@ref) maps it back, [`@wrapped`](@ref)
+generates wrapper-accepting methods, and `@register_symbolic` knows `W` counts as symbolic.
+
+Two things are the caller's responsibility. `W` must be constructible from the value it
+wraps, because that is how `Symbolics.wrap` builds it, and a `Symbolics.unwrap` method must
+be defined for `W` to get the value back out.
+
+The registration is on the *unparameterized* supertype, so
+`Symbolics.wrapper_type(T{Int})` also returns `W`; if a parameterized wrapper is wanted
+there, add the method by hand.
+
+Only one wrapper may be registered per symbolic type, and `Real` is already taken by `Num`.
+`@symbolic_wrap` is therefore for introducing wrappers over *new* symbolic types, not for
+replacing the built-in ones.
+
+# Example
+
+```julia
+using Symbolics
+
+abstract type AbstractFoo{T} end
+struct Foo{T} <: AbstractFoo{T} end
+
+@symbolic_wrap struct FooWrap{T} <: AbstractFoo{T}
+    val::Foo{T}
+end
+
+Symbolics.unwrap(r::FooWrap) = r.val
+
+wrap(Foo{Int}())            # FooWrap{Int}
+unwrap(wrap(Foo{Int}()))    # Foo{Int}
+```
+
+With that in place, [`@wrapped`](@ref) can generate methods that accept `FooWrap` wherever
+they declare an `AbstractFoo` argument.
+
+See also: [`@wrapped`](@ref), [`Symbolics.wrap`](@ref), [`Symbolics.unwrap`](@ref).
+"""
 macro symbolic_wrap(expr)
     @assert expr isa Expr && expr.head == :struct
     @assert expr.args[2].head == :(<:)
@@ -214,6 +274,65 @@ function wrap_func_expr(mod, expr, wrap_arrays = true)
     end |> esc
 end
 
+"""
+    @wrapped function f(x::T, ...) ... end
+    @wrapped f(x::T, ...) = ...
+    @wrapped function f(x::T, ...) ... end false
+
+Given one function definition written against concrete types, generate the additional
+methods that accept symbolic expressions and wrapper types in those argument positions.
+
+A function written as `f(x::Real)` will not accept a `Num`, because `Num` holds an
+expression tree rather than a number, and will not accept a raw `BasicSymbolic` either.
+Writing the symbolic methods by hand means one method per combination of "concrete /
+symbolic / wrapped" across all arguments, each of which has to unwrap its wrapper
+arguments, call the body, and re-wrap the result. `@wrapped` writes that combinatorial
+expansion for you.
+
+The body is emitted once under a private name, and one method of `f` is emitted per element
+of the product of the type options for each argument. For an argument annotated `::T` the
+options are `T` itself, a symbolic expression whose `symtype` is `T`, and — when `T` has a
+wrapper registered via [`@symbolic_wrap`](@ref) — that wrapper type. When `T` is an array
+type, array-of-symbolic and array-of-wrapper options are added as well. Unannotated
+arguments are left as `Any`.
+
+The all-concrete method is deliberately *not* emitted: `@wrapped function f(x::Real)` does
+not define `f(::Real)`. That method is assumed to already exist outside Symbolics (often it
+is the very Base function being extended), and emitting it would be piracy. Consequently
+`f` must have a non-symbolic definition of its own if it is to be called on plain values.
+
+In each generated method, wrapper-typed arguments are unwrapped before the body runs, and
+the result is re-wrapped with [`Symbolics.wrap`](@ref) whenever at least one argument was
+wrapped — so passing `Num`s in gets a `Num` back out, while passing raw `BasicSymbolic`s in
+returns a raw expression. Symbolic arguments additionally get an `@assert` that their
+`symtype` matches the declared annotation, which turns a type mismatch into an error at the
+call rather than a wrong answer downstream.
+
+Keyword arguments are forwarded as declared and are not expanded over; only positional
+arguments participate in the product.
+
+The optional trailing argument (default `true`) controls whether array-typed arguments are
+expanded over their symbolic-array and wrapped-array options. Pass `false` to suppress
+that, which is useful when the method is meant to see the container itself rather than a
+symbolic array.
+
+# Example
+
+Continuing the wrapper from [`@symbolic_wrap`](@ref):
+
+```julia
+@wrapped function foo(f::AbstractFoo, x::Real)
+    x > 1 ? Foo{Int}() : 0
+end
+
+applicable(foo, Foo{Int}(), 2)             # false: the all-concrete method is not emitted
+applicable(foo, Foo{Int}(), wrap(2))       # true
+applicable(foo, wrap(Foo{Int}()), 2)       # true
+applicable(foo, wrap(Foo{Int}()), wrap(2)) # true
+```
+
+See also: [`@symbolic_wrap`](@ref), [`Symbolics.wrap`](@ref), [`Symbolics.unwrap`](@ref).
+"""
 macro wrapped(expr, wrap_arrays = true)
     wrap_func_expr(__module__, expr, wrap_arrays)
 end


### PR DESCRIPTION
> [!WARNING]
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## Why

ModelingToolkit's QA suite (SciMLTesting's `run_api_docs`) requires every name on a
package's public API to have a docstring. Nine of MTK's public names fail, and none of them
are MTK's: they reach MTK's surface through `@reexport using Symbolics` and are
undocumented at their owner. Six are owned by Symbolics: `@symbolic_wrap`, `@wrapped`,
`is_derivative`, `solve_for`, `infimum`, `supremum`. (The other three are SymbolicUtils';
see the companion PR.)

MTK currently carries a `SYMBOLICS_OWNED_REEXPORTS` ignore tuple in `test/qa/qa.jl` listing
those nine. https://github.com/SciML/ModelingToolkit.jl/pull/4832 removes that waiver, on
the principle that the fix belongs at the owner. This PR is the Symbolics half.

## Commit 1 — docstrings for four genuinely-public names

`@symbolic_wrap` and `@wrapped` are the wrapper-type extension points that let a downstream
package introduce its own `Num`-like type. They had no prose anywhere: what trait methods
`@symbolic_wrap` emits, what the caller still has to supply (`unwrap`, and a constructor),
which argument-type combinations `@wrapped` expands over, that it deliberately does *not*
emit the all-concrete method, when the result gets re-wrapped, and what the optional
trailing `wrap_arrays` argument does — all of that previously required reading
`wrap_func_expr`. Both are documented and rendered in `manual/types.md` beside
`wrap`/`unwrap`.

`is_derivative` already had a `@docs` entry with no docstring behind it (`missing_docs` is
in `warnonly`, so the docs build never complained). Its docstring covers the two things
that actually catch people out:

- it inspects only the top node, so `D(x) + y` is not a derivative term; and
- it takes an **unwrapped** expression. `D(x)` returns a `Num`, and `is_derivative` of a
  `Num` falls through to the `is_derivative(_) = false` catch-all:

  ```julia
  julia> is_derivative(D(x))                      # a Num
  false

  julia> is_derivative(Symbolics.unwrap(D(x)))
  true
  ```

  I documented that rather than "fixing" it, because adding an `is_derivative(::Num)`
  method changes the answer for existing callers and that is a decision for you, not a
  drive-by in a docs PR. Tracked as https://github.com/JuliaSymbolics/Symbolics.jl/issues/1942; happy to add it there if you want it.

`solve_for` is the deprecated former name of `symbolic_linear_solve`. Its docstring says so
and explains why the rename happened (to distinguish it from `symbolic_solve`); it is
rendered under the solver page.

## Commit 2 — `infimum`/`supremum` are broken; deprecate them

These two are exported, undocumented, and have never worked. Their only method calls
`leftendpoint`/`rightendpoint`, which are not imported into Symbolics:

```julia
julia> Symbolics.infimum(ClosedInterval(Num(0), Num(1)))
ERROR: UndefVarError: `leftendpoint` not defined in `Symbolics`

julia> Symbolics.supremum(ClosedInterval(Num(0), Num(1)))
ERROR: UndefVarError: `rightendpoint` not defined in `Symbolics`
```

That has been the case since 880f2c250 in August 2021, which is a good indication that
nothing calls them.

They are also not methods on the IntervalSets functions of the same name, but *separate
functions that shadow them* — so `using Symbolics, DomainSets` makes a bare `infimum`
ambiguous. And they are redundant: `IntervalSets.infimum` is generic over the endpoint type
and already handles the `Num` case they were added for.

```julia
julia> IntervalSets.infimum(ClosedInterval(Num(0), Num(1)))
0
```

So rather than write a docstring for a function that cannot run, both now forward to the
IntervalSets function with a `depwarn`, widened from `AbstractInterval{<:Num}` to
`AbstractInterval`. That is strictly more permissive than before (an error becomes a
working call), tells callers what to move to, and puts the names on a removal path. They
are documented and rendered under a "Deprecated" heading in `manual/misc.md`.

Removing the exports outright would be the cleaner end state, but that is a major bump; I
would rather land the deprecation now and drop them in Symbolics 8.

## Versioning

7.35.0 → 7.36.0. Nothing is removed. `infimum`/`supremum` gain behavior (they previously
threw for every input) and gain a deprecation warning; everything else is documentation.

## Verification

- `run_api_docs(ModelingToolkit; rendered = false)` before, with released Symbolics 7.35.0 /
  SymbolicUtils 4.44.0 and MTK's ignore list removed, reports
  `[@symbolic_wrap, @wrapped, RuleSet, StructuralTransformations, UnPack, get_canonical_expr,
  infimum, is_derivative, istree, solve_for, supremum]` as undocumented.
- With this branch and https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1025
  dev'ed in, all nine Symbolics/SymbolicUtils-owned names drop out.
  (`StructuralTransformations` and `UnPack` are module reexports on MTK's own surface --
  a separate issue, not Symbolics'.)
- Runic reports the added code clean. The touched files are not Runic-formatted at baseline,
  so I did not reformat them wholesale.