### PR TITLE
Fix @register_array_symbolic escaping bare @wrapped into callers

### DIFF
--- a/src/register.jl
+++ b/src/register.jl
@@ -146,7 +146,7 @@ function register_array_symbolic(f, ftype, argnames, Ts, ret_type, partial_defs 
     symbolicT = Union{BasicSymbolic{VartypeT}, AbstractArray{BasicSymbolic{VartypeT}}}
     assigns = macroexpand(@__MODULE__, :(Base.Cartesian.@nexprs $N i -> ($argnames[i] = args[i])))
     fexpr = quote
-        @wrapped function $f($(args′...))
+        Symbolics.@wrapped function $f($(args′...))
             args = ($(argnames...),)
             if Base.Cartesian.@nany $N i -> args[i] isa $symbolicT
                 args = Base.Cartesian.@ntuple $N i -> $Const{$VartypeT}(args[i])

--- a/src/register.jl
+++ b/src/register.jl
@@ -37,7 +37,7 @@ macro register_symbolic(expr, define_promotion = true, wrap_arrays = true)
             $f($(argnames...))
         end
     end)
-    fexpr = macroexpand(@__MODULE__, :(@wrapped $inner $wrap_arrays))
+    fexpr = wrap_func_expr(__module__, inner, wrap_arrays)
 
     if define_promotion
         type_args = [:($name::$Type) for name in argnames]
@@ -120,7 +120,7 @@ symbolic_eltype(x::AbstractArray{BasicSymbolic{T}}) where {T} = eltype(symtype(C
 symbolic_eltype(::AbstractArray{Num}) = Real
 symbolic_eltype(::AbstractArray{symT}) where {eT, symT <: Arr{eT}} = eT
 
-function register_array_symbolic(f, ftype, argnames, Ts, ret_type, partial_defs = :(), define_promotion = true, wrap_arrays = true)
+function register_array_symbolic(f, ftype, argnames, Ts, ret_type, partial_defs = :(), define_promotion = true, wrap_arrays = true, caller = @__MODULE__)
     def_assignments = MacroTools.rmlines(partial_defs).args
     defs = map(def_assignments) do ex
         @assert ex.head == :(=)
@@ -163,7 +163,7 @@ function register_array_symbolic(f, ftype, argnames, Ts, ret_type, partial_defs 
             $f($(argnames...))
         end
     end)
-    fexpr = macroexpand(@__MODULE__, :(@wrapped $inner $wrap_arrays))
+    fexpr = wrap_func_expr(caller, inner, wrap_arrays)
 
     if define_promotion
         is_callable_struct = f isa Expr && f.head == :(::)
@@ -214,7 +214,7 @@ function register_array_symbolic(f, ftype, argnames, Ts, ret_type, partial_defs 
                     $promote_shape_body
                 end
             end
-        end |> esc
+        end
         fexpr = :($fexpr; $promote_expr)
     end
 
@@ -255,5 +255,5 @@ overwriting.
 """
 macro register_array_symbolic(expr, block, define_promotion = true, wrap_arrays = true)
     f, ftype, argnames, Ts, ret_type = destructure_registration_expr(expr)
-    register_array_symbolic(f, ftype, argnames, Ts, ret_type, block, define_promotion, wrap_arrays)
+    esc(register_array_symbolic(f, ftype, argnames, Ts, ret_type, block, define_promotion, wrap_arrays, __module__))
 end

--- a/src/register.jl
+++ b/src/register.jl
@@ -28,7 +28,7 @@ macro register_symbolic(expr, define_promotion = true, wrap_arrays = true)
     ret_type = isnothing(ret_type) ? Real : ret_type
     N = length(args′)
     symbolicT = Union{BasicSymbolic{VartypeT}, AbstractArray{BasicSymbolic{VartypeT}}}
-    fexpr = :(Symbolics.@wrapped function $f($(args′...))
+    inner = :(function $f($(args′...))
         args = ($(argnames...),)
         if Base.Cartesian.@nany $N i -> args[i] isa $symbolicT
             args = Base.Cartesian.@ntuple $N i -> $Const{$VartypeT}(args[i])
@@ -36,7 +36,8 @@ macro register_symbolic(expr, define_promotion = true, wrap_arrays = true)
         else
             $f($(argnames...))
         end
-    end $wrap_arrays)
+    end)
+    fexpr = macroexpand(@__MODULE__, :(@wrapped $inner $wrap_arrays))
 
     if define_promotion
         type_args = [:($name::$Type) for name in argnames]
@@ -145,25 +146,24 @@ function register_array_symbolic(f, ftype, argnames, Ts, ret_type, partial_defs 
     N = length(args′)
     symbolicT = Union{BasicSymbolic{VartypeT}, AbstractArray{BasicSymbolic{VartypeT}}}
     assigns = macroexpand(@__MODULE__, :(Base.Cartesian.@nexprs $N i -> ($argnames[i] = args[i])))
-    fexpr = quote
-        Symbolics.@wrapped function $f($(args′...))
-            args = ($(argnames...),)
-            if Base.Cartesian.@nany $N i -> args[i] isa $symbolicT
-                args = Base.Cartesian.@ntuple $N i -> $Const{$VartypeT}(args[i])
-                $assigns
-                $shape_expr
-                eltype = $eltype ∘ $symtype
-                type = if nd == -1
-                    $container_type{$eltype_expr}
-                else
-                    $container_type{$eltype_expr, nd}
-                end
-                $Term{$VartypeT}($f, $(SymbolicUtils.ArgsT){$VartypeT}(args); type, shape = sh)
+    inner = :(function $f($(args′...))
+        args = ($(argnames...),)
+        if Base.Cartesian.@nany $N i -> args[i] isa $symbolicT
+            args = Base.Cartesian.@ntuple $N i -> $Const{$VartypeT}(args[i])
+            $assigns
+            $shape_expr
+            eltype = $eltype ∘ $symtype
+            type = if nd == -1
+                $container_type{$eltype_expr}
             else
-                $f($(argnames...))
+                $container_type{$eltype_expr, nd}
             end
-        end $wrap_arrays
-    end |> esc
+            $Term{$VartypeT}($f, $(SymbolicUtils.ArgsT){$VartypeT}(args); type, shape = sh)
+        else
+            $f($(argnames...))
+        end
+    end)
+    fexpr = macroexpand(@__MODULE__, :(@wrapped $inner $wrap_arrays))
 
     if define_promotion
         is_callable_struct = f isa Expr && f.head == :(::)

--- a/src/wrapper-types.jl
+++ b/src/wrapper-types.jl
@@ -272,7 +272,7 @@ function wrap_func_expr(mod, expr, wrap_arrays = true)
     quote
         $impl
         $(methods...)
-    end |> esc
+    end
 end
 
 """
@@ -336,5 +336,5 @@ See also: [`@symbolic_wrap`](@ref), [`Symbolics.wrap`](@ref),
 [`SymbolicUtils.unwrap`](https://symbolicutils.juliasymbolics.org/api/#SymbolicUtils.unwrap).
 """
 macro wrapped(expr, wrap_arrays = true)
-    wrap_func_expr(__module__, expr, wrap_arrays)
+    esc(wrap_func_expr(__module__, expr, wrap_arrays))
 end

--- a/test/registration_without_using.jl
+++ b/test/registration_without_using.jl
@@ -1,5 +1,15 @@
+module RegistrationWithoutUsingImport
 import Symbolics
 Symbolics.@register_symbolic foo(x, y)
 Symbolics.@register_array_symbolic bar(x::AbstractVector) begin
     size = (length(x), length(x))
 end false
+end
+
+module RegistrationWithoutUsingSelective
+import Symbolics: @register_array_symbolic, @register_symbolic
+@register_symbolic goo(x, y)
+@register_array_symbolic hoo(x::AbstractVector) begin
+    size = (length(x), length(x))
+end false
+end

--- a/test/registration_without_using.jl
+++ b/test/registration_without_using.jl
@@ -1,1 +1,5 @@
-import Symbolics;Symbolics.@register_symbolic foo(x, y)
+import Symbolics
+Symbolics.@register_symbolic foo(x, y)
+Symbolics.@register_array_symbolic bar(x::AbstractVector) begin
+    size = (length(x), length(x))
+end false

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -69,6 +69,13 @@ end
     @test @doc(Symbolics.NAMESPACE_SEPARATOR) !== nothing
     @test @doc(Symbolics.get_variables!) !== nothing
     @test @doc(Symbolics.map_subscripts) !== nothing
+    @test @doc(Symbolics.@symbolic_wrap) !== nothing
+    @test @doc(Symbolics.@wrapped) !== nothing
+end
+
+@testset "wrapper macro public API" begin
+    VERSION >= v"1.11" && @test Base.ispublic(Symbolics, Symbol("@symbolic_wrap"))
+    VERSION >= v"1.11" && @test Base.ispublic(Symbolics, Symbol("@wrapped"))
 end
 
 @testset "fixpoint_sub warn_maxiters" begin


### PR DESCRIPTION
## Summary
- Qualify `@wrapped` as `Symbolics.@wrapped` in `@register_array_symbolic`, matching `@register_symbolic`
- Downstream packages (e.g. MethodOfLines) no longer need to import `@wrapped` when calling `@register_array_symbolic`
- Add regression test and public API docstring/`ispublic` checks for `@wrapped` / `@symbolic_wrap`

Fixes the upstream issue discussed in https://github.com/SciML/MethodOfLines.jl/pull/667#discussion_r3872792914

## Test plan
- [x] Smoke test: `@register_array_symbolic` works with only `import Symbolics`
- [x] `@wrapped` is public and has a docstring

Made with [Cursor](https://cursor.com)