### PR TITLE
Fix symbolic cache dispatch with PreallocationTools 1.5+

### DIFF
--- a/ext/SymbolicsPreallocationToolsExt.jl
+++ b/ext/SymbolicsPreallocationToolsExt.jl
@@ -1,49 +1,37 @@
 module SymbolicsPreallocationToolsExt
 
 using PreallocationTools
-import PreallocationTools: _restructure, get_tmp
+import PreallocationTools: get_tmp
 using Symbolics, ForwardDiff
 
-function get_tmp(dc::DiffCache, u::Type{X}) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function _symbolic_tmp(dc::C, u::Type{X}) where {
+        C <: Union{DiffCache, FixedSizeDiffCache}, X <: ForwardDiff.Dual,
+    }
+    return invoke(get_tmp, Tuple{C, Type{Y} where {Y <: Number}}, dc, u)
 end
 
-function get_tmp(dc::DiffCache, u::X) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function get_tmp(dc::DiffCache, u::Type{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return _symbolic_tmp(dc, u)
 end
 
-function get_tmp(dc::DiffCache, u::AbstractArray{X}) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function get_tmp(dc::DiffCache, u::X) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return get_tmp(dc, X)
 end
 
-function get_tmp(dc::FixedSizeDiffCache, u::Type{X}) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function get_tmp(dc::DiffCache, u::AbstractArray{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return get_tmp(dc, X)
 end
 
-function get_tmp(dc::FixedSizeDiffCache, u::X) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function get_tmp(dc::FixedSizeDiffCache, u::Type{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return _symbolic_tmp(dc, u)
 end
 
-function get_tmp(dc::FixedSizeDiffCache, u::AbstractArray{X}) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function get_tmp(dc::FixedSizeDiffCache, u::X) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return get_tmp(dc, X)
+end
+
+function get_tmp(dc::FixedSizeDiffCache, u::AbstractArray{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return get_tmp(dc, X)
 end
 
 end

--- a/test/nested_forwarddiff_sparsity.jl
+++ b/test/nested_forwarddiff_sparsity.jl
@@ -21,3 +21,17 @@ cache = DiffCache(zeros(2))
 pattern = Symbolics.jacobian_sparsity((r, x) -> residual(r, x, cache), zeros(2), zeros(2))
 @test pattern == sparse([1 0
                          0 1])
+
+@testset "symbolic dual cache methods" begin
+    dual_type = ForwardDiff.Dual{Nothing, Num, 2}
+    dual = dual_type(Num(1), ForwardDiff.Partials((Num(1), Num(0))))
+    duals = fill(dual, 2)
+
+    for cache in (DiffCache(zeros(2)), FixedSizeDiffCache(zeros(2), 2))
+        for input in (dual, dual_type, duals)
+            workspace = get_tmp(cache, input)
+            workspace .= duals
+            @test get_tmp(cache, input) == duals
+        end
+    end
+end


### PR DESCRIPTION
## What changed and why

PreallocationTools 1.5 replaced the `any_du` cache field with typed workspaces, but the Symbolics extension still accessed `any_du` directly. Symbolic ForwardDiff cache requests therefore failed with PreallocationTools 1.5 and later.

This delegates symbolic dual requests through PreallocationTools' documented public `get_tmp` interface. Tests cover scalar, type, and array requests for both `DiffCache` and `FixedSizeDiffCache`, including repeated access to the same workspace.

This PR should be ignored until reviewed by @ChrisRackauckas.

## Regression boundary

The existing `test/nested_forwarddiff_sparsity.jl` passes at PreallocationTools commit `a28de1f58e1686b28b62bbfac81f66007da949eb` and fails at `a032da6e40b36efcfa459d7530816b7b77d0bd2c`, which replaced `any_du` with `typed_du` and was released in PreallocationTools 1.5.0:

https://github.com/SciML/PreallocationTools.jl/commit/a032da6e40b36efcfa459d7530816b7b77d0bd2c

## Verification

### Failing before the fix

```console
$ TMPDIR="$PWD/../tmp" JULIA_DEPOT_PATH="$PWD/../julia-depot" julia --startup-file=no --project=../base-env -e 'using Pkg; Pkg.status(); include("test/nested_forwarddiff_sparsity.jl")'
Status `~/sandbox/tmp_20260825_174238_75437/base-env/Project.toml`
  [f6369f11] ForwardDiff v1.4.5
  [d236fae5] PreallocationTools v1.6.0
  [0c5d862f] Symbolics v7.37.0 `~/sandbox/tmp_20260825_174238_75437/Symbolics-master`
ERROR: LoadError: FieldError: type DiffCache has no field `any_du`, available fields: `du`, `dual_du`, `typed_du`, `warn_on_resize`
```

The same clean-master test passed before the dependency change and failed at the first changed commit:

```console
PreallocationTools a28de1f58e1686b28b62bbfac81f66007da949eb
PASS: nested_forwarddiff_sparsity.jl

PreallocationTools a032da6e40b36efcfa459d7530816b7b77d0bd2c
ERROR: LoadError: FieldError: type DiffCache has no field `any_du`, available fields: `du`, `dual_du`, `typed_du`, `warn_on_resize`
```

### Passing with the fix

```console
$ TMPDIR="$PWD/../tmp" JULIA_DEPOT_PATH="$PWD/../julia-depot" julia --startup-file=no --project=../forwarddiff-env -e 'include("test/nested_forwarddiff_sparsity.jl"); println("PASS: PreallocationTools 1.6.0")'
Test Summary:               | Pass  Total  Time
symbolic dual cache methods |    6      6  0.5s
PASS: PreallocationTools 1.6.0

$ TMPDIR="$PWD/../tmp" JULIA_DEPOT_PATH="$PWD/../julia-depot" julia --startup-file=no --project=../forwarddiff-env -e 'include("test/nested_forwarddiff_sparsity.jl"); println("PASS: PreallocationTools 1.0.0")'
Test Summary:               | Pass  Total  Time
symbolic dual cache methods |    6      6  0.4s
PASS: PreallocationTools 1.0.0
```

The full Core group ran with PreallocationTools 1.6.0. The affected test passed all seven assertions. The suite's only error was in unrelated solver code at `test/solver.jl:461` after 93 minutes:

```console
$ GROUP=Core TMPDIR="$PWD/../tmp" JULIA_DEPOT_PATH="$PWD/../julia-depot" julia --startup-file=no --project=../forwarddiff-env -e 'using Pkg; Pkg.test("Symbolics")'
Test Summary:                             |  Pass  Error  Broken  Total       Time
test set                                  | 17080      1     360  17441  110m32.9s
  Nested ForwardDiff Sparsity Test        |     7                     7       2.6s
  RootFinding solver                      |   166      1       5    172   97m33.5s
    Isolate/Attract solve                 |    31      1       1     33   93m09.7s
ERROR: LoadError: Some tests did not pass: 17080 passed, 0 failed, 1 errored, 360 broken.
```

The isolated solver expression passed against clean `upstream/master` commit `043d7d2b480fc0c58a799f80bef114892be93cdf`, returning `[(1//2)*√(8.0)]`. The full-suite error is therefore order- or state-dependent rather than a standalone clean-master reproducer, and is being investigated separately. This PR does not claim to fix or explain that solver error.

The repository has no `QA` branch in `test/runtests.jl`; `GROUP=QA` completed package loading without running QA assertions:

```console
$ GROUP=QA TMPDIR="$PWD/../tmp" JULIA_DEPOT_PATH="$PWD/../julia-depot" julia --startup-file=no --project=../forwarddiff-env -e 'using Pkg; Pkg.test("Symbolics")'
Testing Symbolics tests passed
```

Formatting and spelling checks completed with exit status 0:

```console
$ tr -d '\r' < ext/SymbolicsPreallocationToolsExt.jl | julia --startup-file=no --project=../formatter-env -m Runic --check --stdin-filename=ext/SymbolicsPreallocationToolsExt.jl -
$ sed -n '25,38p' test/nested_forwarddiff_sparsity.jl | tr -d '\r' | julia --startup-file=no --project=../formatter-env -m Runic --check --stdin-filename=test/nested_forwarddiff_sparsity.jl -
$ typos --format brief ext/SymbolicsPreallocationToolsExt.jl test/nested_forwarddiff_sparsity.jl
```

## Not verified

- Documentation was not built because this does not change public API, docstrings, or documentation.
- Downstream and environment-specific groups were not run.

## Reviewer attention

The extension uses `invoke` to reach PreallocationTools' public generic `get_tmp(::Cache, ::Type{<:Number})` method, bypassing the more-specific ForwardDiff method that cannot reinterpret a non-bits symbolic dual for `FixedSizeDiffCache`. This preserves Symbolics' specialization without relying on PreallocationTools internals or concrete cache fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
