### PR TITLE
fix: `is_derivative` unwraps wrapper types, so `is_derivative(D(x))` is `true`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+## 7.37.0
+
+### Behavior changes
+
+- `is_derivative` now unwraps wrapper types before inspecting the expression, so
+  `is_derivative(D(x))` is `true` where it previously returned `false` (`D(x)` is a `Num`,
+  and the old catch-all method answered `false` for anything that was not a raw expression
+  tree). This applies to any registered wrapper, including `Arr`. Code that relied on the
+  old answer to distinguish a wrapped value from an unwrapped one should test
+  `Symbolics.iswrapped` instead.
+
 ## 7.0.0
 
 ### Breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.36.0"
+version = "7.37.0"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]

--- a/src/diff.jl
+++ b/src/diff.jl
@@ -68,24 +68,26 @@ end
 """
     is_derivative(x)
 
-Return `true` if `x` is an unapplied derivative term, i.e. an unwrapped symbolic expression
-whose operation is a [`Differential`](@ref). Return `false` for everything else.
+Return `true` if `x` is an unapplied derivative term, i.e. a symbolic expression whose
+operation is a [`Differential`](@ref). Return `false` for everything else.
 
 Applying a `Differential` does not differentiate immediately: `D(x^2)` is stored as the
 symbolic application of `D` to `x^2` until [`expand_derivatives`](@ref) is called. This
 predicate is the test for "this node is still an unapplied derivative", and is the usual
 building block for finding them inside an expression.
 
+Wrapper types are unwrapped first, so the `Num` that `D(x)` returns and the raw expression
+tree `Symbolics.unwrap(D(x))` give the same answer. That holds for any registered wrapper
+([`@symbolic_wrap`](@ref)), including `Arr`.
+
 Two things to be aware of when calling it:
 
   - It only inspects the top node. `D(x) + y` is not a derivative term even though it
     contains one. Combine it with `Symbolics.hasnode` or `Symbolics.filterchildren` to ask
     about a whole tree.
-  - It operates on the unwrapped expression tree, so a wrapper such as `Num` must be
-    unwrapped first. `D(x)` returns a `Num`, and `is_derivative` of a `Num` falls through to
-    the catch-all and returns `false`; call `is_derivative(Symbolics.unwrap(D(x)))`
-    instead. Tree walkers like `hasnode` and `filterchildren` unwrap for you, so the common
-    case needs no special handling.
+  - A `Differential` applied to a `Complex{Num}` distributes over the real and imaginary
+    parts rather than forming one derivative term, so `is_derivative` is `false` for it
+    even though each part is a derivative.
 
 ```julia
 julia> using Symbolics
@@ -94,16 +96,16 @@ julia> @variables t x(t);
 
 julia> D = Differential(t);
 
+julia> is_derivative(D(x))
+true
+
 julia> is_derivative(Symbolics.unwrap(D(x)))
 true
 
-julia> is_derivative(D(x))   # a `Num`, not an expression tree
+julia> is_derivative(D(x) + x)
 false
 
-julia> is_derivative(Symbolics.unwrap(D(x) + x))
-false
-
-julia> is_derivative(Symbolics.unwrap(expand_derivatives(D(x^2))))
+julia> is_derivative(expand_derivatives(D(x^2)))
 false
 
 julia> Symbolics.hasnode(is_derivative, D(x) + x)
@@ -119,7 +121,7 @@ function is_derivative(x::SymbolicT)
         _ => false
     end
 end
-is_derivative(_) = false
+is_derivative(x) = iswrapped(x) && is_derivative(unwrap(x))
 
 Base.:*(D1::ComposedFunction, D2::Differential) = D1 ∘ D2
 Base.:*(D1::Differential, D2) = D1 ∘ D2

--- a/test/diff.jl
+++ b/test/diff.jl
@@ -397,6 +397,28 @@ let
     @test Symbolics.is_derivative(Symbolics.unwrap(D(X + 2a*Y)))
     @test !Symbolics.is_derivative(Symbolics.unwrap(D(X) + D(Y)))
     @test !Symbolics.is_derivative(Symbolics.unwrap(my_f(X, D(Y))))
+
+    # Wrapper types give the same answer as the expression they wrap (#1942).
+    @test !Symbolics.is_derivative(D)
+    @test !Symbolics.is_derivative(t)
+    @test !Symbolics.is_derivative(X)
+    @test !Symbolics.is_derivative(1)
+    @test Symbolics.is_derivative(D(X))
+    @test !Symbolics.is_derivative(D(X) + 3)
+    @test Symbolics.is_derivative(D(X + 2a * Y))
+    @test !Symbolics.is_derivative(D(X) + D(Y))
+    @test !Symbolics.is_derivative(my_f(X, D(Y)))
+    @test !Symbolics.is_derivative(expand_derivatives(D(X^2)))
+
+    @variables Z(t)[1:3]
+    @test Symbolics.is_derivative(D(Z))
+    @test !Symbolics.is_derivative(Z)
+
+    # `Differential` distributes over the parts of a `Complex{Num}`, so the result is a
+    # `complex` term rather than a single derivative term.
+    @variables W(t)::Complex
+    @test !Symbolics.is_derivative(D(W))
+    @test !Symbolics.is_derivative(Symbolics.unwrap(D(W)))
 end
 
 # Zeroth derivative (#1163)


### PR DESCRIPTION
> [!WARNING]
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

Fixes https://github.com/JuliaSymbolics/Symbolics.jl/issues/1942.

## The bug

`is_derivative` is exported, but the only way a user normally obtains a derivative term is
by applying a `Differential`, which returns a `Num`. `is_derivative` only had a method for
the raw expression tree plus an `is_derivative(_) = false` catch-all, so the obvious call
answered wrong:

```julia
julia> is_derivative(D(x))            # a `Num`
false

julia> is_derivative(Symbolics.unwrap(D(x)))
true
```

## The fix

```julia
-is_derivative(_) = false
+is_derivative(x) = iswrapped(x) && is_derivative(unwrap(x))
```

I used the `iswrapped` trait rather than adding `is_derivative(::Num)` and
`is_derivative(::Arr)` methods, because it also covers wrappers a downstream package
registers with `@symbolic_wrap` — that macro is public API for exactly that purpose, and a
per-type list would silently miss them. `iswrapped` is `false` on concrete non-wrapper
types, so the branch folds away and non-wrapper inputs behave exactly as before (`false`,
no `unwrap` call). Inference still gives `Bool` for `Num`, `Int` and `Any`.

`Complex{Num}` keeps answering `false`, and now says why in the docstring: a `Differential`
applied to one distributes over the real and imaginary parts, so
`unwrap(D(z)) == complex(D(real(z)), D(imag(z)))` — a `complex` term, not a single
derivative term. Making it `true` would mean inventing a "both parts are derivatives w.r.t.
the same variable" rule that no other part of the package uses, so I left it and documented
it instead.

The docstring's "must be unwrapped first" gotcha, added in
https://github.com/JuliaSymbolics/Symbolics.jl/pull/1941, is replaced by the new behavior,
and its examples now call `is_derivative` directly the way a user would.

## Blast radius

In-tree callers (`get_differential_vars!`) pass unwrapped `BasicSymbolic` nodes, and
`hasnode`/`filterchildren` already unwrap before calling the predicate, so nothing in
Symbolics changes. The only external users I could find are in Catalyst
(`is_species_diff`, `remove_diffs`/`diff_2_zero`, and the `D(x) ~ ...` shape check in the
`NonlinearSystem` conversion); all of them are on unwrapped nodes or on `Equation` fields,
which `~` unwraps. Where a wrapped value could reach one of them, the old answer was the
wrong one, so this can only fix.

## Versioning

7.36.0 → 7.37.0, with a NEWS entry under "Behavior changes".

Strictly this changes the answer of a documented public function, and a docstring stating
the old `false` behavior shipped in 7.36.0 a few hours ago, so there is an argument for
8.0.0. I went with a minor bump because the old answer was a wrong answer to the question
the function asks rather than a contract anyone could sensibly depend on — but it is your
call, and I am happy to redo it as a major.

## Verification

- Reproduced on the merge base (`d9041dd`): `is_derivative(D(x))` → `false`,
  `is_derivative(Symbolics.unwrap(D(x)))` → `true`.
- After the change, on Julia 1.11.9:

  | input | result |
  | --- | --- |
  | `D(x)` (`Num`) | `true` |
  | `unwrap(D(x))` | `true` |
  | `D(A)` where `@variables A(t)[1:3]` (`Arr`) | `true` |
  | `D(x) + 3`, `D(x) + D(y)`, `expand_derivatives(D(x^2))` | `false` |
  | `D`, `t`, `x`, `1`, `"hi"`, `nothing`, `[1,2]` | `false` |
  | `D(z)` where `@variables z(t)::Complex` | `false` |
  | `hasnode(is_derivative, D(x) + x)` | `true` (unchanged) |

- `GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` on Julia 1.11.9:
  `17042 pass, 380 broken, 0 fail` in 14m01s. That is the group containing `diff.jl` and
  `rewrite_helpers.jl`; I did not run `Everything`.
- New assertions added to the existing `is_derivative` `let` block in `test/diff.jl`,
  covering `Num`, `Arr` and `Complex{Num}` alongside the existing unwrapped cases.
- Runic reports the added lines clean. `src/diff.jl` and `test/diff.jl` are not
  Runic-formatted at baseline, so I did not reformat them wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLWVfZSWAySGqC7ausSJ18
