### PR TITLE
Fix Latexify for whole-array equation vectors

### DIFF
--- a/ext/SymbolicsLatexifyExt.jl
+++ b/ext/SymbolicsLatexifyExt.jl
@@ -80,6 +80,11 @@ _as_latexstring(x::AbstractString) = LaTeXString(x)
 
 recipe(n) = _as_latexstring(latexify_derivatives(cleanup_exprs(_toexpr(n))))
 
+function align_side(n)
+    wrapped = wrap(n)
+    return wrapped isa Symbolics.Arr ? recipe(n) : wrapped
+end
+
 @latexrecipe function f(n::Num)
     env --> :equation
     mult_symbol --> "~"
@@ -142,7 +147,7 @@ end
         return map(first ∘ first ∘ Latexify.apply_recipe, eqs)
     else
         env --> :align
-        return wrap.(getfield.(eqs, :lhs)), wrap.(getfield.(eqs, :rhs))
+        return align_side.(getfield.(eqs, :lhs)), align_side.(getfield.(eqs, :rhs))
     end
 end
 

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -77,6 +77,9 @@ end
     ]
 )
 
+@variables s p(s)[1:2] q(s)[1:2] A[1:2, 1:2]
+@test_reference "latexify_refs/equation_vec_array.txt" latexify([q ~ A * p])
+
 @test_reference "latexify_refs/complex1.txt" latexify(x^2 - y^2 + 2im * x * y)
 @test_reference "latexify_refs/complex2.txt" latexify(3im * x)
 @test_reference "latexify_refs/complex3.txt" latexify(1 - x + (1 + 2x) * im; imaginary_unit = "\\mathbb{i}")

--- a/test/latexify_refs/equation_vec_array.txt
+++ b/test/latexify_refs/equation_vec_array.txt
@@ -1,0 +1,3 @@
+\begin{align}
+q\left( s \right) &= A \cdot p\left( s \right)
+\end{align}


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

Whole-array equation sides reached Latexify's `:align` renderer as `Symbolics.Arr` wrappers around raw `BasicSymbolic` values, which the array recipe could not render. Convert only array-valued alignment sides through Symbolics' existing expression recipe while preserving the established scalar-equation rendering path.

This adds a reference regression for a vector containing `q ~ A * p`, including the expected aligned LaTeX output. Closes https://github.com/JuliaSymbolics/Symbolics.jl/issues/1961.

## Verification

Failing before the implementation change, with the new regression test present:

```text
$ julia +1.12 --project=../repro-env test/latexify.jl
ERROR: cannot latexify objects of type SymbolicUtils.BasicSymbolicImpl.var"typeof(BasicSymbolicImpl)"{SymReal}
...
in expression starting at Symbolics.jl/test/latexify.jl:81
```

The same test file after the fix exits successfully:

```text
$ julia +1.12 --project=../repro-env test/latexify.jl
Test Summary:                         | Pass  Total  Time
getindex with vector argument (#1820) |    1      1  1.3s
Test Summary:                          | Pass  Total  Time
ifelse_eager / ifelse_branching render |    2      2  0.8s
```

The full relevant group confirms all Latexify tests pass:

```text
$ GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:   |  Pass  Error  Broken  Total      Time
test set        | 17090      1     365  17456  17m49.8s
  Latexify Test |    43                    43     20.7s
```

The sole local `Core` error is unrelated and reproduces on a detached clean `upstream/master` checkout: `test/nested_forwarddiff_sparsity.jl` accesses the removed `PreallocationTools.DiffCache.any_du` field with PreallocationTools 1.6.0. It is fixed separately in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1964; no workaround or unrelated change is included here.

### CI and clean-master failures

The completed PR CI run has 19 passing checks and five failures. The `Core` job confirms `Latexify Test | 43 pass | 43 total`; the documentation build, spelling check, benchmark, and all other completed feature-relevant jobs pass.

Every failing job is unrelated to this three-file Latexify change and has a corresponding clean-master reproduction and isolated draft fix:

- `Core`: removed PreallocationTools cache field, fixed in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1964 — https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/32885989625/job/97926454997
- `Downstream`: stale `ModelingToolkit.MATLABTarget` test reference, fixed in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1963 — https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/32885989625/job/97926454918
- `Catalyst.jl/Modeling` and `Catalyst.jl/Simulation`: accidental ModelingToolkitBase bindings, fixed in https://github.com/SciML/Catalyst.jl/pull/1543 — https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/32885989739/job/97926455606 and https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/32885989739/job/97926455689
- `ModelingToolkit.jl/InterfaceI`: removed blanket Optim algorithm reexports, fixed in https://github.com/SciML/ModelingToolkit.jl/pull/5016 — https://github.com/JuliaSymbolics/Symbolics.jl/actions/runs/32885989739/job/97926455593

The mandatory clean-master investigation also exposed a deterministic higher-degree solver recursion, fixed separately in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1966. It is not a failure of this PR's CI run.

Additional checks:

```text
$ GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Testing Symbolics tests passed

$ julia +1.12 --project=../formatter-env -m Runic --check --lines=83:86 --lines=149:150 ext/SymbolicsLatexifyExt.jl
$ julia +1.12 --project=../formatter-env -m Runic --check --lines=80:81 test/latexify.jl
$ typos ext/SymbolicsLatexifyExt.jl test/latexify.jl test/latexify_refs/equation_vec_array.txt
$ git diff --check
```

The repository currently has no `GROUP=QA` test body, so that harness invocation is a successful no-op. Documentation was not built locally because this change does not touch docs, docstrings, or public API; the CI documentation build passed. GPU and downstream groups were not run locally because this extension-only fix is covered by `Core`; CI exercised the downstream matrix, with the unrelated clean-master failures documented above.

Implemented with OpenAI Codex; the session is linked below alongside the repository-required attribution footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
