### PR TITLE
Fix PreallocationTools symbolic dual cache dispatch

### DIFF
--- a/ext/SymbolicsPreallocationToolsExt.jl
+++ b/ext/SymbolicsPreallocationToolsExt.jl
@@ -1,49 +1,37 @@
 module SymbolicsPreallocationToolsExt
 
 using PreallocationTools
-import PreallocationTools: _restructure, get_tmp
+import PreallocationTools: get_tmp
 using Symbolics, ForwardDiff
 
-function get_tmp(dc::DiffCache, u::Type{X}) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function _symbolic_tmp(dc::C, u::Type{X}) where {
+        C <: Union{DiffCache, FixedSizeDiffCache}, X <: ForwardDiff.Dual,
+    }
+    return invoke(get_tmp, Tuple{C, Type{Y} where {Y <: Number}}, dc, u)
 end
 
-function get_tmp(dc::DiffCache, u::X) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function get_tmp(dc::DiffCache, u::Type{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return _symbolic_tmp(dc, u)
 end
 
-function get_tmp(dc::DiffCache, u::AbstractArray{X}) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function get_tmp(dc::DiffCache, u::X) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return get_tmp(dc, X)
 end
 
-function get_tmp(dc::FixedSizeDiffCache, u::Type{X}) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function get_tmp(dc::DiffCache, u::AbstractArray{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return get_tmp(dc, X)
 end
 
-function get_tmp(dc::FixedSizeDiffCache, u::X) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function get_tmp(dc::FixedSizeDiffCache, u::Type{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return _symbolic_tmp(dc, u)
 end
 
-function get_tmp(dc::FixedSizeDiffCache, u::AbstractArray{X}) where {T,N, X<: ForwardDiff.Dual{T, Num, N}}
-    if length(dc.du) > length(dc.any_du)
-        resize!(dc.any_du, length(dc.du))
-    end
-    _restructure(dc.du, dc.any_du)
+function get_tmp(dc::FixedSizeDiffCache, u::X) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return get_tmp(dc, X)
+end
+
+function get_tmp(dc::FixedSizeDiffCache, u::AbstractArray{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+    return get_tmp(dc, X)
 end
 
 end

--- a/test/nested_forwarddiff_sparsity.jl
+++ b/test/nested_forwarddiff_sparsity.jl
@@ -21,3 +21,17 @@ cache = DiffCache(zeros(2))
 pattern = Symbolics.jacobian_sparsity((r, x) -> residual(r, x, cache), zeros(2), zeros(2))
 @test pattern == sparse([1 0
                          0 1])
+
+@testset "symbolic dual cache methods" begin
+    dual_type = ForwardDiff.Dual{Nothing, Num, 2}
+    dual = dual_type(Num(1), ForwardDiff.Partials((Num(1), Num(0))))
+    duals = fill(dual, 2)
+
+    for cache in (DiffCache(zeros(2)), FixedSizeDiffCache(zeros(2), 2))
+        for input in (dual, dual_type, duals)
+            workspace = get_tmp(cache, input)
+            workspace .= duals
+            @test get_tmp(cache, input) == duals
+        end
+    end
+end


### PR DESCRIPTION
Fixes the Nested ForwardDiff Sparsity Test against PreallocationTools v1.5+ by delegating symbolic-dual workspace allocation to the public `PreallocationTools.get_tmp` API. This avoids direct reads of the removed `any_du` field and use of the internal `_restructure` helper. Adds regression coverage for `DiffCache` and `FixedSizeDiffCache` with scalar, type, and array dual inputs.

Fixes the test failure reported on https://github.com/JuliaSymbolics/Symbolics.jl/pull/1951.

## Verification

Before the fix, using Symbolics `master` with PreallocationTools 1.6.0 failed:

```
ERROR: LoadError: FieldError: type DiffCache has no field `any_du`, available fields: `du`, `dual_du`, `typed_du`, `warn_on_resize`
```

After the fix, the same regression test passed with PreallocationTools 1.6.0:

```
Test Summary:               | Pass  Total  Time
symbolic dual cache methods |    6      6  0.4s
nested ForwardDiff sparsity passed
```

`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` passed: 17,128 passing assertions, 382 existing broken tests, plus all three SymbolicIndexingInterface suites.\n\n`typos ext/SymbolicsPreallocationToolsExt.jl test/nested_forwarddiff_sparsity.jl` and `git diff --no-ext-diff upstream/master...HEAD | typos -` passed.\n\nNot run: no QA group or repository formatter is configured; docs were unchanged.\n\nPlease ignore this PR until reviewed by @ChrisRackauckas.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nhttps://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47