### PR TITLE
Fix metadata rename with current SymbolicUtils

### DIFF
--- a/src/variable.jl
+++ b/src/variable.jl
@@ -634,7 +634,7 @@ function renamed_metadata(metadata::Union{Nothing, SymbolicUtils.MetadataT}, nam
                 v = v::NTuple{2, Symbol}
                 v = (v[1], name)
             end
-            newmeta = Base.ImmutableDict(newmeta, k, v)
+            newmeta = Base.ImmutableDict{DataType, Any}(newmeta, k, v)
         end
         return newmeta
     end

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -179,6 +179,14 @@ let
     @test Symbolics.getname(Symbolics.rename(y[2], :u)) === :u
 end
 
+@testset "renamed metadata" begin
+    metadata = Base.ImmutableDict{DataType, Any}(
+        Symbolics.VariableSource, (:variables, :x),
+    )
+    renamed = Symbolics.renamed_metadata(metadata, :y)
+    @test renamed[Symbolics.VariableSource] === (:variables, :y)
+end
+
 let
     s = :y
     x = (1:2,1:3)


### PR DESCRIPTION
## What changed

Use the typed `Base.ImmutableDict{DataType, Any}` constructor when rebuilding variable metadata. The current SymbolicUtils developer interface no longer provides the old untyped constructor path, so the existing call fails when a `VariableSource` metadata entry is renamed.

Add a regression test for `renamed_metadata`.

## Verification

- Before the fix, with the current SymbolicUtils owner checkout: the direct reproducer failed with `MethodError: no method matching Base.ImmutableDict(::Base.ImmutableDict{DataType, Any}, ::Type{Symbolics.VariableSource}, ::Tuple{Symbol, Symbol})`.
- After the fix, the same reproducer printed `RENAME_OK`.
- `include("test/macro.jl")` passed, including the new `renamed metadata` test (`1/1`).
- `git diff --check` passed.
- Changed-line `typos` passed.

Please ignore this draft until reviewed by @ChrisRackauckas.
