### PR TITLE
Use job summaries for fork benchmarks

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -23,3 +23,4 @@ jobs:
           julia-version: '1'
           rev: '${{ github.event.pull_request.base.sha }},${{ github.sha }}'
           bench-on: '${{ github.sha }}'
+          job-summary: '${{ github.event.pull_request.head.repo.fork }}'


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Use AirspeedVelocity.jl's existing `job-summary` mode for fork pull requests. Same-repository PRs continue to receive benchmark comments.

## Root cause

PR #1945's benchmark measurements completed for both revisions. The job failed only when `peter-evans/create-or-update-comment@v5` called the issue-comment API:
https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/31277434853/job/93153218654

The fork-triggered `pull_request` run received `PullRequests: read`, despite the workflow requesting write access, and the comment request returned HTTP 403 `Resource not accessible by integration`. This is GitHub's fork-token permission downgrade, not a benchmark regression.

The composite action already supports `job-summary: true`, which skips both comment actions and writes the same report to `GITHUB_STEP_SUMMARY`. This workflow now selects that mode exactly when `github.event.pull_request.head.repo.fork` is true.

## Local verification

- actionlint 1.7.7 passes YAML and expression validation with shellcheck integration disabled
- full actionlint reports only the unchanged SC2006 warning for line 20's legacy backticks; current `master` reports the same warning
- `git diff --check`: passes
- Runic.jl 1.7.0 was run repository-wide; it reports existing formatting debt in unchanged Julia files, and this PR changes no Julia source

This fork PR's own benchmark workflow is the end-to-end verification of the fork branch.