### PR TITLE
Simplify symbolic PreallocationTools cache dispatch

### DIFF
--- a/ext/SymbolicsPreallocationToolsExt.jl
+++ b/ext/SymbolicsPreallocationToolsExt.jl
@@ -4,34 +4,25 @@ using PreallocationTools
 import PreallocationTools: get_tmp
 using Symbolics, ForwardDiff
 
-function _symbolic_tmp(dc::C, u::Type{X}) where {
-        C <: Union{DiffCache, FixedSizeDiffCache}, X <: ForwardDiff.Dual,
-    }
-    return invoke(get_tmp, Tuple{C, Type{Y} where {Y <: Number}}, dc, u)
+function _symbolic_tmp(dc::C,
+        u::Union{X, Type{X}, AbstractArray{X}}) where {
+        C <: Union{DiffCache, FixedSizeDiffCache}, X <: ForwardDiff.Dual
+}
+    return invoke(get_tmp, Tuple{C, Type{Y} where {Y <: Number}}, dc, X)
 end
 
-function get_tmp(dc::DiffCache, u::Type{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+function get_tmp(dc::DiffCache,
+        u::Union{X, Type{X}, AbstractArray{X}}) where {
+        T, N, X <: ForwardDiff.Dual{T, Num, N}
+}
     return _symbolic_tmp(dc, u)
 end
 
-function get_tmp(dc::DiffCache, u::X) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
-    return get_tmp(dc, X)
-end
-
-function get_tmp(dc::DiffCache, u::AbstractArray{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
-    return get_tmp(dc, X)
-end
-
-function get_tmp(dc::FixedSizeDiffCache, u::Type{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
+function get_tmp(dc::FixedSizeDiffCache,
+        u::Union{X, Type{X}, AbstractArray{X}}) where {
+        T, N, X <: ForwardDiff.Dual{T, Num, N}
+}
     return _symbolic_tmp(dc, u)
-end
-
-function get_tmp(dc::FixedSizeDiffCache, u::X) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
-    return get_tmp(dc, X)
-end
-
-function get_tmp(dc::FixedSizeDiffCache, u::AbstractArray{X}) where {T, N, X <: ForwardDiff.Dual{T, Num, N}}
-    return get_tmp(dc, X)
 end
 
 end


### PR DESCRIPTION
Simplifies the Symbolics dispatch override added in https://github.com/JuliaSymbolics/Symbolics.jl/pull/1967 from six overloads to two cache-specific overloads and one shared helper. The override remains necessary: PreallocationTools' generic ForwardDiff methods attempt to reinterpret `Dual{..., Num, ...}` storage, but `Num` is not an isbits type.

Please ignore this PR until reviewed by @ChrisRackauckas.

## Verification

- `julia --startup-file=no test/nested_forwarddiff_sparsity.jl`
  - `symbolic dual cache methods | 6 pass, total 6`
- `GROUP=Core julia --project -e 'using Pkg; Pkg.test()'`
  - `test set | 17125 pass, 368 broken, 17493 total`
  - `Testing Symbolics tests passed`
- `GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`
  - `Testing Symbolics tests passed`
- JuliaFormatter SciML style check and `typos ext/SymbolicsPreallocationToolsExt.jl test/nested_forwarddiff_sparsity.jl` passed.

## Regression discrimination

With all Symbolics-specific `get_tmp` methods removed in an isolated Julia process, the new test fails. The dynamic-cache assertions return the unchanged zero workspace; `FixedSizeDiffCache` errors with `ArgumentError: cannot reinterpret ForwardDiff.Dual{Nothing, Float64, 2} as ForwardDiff.Dual{Nothing, Num, 2}, type ForwardDiff.Dual{Nothing, Num, 2} is not a bits type`. With this two-method override applied, the same test passes all six value/type/array and cache combinations.

## Not verified

No docs build was run because this changes neither docs nor public API. GPU and downstream jobs were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a04-70ae-77a0-ba1b-ec7a1ed9ef47