### PR TITLE
Fix inherited discontinuity spell-check failures

### DIFF
--- a/src/discontinuities.jl
+++ b/src/discontinuities.jl
@@ -166,7 +166,7 @@ function SU.promote_symtype(::typeof(_approx_max), M::SU.TypeT, A::SU.TypeT, B::
     return SU.promote_symtype(*, SU.promote_symtype(+, A, B), M)
 end
 
-function SU.promote_shape(::typeof(_approx_max), @nospecialize(shs::Vararg{SU.ShapeT, 3}))
+function SU.promote_shape(::typeof(_approx_max), @nospecialize(shapes::Vararg{SU.ShapeT, 3}))
     return SU.ShapeVecT()
 end
 
@@ -178,7 +178,7 @@ function SU.promote_symtype(::typeof(_approx_min), args::SU.TypeT...)
     return SU.promote_symtype(_approx_max, args...)
 end
 
-function SU.promote_shape(::typeof(_approx_min), @nospecialize(shs::Vararg{SU.ShapeT, 3}))
+function SU.promote_shape(::typeof(_approx_min), @nospecialize(shapes::Vararg{SU.ShapeT, 3}))
     return SU.ShapeVecT()
 end
 
@@ -190,7 +190,7 @@ function SU.promote_symtype(::typeof(_approx_abs), M::SU.TypeT, A::SU.TypeT)
     return SU.promote_symtype(*, M, A)
 end
 
-function SU.promote_shape(::typeof(_approx_abs), @nospecialize(shs::Vararg{SU.ShapeT, 2}))
+function SU.promote_shape(::typeof(_approx_abs), @nospecialize(shapes::Vararg{SU.ShapeT, 2}))
     return SU.ShapeVecT()
 end
 
@@ -202,7 +202,7 @@ function SU.promote_symtype(::typeof(_approx_ge), args::SU.TypeT...)
     return SU.promote_symtype(_approx_max, args...)
 end
 
-function SU.promote_shape(::typeof(_approx_ge), @nospecialize(shs::Vararg{SU.ShapeT, 3}))
+function SU.promote_shape(::typeof(_approx_ge), @nospecialize(shapes::Vararg{SU.ShapeT, 3}))
     return SU.ShapeVecT()
 end
 
@@ -212,7 +212,7 @@ function SU.promote_symtype(::typeof(_approx_le), args::SU.TypeT...)
     return SU.promote_symtype(_approx_max, args...)
 end
 
-function SU.promote_shape(::typeof(_approx_le), @nospecialize(shs::Vararg{SU.ShapeT, 3}))
+function SU.promote_shape(::typeof(_approx_le), @nospecialize(shapes::Vararg{SU.ShapeT, 3}))
     return SU.ShapeVecT()
 end
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- rename the five unused `shs` shape parameters to `shapes`
- clear the inherited `crate-ci/typos@v1.35.3` failures without changing behavior

## Investigation

The identifiers entered `src/discontinuities.jl` in commit `20ef12d9` (PR #1931). The exact spell checker passes its parent `0ff66954a` and fails `20ef12d9`. PR #1931's own spell job failed before merge:
https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/30086013389/job/89458254048

PR #1945 reproduced the same inherited failure:
https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/31277434905/job/93153218821

## Local verification

- `typos-cli 1.35.3 .`: passes
- `include("test/discontinuities.jl")` on Julia 1.12.6: all focused testsets pass
- Runic.jl 1.7.0 was run in-place on every changed line and made no changes
- `git diff --check`: passes

The repository-wide Runic check still reports unrelated pre-existing formatting outside these lines; this PR does not alter those files.