### PR TITLE
build: register this release as 7.36.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.37.0"
+version = "7.36.0"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]


### PR DESCRIPTION
Reclaims the version number so the released sequence stays contiguous.

`7.36.0` was set by #1941, but Registrator was never invoked on that merge — so `7.36.0` was never tagged and never registered. #1943 then bumped to `7.37.0`. Registering `7.37.0` trips General's sequential-version guideline (https://github.com/JuliaRegistries/General/pull/163750) and would need a `[merge approved]` override for a gap that has no reason to exist.

Verified `7.36.0` is still free:
- tags on this repo: `v7.35.0`, `v7.34.1`, `v7.34.0` — no `v7.36.0`
- General `Versions.toml`: up to `7.35.0` — no `7.36.0`

This release contains both #1941 (docstrings for the previously-undocumented public names, deprecation of the broken `infimum`/`supremum`, de-export of the accidentally-exported `get_canonical_expr`) and #1943 (`is_derivative` unwrapping fix). A minor bump from `7.35.0` is correct for that content.

One-line change to `Project.toml`; no code touched, so no formatter or test run applies. Registrator will be re-run against master once this merges.

Ignore until reviewed by @ChrisRackauckas.