### PR TITLE
Document fixpoint_sub as public API

### DIFF
--- a/src/Symbolics.jl
+++ b/src/Symbolics.jl
@@ -616,6 +616,7 @@ include("despecialize.jl")
 @public value
 @public CodegenFunctionOptions, codegen_function
 @public diff2term, map_subscripts
+@public fixpoint_sub
 
 @setup_workload begin
     fold1 = Val{false}()

--- a/src/variable.jl
+++ b/src/variable.jl
@@ -458,17 +458,47 @@ function (sub::FixpointSubstituter)(ex::SymbolicT)
 end
 
 """
-    fixpoint_sub(expr, dict, ::Type{OP} = Nothing; maxiters = 1000, warn_maxiters = true, filterer = SymbolicUtils.default_substitute_filter)
+    fixpoint_sub(
+        expr, dict, ::Type{OP} = Nothing;
+        maxiters = 1000,
+        warn_maxiters = true,
+        filterer = SymbolicUtils.default_substitute_filter,
+        fold = Val(false),
+    )
 
-Given a symbolic expression, equation or inequality `expr` perform the substitutions in
-`dict` recursively until the expression does not change. Substitutions that depend on one
-another will thus be recursively expanded. For example,
-`fixpoint_sub(x, Dict(x => y, y => 3))` will return `3`. The `OP` argument can be
-specified to prevent substitution of expressions inside `Operator`s of the given type. The
-`maxiters` keyword is used to limit the number of times the substitution can occur to avoid
-infinite loops in cases where the substitutions in `dict` are circular
-(e.g. `[x => y, y => x]`). Set `warn_maxiters = false` to suppress the warning emitted
-when the iteration limit is hit.
+Recursively apply the substitutions in `dict` until `expr` no longer changes.
+Substitutions that depend on one another are fully expanded. Circular substitutions stop
+after `maxiters` applications.
+
+# Arguments
+
+- `expr`: symbolic expression, equation, inequality, or array to transform.
+- `dict`: substitution rules accepted by [`SymbolicUtils.Substituter`](@ref).
+- `OP`: operator type whose contents should not be substituted. The default `Nothing`
+  does not exclude an operator type.
+
+# Keywords
+
+- `maxiters::Integer = 1000`: maximum number of repeated substitutions.
+- `warn_maxiters::Bool = true`: emit a warning when the iteration limit is reached.
+- `filterer = SymbolicUtils.default_substitute_filter`: predicate controlling which
+  expression nodes may be substituted.
+- `fold::Val = Val(false)`: whether to constant-fold while substituting.
+
+# Returns
+
+The transformed value after reaching a fixpoint or the iteration limit.
+
+# Examples
+
+```jldoctest
+julia> using Symbolics
+
+julia> @variables x y;
+
+julia> Symbolics.fixpoint_sub(x, Dict(x => y, y => 3))
+3
+```
 
 See also: [`FixpointSubstituter`](@ref).
 """

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -57,6 +57,7 @@ end
 
 @testset "fixpoint_sub maxiters" begin
     @variables x y
+    VERSION >= v"1.11" && @test Base.ispublic(Symbolics, :fixpoint_sub)
     expr = Symbolics.fixpoint_sub(x, Dict(x => y, y => x))
     @test isequal(expr, y)
     expr = Symbolics.fixpoint_sub(x, Dict(x => y, y => x); maxiters = 9)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- declare `fixpoint_sub` as public API
- replace its existing prose docstring with a SciMLStyle API docstring and executable usage example
- test the public declaration on Julia versions that provide `Base.ispublic`

`fixpoint_sub` is already rendered on the expression-manipulation manual page. This makes the declaration, definition-site docstring, rendered entry, and API status agree. This adds public API and therefore needs a minor release (7.37.0).

## Local verification

- Julia 1.12.6: focused `test/utils.jl` passed, 122 tests.
- Julia 1.10.11: focused `test/utils.jl` passed, 121 tests.
- Julia 1.12.6: the documentation build completed and the generated expression-manipulation page contains `Symbolics.fixpoint_sub` and its example. The existing docs configuration has `doctest = false` and pre-existing warn-only warnings, so this is not a claim that the whole docs tree is strict.
- Runic check passed for all changed files.
- `git diff --check` passed.

A full Julia 1.12.6 Core `Pkg.test()` run reached 17,018 passes and 379 pre-existing broken tests, then failed only in the ForwardDiff extension at `round(::Num, RoundUp)`. The exact failure reproduces on a clean checkout of current `master` (`30e97f6b5`) with ForwardDiff 1.4.5, so it is not introduced by this PR. A separate clean-default regression investigation is in progress.