### PR TITLE
Use MATLABTarget through its owning module

### DIFF
--- a/test/downstream/ParameterizedFunctions_MATLAB.jl
+++ b/test/downstream/ParameterizedFunctions_MATLAB.jl
@@ -1,4 +1,5 @@
 using ModelingToolkit, ParameterizedFunctions
+import Symbolics
 
 # Build the expected MATLAB string from the actual orderings reported by the
 # `System` (parameter index assignment is determined by MTK and changes from
@@ -38,7 +39,7 @@ eqs = [D(x) ~ a*x - b*x*y
 equations(sys)
 matstr = Symbolics.build_function(map(x->x.rhs,equations(sys)),unknowns(sys),
                                         parameters(sys),ModelingToolkit.get_iv(sys),
-                                        target = ModelingToolkit.MATLABTarget())
+                                        target = Symbolics.MATLABTarget())
 @test _normalize_matlab(matstr) == _normalize_matlab(_matlab_lotka_volterra_expected(sys, a, b, c, d))
 
 f = @ode_def_bare LotkaVolterra begin
@@ -54,7 +55,7 @@ sys = modelingtoolkitize(prob)
 [eq.rhs for eq ∈ equations(sys)]
 matstr = Symbolics.build_function(map(x->x.rhs,equations(sys)),unknowns(sys),
                                         parameters(sys),ModelingToolkit.get_iv(sys),
-                                        target = ModelingToolkit.MATLABTarget())
+                                        target = Symbolics.MATLABTarget())
 # `modelingtoolkitize` names the parameters `α, β, γ, δ` (in declaration
 # order), so look them up by name from the resulting system.
 let ps = parameters(sys)


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

The ParameterizedFunctions downstream regression constructed the public `MATLABTarget` API through `ModelingToolkit`, which only exposed that name as an accidental internal binding. ModelingToolkit 11.39.1 removed the stale binding while making imports owner-correct, so the Symbolics downstream lane began erroring before its assertions ran.

Import `Symbolics` directly in the regression and construct `Symbolics.MATLABTarget()` at both call sites. That is the declaring module and the target is public, documented API.

## Failure before

On clean Symbolics `upstream/master` (`043d7d2b480fc0c58a799f80bef114892be93cdf`), Julia 1.12.7, ModelingToolkit 11.40.0:

```
GROUP=Downstream ~/.juliaup/bin/julia +1.12 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'

LoadError: UndefVarError: `MATLABTarget` not defined in `ModelingToolkit`
Hint: a global variable of this name also exists in Symbolics.

Test Summary:                                       | Error  Total   Time
ParameterizedFunctions MATLABDiffEq Regression Test |     1      1  11.7s
ERROR: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
```

The last successful Symbolics downstream job used ModelingToolkit 11.39.0; the first observed failure used 11.39.1. A source bisect across those tags identified `03c130782349ca8ed91e4f9a92da08d590c53ffe` as the first commit removing the stale `ModelingToolkit.MATLABTarget` binding:

```
git bisect start v11.39.1 v11.39.0
git bisect run bash -c 'git grep -q MATLABTarget -- src/ModelingToolkit.jl'

03c130782349ca8ed91e4f9a92da08d590c53ffe is the first bad commit
```

That commit is the intended import-owner cleanup in https://github.com/SciML/ModelingToolkit.jl/pull/4981, so restoring the re-export would be the wrong fix. Symbolics made `MATLABTarget` public and documented in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1933.

## Verification after

```
GROUP=Downstream ~/.juliaup/bin/julia +1.12 --project=. --startup-file=no -e 'using Pkg; Pkg.test()'

Test Summary:                                       | Pass  Total   Time
ParameterizedFunctions MATLABDiffEq Regression Test |    2      2  16.2s
Test Summary:                       | Pass  Total  Time
ModelingToolkit Variable Utils Test |    2      2  0.2s
Test Summary: | Pass  Total     Time
DI Test       | 7278   7278  7m14.8s
Testing Symbolics tests passed
```

Additional checks:

- `GROUP=QA ... Pkg.test()`: exit 0. The current `test/runtests.jl` has no QA group branch, so this command runs no QA assertions; it is not counted as QA coverage.
- `Runic.jl 1.7.0 --check test/downstream/ParameterizedFunctions_MATLAB.jl`: exit 0.
- `typos test/downstream/ParameterizedFunctions_MATLAB.jl`: exit 0.
- `git diff --check`: exit 0.

## Not verified

The Core group, documentation build, GPU paths, downstream packages outside the declared Downstream group, and Julia pre were not run. This changes only an existing downstream test and does not change package source, documentation, public API, or dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47