### PR TITLE
Fix symbolic rounding with ForwardDiff 1.4.5

### DIFF
--- a/ext/SymbolicsForwardDiffExt.jl
+++ b/ext/SymbolicsForwardDiffExt.jl
@@ -122,6 +122,9 @@ for pred in [:isequal, :(==)]
     end
 end
 
+Base.floor(d::Dual{T, Num}) where {T} = floor(value(d))
+Base.ceil(d::Dual{T, Num}) where {T} = ceil(value(d))
+
 ###################################
 # General Mathematical Operations #
 ###################################

--- a/test/forwarddiff_symbolic_dual_ops.jl
+++ b/test/forwarddiff_symbolic_dual_ops.jl
@@ -125,3 +125,9 @@ end
     @variables y
     @test ForwardDiff.derivative(x -> promote(x, y)[1], 1) === Num(1)
 end
+
+@testset "symbolic rounding discontinuities" begin
+    @variables y
+    @test iszero(ForwardDiff.derivative(floor, y))
+    @test iszero(ForwardDiff.derivative(ceil, y))
+end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Restore symbolic `floor` and `ceil` differentiation after ForwardDiff 1.4.5 switched `Dual` rounding to Base's `round(x, ::RoundingMode)` interface.

The compatibility methods are confined to `SymbolicsForwardDiffExt` and only apply when the dual primal is `Num`. The regression test directly checks both symbolic discontinuities.

## Regression boundary

Clean Symbolics `master` at `30e97f6b5`:

- ForwardDiff 1.4.4: `test/forwarddiff_symbolic_dual_ops.jl` passes
- ForwardDiff 1.4.5: fails at `ceil(Dual{...,Num})` because ForwardDiff calls `round(::Num, RoundUp)`

The behavior changed in ForwardDiff PR #829 / commit `569af35`:
https://github.com/JuliaDiff/ForwardDiff.jl/pull/829

ForwardDiff's new method is correct for its rounding interface. Symbolics owns the cross-package compatibility because `Num` supports symbolic `floor` and `ceil` without implementing every Base rounding mode.

## Local verification

Julia 1.12.6, ForwardDiff 1.4.5:
- focused ForwardDiff extension test: passes, including the two new assertions
- full `GROUP=Core Pkg.test()`: `17,105` passed, `355` pre-existing broken, exit 0

Julia 1.10.11, ForwardDiff 1.4.5:
- focused ForwardDiff extension test: passes, including the two new assertions

Additional:
- Runic.jl 1.7.0 was run in-place on every changed line and made no changes
- `git diff --check`: passes

The clean-default failure was reproduced before this branch was created; no changes from the public `fixpoint_sub` PR are included here.