### PR TITLE
Prevent recursive solver factor cycles

### DIFF
--- a/src/solver/main.jl
+++ b/src/solver/main.jl
@@ -308,8 +308,10 @@ function solve_univar(expression, x; dropmultiplicity=true, strict=true)
 
     factors_subbed = map(factor -> ssubs(factor, subs), factors)
     arr_roots = []
+    is_unfactored = length(factors_subbed) == 1 &&
+        isequal(u * first(factors_subbed), wrap(expression))
 
-    if degree < 5 && isequal(factors_subbed[1], wrap(expression))
+    if degree < 5 && is_unfactored
         arr_roots = get_roots(expression, x)
 
         # multiplicities (repeated roots)
@@ -319,7 +321,7 @@ function solve_univar(expression, x; dropmultiplicity=true, strict=true)
                 append!(arr_roots, og_arr_roots)
             end
         end
-    elseif length(factors) > 1 || (length(factors) == 1 && !isequal(factors_subbed[1], wrap(expression)))
+    elseif !is_unfactored
         for i in eachindex(factors_subbed) 
             if !any(isequal(x, var) for var in get_variables(factors[i]))
                 continue

--- a/test/solver.jl
+++ b/test/solver.jl
@@ -196,6 +196,13 @@ end
     @test all(isapprox.(arr_known_roots, r_novar, atol=0.00001))
 end
 
+@testset "Higher degree univar" begin
+    expr = -b + a*x + c*x - d*x^2 + b*x^3 - a*x^4 - x^5
+    root = only(symbolic_solve(expr, x))
+    @test operation(root) === Symbolics.RootsOf
+    @test isequal(arguments(root), [Symbolics.unwrap(expr), Symbolics.unwrap(x)])
+end
+
 @testset "Complex coeffs univar" begin
     expr = x^4 + sqrt(complex(-2//1))
     arr_get_roots = sort_roots(eval.(Symbolics.toexpr.(symbolic_solve(expr, x))))


### PR DESCRIPTION
Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`solve_univar` treated a single Nemo factor as new work whenever the factor was not structurally equal to the input polynomial. Nemo returns a separate factorization unit, so an irreducible polynomial can be represented as `u = -1` plus the negated polynomial; recursively factoring that result can alternate between `p` and `-p` until a stack overflow.

This PR reconstructs the single-factor result with Nemo's unit before deciding that factorization made progress. It adds a public-API regression for an irreducible degree-5 symbolic polynomial and verifies that `symbolic_solve` returns `RootsOf` rather than recursing.

## Failing before

I ran the new test against unfixed `master` with a temporary recursion-depth diagnostic guard (not included in this PR), which turns the otherwise unbounded recursion into a prompt error:

```text
$ julia +1.12 --startup-file=no --project=../solver-instrument-env -e 'using Test, Symbolics; using Groebner, Nemo; @variables x a b c d; @testset "Higher degree univar" begin; expr=-b+a*x+c*x-d*x^2+b*x^3-a*x^4-x^5; root=only(symbolic_solve(expr,x)); @test Symbolics.operation(root)===Symbolics.RootsOf; @test isequal(Symbolics.arguments(root),[Symbolics.unwrap(expr),Symbolics.unwrap(x)]); end'
Higher degree univar: Error During Test
  solve_univar recursion at depth 51 for b - a*x - c*x + d*(x^2) - b*(x^3) + a*(x^4) + x^5
  solve_univar(...) (repeats 51 times)
Test Summary:        | Error  Total     Time
Higher degree univar |     1      1  1m10.5s
ERROR: Some tests did not pass: 0 passed, 0 failed, 1 errored, 0 broken.
```

The factor trace on unfixed code alternates deterministically:

```text
1 u=-1//1 next=b - a*x - c*x + d*(x^2) - b*(x^3) + a*(x^4) + x^5 equal=false reconstructed=true
2 u=-1//1 next=-b + a*x + c*x - d*(x^2) + b*(x^3) - a*(x^4) - (x^5) equal=false reconstructed=true
3 u=-1//1 next=b - a*x - c*x + d*(x^2) - b*(x^3) + a*(x^4) + x^5 equal=false reconstructed=true
```

## Passing after

The identical test against this branch passes:

```text
$ julia +1.12 --startup-file=no --project=../solver-stack-env -e 'using Test, Symbolics; using Groebner, Nemo; @variables x a b c d; @testset "Higher degree univar" begin; expr=-b+a*x+c*x-d*x^2+b*x^3-a*x^4-x^5; root=only(symbolic_solve(expr,x)); @test Symbolics.operation(root)===Symbolics.RootsOf; @test isequal(Symbolics.arguments(root),[Symbolics.unwrap(expr),Symbolics.unwrap(x)]); end'
Test Summary:        | Pass  Total     Time
Higher degree univar |    2      2  1m08.2s
```

The complete solver file passes, including the regression:

```text
$ julia +1.12 --startup-file=no --project=../solver-stack-env test/solver.jl
Test Summary:        | Pass  Total  Time
Higher degree univar |    2      2  1.2s
Test Summary:         | Pass  Broken  Total   Time
Isolate/Attract solve |   32       1     33  29.0s
```

The full Core group reached 17,087 passes. The sole error is the independently reproduced `PreallocationTools.DiffCache.any_du` failure already fixed in the separate draft PR linked below; the RootFinding solver group is clean.

```text
$ GROUP=Core julia +1.12 --startup-file=no --project=../solver-stack-env -e 'using Pkg; Pkg.test("Symbolics")'
Test Summary:                            |  Pass  Error  Broken  Total      Time
test set                                 | 17087      1     357  17445  16m54.5s
  Nested ForwardDiff Sparsity Test       |            1              1      2.4s
  RootFinding solver                     |   169              5    174   4m52.0s
```

Additional local checks:

```text
$ GROUP=QA julia +1.12 --startup-file=no --project=../solver-stack-env -e 'using Pkg; Pkg.test("Symbolics")'
Testing Symbolics tests passed

$ julia +1.12 --startup-file=no --project=../formatter-env -m Runic --check src/solver/main.jl test/solver.jl
$ typos src/solver/main.jl test/solver.jl
$ git diff --check
```

The last three commands exited successfully without output.

## Regression boundary

The recursive single-factor condition was introduced by the Symbolics commit linked below. Its parent returned the reduced polynomial as `RootsOf` in 13.912763 seconds. The dependency behavior that exposes the latent bug begins at the tested Nemo version boundary: Nemo 0.47.5 terminates, while 0.48.0, 0.48.1, 0.49.5, 0.52.4, 0.56.0, and 0.56.1 return alternating unit/factor representations for this polynomial. This is valid factorization behavior; consuming Nemo's unit in Symbolics is the scoped fix.

## Not verified

Docs were not built because this changes no docstring, rendered documentation, or public API. GPU, downstream, and allowed-to-fail jobs were not run locally. No dependency or license changes are included.

Reviewer focus: `is_unfactored` reconstructs only a single factor with Nemo's unit for the progress check. Multi-factor root handling is unchanged.

## Links

- Original solver task context: https://github.com/JuliaSymbolics/Symbolics.jl/issues/1961
- PreallocationTools base-failure fix: https://github.com/JuliaSymbolics/Symbolics.jl/pull/1964
- Commit that introduced recursive single-factor handling: https://github.com/JuliaSymbolics/Symbolics.jl/commit/a94771b7b83241f564ad613d899da923bfa4e1c9
- First tested Nemo version exposing the alternating factor form: https://github.com/Nemocas/Nemo.jl/releases/tag/v0.48.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47
