### PR TITLE
Set Symbolics version to 7.37.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.36.0"
+version = "7.37.0"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Set Symbolics' version to `7.37.0`. General's latest non-yanked release is `7.36.0`; the pending source changes add public functionality, so `7.37.0` is the next sequential minor release.

## Verification

- `GROUP=Core /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed: the main test set reported 17,077 passed and 388 pre-existing broken tests, with all three SymbolicIndexingInterface test sets also passing.
- `typos --force-exclude Project.toml` — passed.
- `git diff --check` — passed.

No Julia source file changes in this version-only diff, so no formatter output is introduced. A whole-repository Runic check was attempted and found broad pre-existing formatter drift; this PR does not mix that unrelated mechanical sweep into the release correction. The repository's JuliaFormatter configuration also does not declare a formatter version, and JuliaFormatter 2.12.4 would rewrite 140 pre-existing files, so that sweep was not included.

The docs build was not run because the diff changes no docstrings, documentation, or public API. Downstream, SymPy, GPU, and platform-specific groups were not run locally.

## Registration

After merge, register from a commit on the default branch with:

`@JuliaRegistrator register`
