### PR TITLE
Require SymbolicUtils 4.46.2 so `dims` reductions stop corrupting their argument

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.39.0"
+version = "7.39.1"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]
@@ -116,7 +116,7 @@ SymPy = "2.2"
 SymPyPythonCall = "0.5"
 SymbolicIndexingInterface = "0.3.14"
 SymbolicLimits = "1.1"
-SymbolicUtils = "4.37"
+SymbolicUtils = "4.46.2"
 TermInterface = "2"
 julia = "1.10"
 Libdl = "1"

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -671,3 +671,28 @@ end
     @test build_function(x in 1:3, x; expression = Val{false})(5) === false
     @test build_function(x in 1:3, x; expression = Val{false})(2) === true
 end
+
+@testset "Issue#1975: `dims` reductions do not mutate their argument's shape" begin
+    @variables A[1:5, 1:4] W[1:3, 1:4, 1:5]
+    reductions = [
+        "sum(A, dims = 1)" => (A, x -> sum(x, dims = 1), (1, 4)),
+        "sum(A, dims = 2)" => (A, x -> sum(x, dims = 2), (5, 1)),
+        "sum(sin, A, dims = 1)" => (A, x -> sum(sin, x, dims = 1), (1, 4)),
+        "prod(A, dims = 2)" => (A, x -> prod(x, dims = 2), (5, 1)),
+        "maximum(A, dims = 1)" => (A, x -> maximum(x, dims = 1), (1, 4)),
+        "minimum(A, dims = 2)" => (A, x -> minimum(x, dims = 2), (5, 1)),
+        "mapreduce(sin, +, A, dims = 2)" => (A, x -> mapreduce(sin, +, x, dims = 2), (5, 1)),
+        "sum(W, dims = 3)" => (W, x -> sum(x, dims = 3), (3, 4, 1)),
+    ]
+    @testset "$name" for (name, (x, f, sz)) in reductions
+        before = copy(shape(unwrap(x)))
+        @test size(f(x)) == sz
+        @test shape(unwrap(x)) == before
+    end
+
+    @variables C[1:5, 1:4] D[1:5, 1:4]
+    sum(C, dims = 1)
+    sum(C, dims = 2)
+    @test size(C[1:5, 1:4]) == (5, 4)
+    @test_nowarn C ~ D
+end


### PR DESCRIPTION
> 🚧 **Ignore until reviewed by @ChrisRackauckas.** Opened as a draft by an AI agent; not ready to merge.

Fixes #1975.

## What changed and why

`sum(x; dims = k)` on a symbolic array silently rewrote `x`'s own shape metadata to the shape of the *result*. The return value was correct, so nothing looked wrong at the call site — the damage only surfaced later, as an indexing error, an "arrays of different sizes" equation error, or a failed system build, always pointing at code other than the `sum` that caused it.

The root cause is upstream: `promote_shape(::Mapreducer, ...)` in SymbolicUtils mutated the shape vector it was handed, which for a single-argument `mapreduce(...; dims)` is the argument's own shape vector. That was fixed in SymbolicUtils 4.46.2 (JuliaSymbolics/SymbolicUtils.jl#1041). Symbolics' compat, however, was still `SymbolicUtils = "4.37"`, so a resolve could — and by default did, for the reporter — land on a corrupting version.

This PR raises the compat lower bound to `4.46.2` and adds a regression test so the behavior is pinned at the Symbolics level rather than only upstream.

## Verification

Reproducer from the issue, on the versions the issue reports (Symbolics 7.39.0, SymbolicUtils **4.46.1**):

```
shape before : UnitRange{Int64}[1:5, 1:4]
sum size     : (5, 1)
shape after  : UnitRange{Int64}[1:5, 1:1]
A[1:5,1:4]   : throws -> ArgumentError("Tried to index array whose `2`th dimension has shape 1:1 with index 1:4.")
```

Same script with SymbolicUtils **4.46.2**:

```
shape before : UnitRange{Int64}[1:5, 1:4]
sum size     : (5, 1)
shape after  : UnitRange{Int64}[1:5, 1:4]
A[1:5,1:4]   : ok
```

### New test fails without the fix

The new testset, run against a checkout with the compat bump reverted and SymbolicUtils pinned to 4.46.1:

```
Test Summary:                                                      | Pass  Fail  Error  Total  Time
Issue#1975: `dims` reductions do not mutate their argument's shape |    7     9      2     18  8.1s
  sum(A, dims = 1)                                                 |    1     1             2  3.4s
  sum(A, dims = 2)                                                 |          2             2  0.1s
  sum(sin, A, dims = 1)                                            |    1     1             2  0.2s
  prod(A, dims = 2)                                                |    1     1             2  0.3s
  maximum(A, dims = 1)                                             |    1     1             2  0.2s
  minimum(A, dims = 2)                                             |    1     1             2  0.3s
  mapreduce(sin, +, A, dims = 2)                                   |    1     1             2  0.3s
  sum(W, dims = 3)                                                 |    1     1             2  0.0s
ERROR: LoadError: Some tests did not pass: 7 passed, 9 failed, 2 errored, 0 broken.
```

Representative failures:

```
sum(A, dims = 1): Test Failed
  Expression: shape(unwrap(x)) == before
   Evaluated: UnitRange{Int64}[1:1, 1:4] == UnitRange{Int64}[1:5, 1:4]

sum(A, dims = 2): Test Failed
  Expression: size(f(x)) == sz
   Evaluated: (1, 1) == (5, 1)

Got exception outside of a @test
  ArgumentError: Cannot equate an array of different sizes. Got (1, 1) and (5, 4).
```

Note the second one: once `A` is corrupted, even the *return value* of the next reduction is wrong, so this is not purely a metadata nuisance.

### And passes with it

```
Test Summary:                                                      | Pass  Total  Time
Issue#1975: `dims` reductions do not mutate their argument's shape |   18     18  3.1s
```

### Full local runs on this branch

`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'`:

```
Test Summary: |  Pass  Broken  Total      Time
test set      | 17403     362  17765  16m56.2s
...
     Testing Symbolics tests passed
```

(The 362 broken are pre-existing `@test_broken`s; no new ones added.)

`GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`:

```
Test Summary:     | Pass  Total     Time
Quality Assurance |   20     20  1m01.1s
     Testing Symbolics tests passed
```

`typos` clean on the diff; Runic reports no changes for the added block. (The rest of `test/arrays.jl` has pre-existing Runic drift, deliberately left alone — formatting sweeps belong in their own PR.)

Julia 1.12.7, x86_64-linux.

## Not verified

- **Docs build** — not run. The diff touches no docstring, no `docs/`, and no public API, so `docs/make.jl` has nothing new to render.
- **Downstream / GPU / `julia pre`** — not run locally. The compat bump is a lower-bound raise, so downstream packages that pin an older SymbolicUtils alongside Symbolics will now resolve differently; that is the intended effect but CI's Downstream job is the real check.

## Worth pushing back on

- **Version bump choice.** I bumped `7.39.0 → 7.39.1`. Raising a compat lower bound is not breaking for Symbolics' own API, but it does change what resolves for users, so if you'd rather this be `7.40.0`, say so.
- **Whether a Symbolics-side guard is also wanted.** I did not add a defensive `copy` in Symbolics; `src/array-lib.jl` only forwards to `Base.mapreduce`, and the bug was genuinely upstream. The compat bound is the whole mechanism preventing recurrence here.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_0182uUKf5s4tJUvwAPz8D6Yh
