### PR TITLE
Release 7.38.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.37.0"
+version = "7.38.0"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]


### PR DESCRIPTION
Release the accumulated source changes: strict API QA with an explicit reexport surface, the obsolete PreallocationTools extension removal, Complex{Num} scalar-symbolic inference, and the @register_array_symbolic hygiene fix that unblocks MethodOfLines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R