### PR TITLE
Add 32-bit (x86) Core CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,38 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           file: lcov.info
+
+  test-x86:
+    name: Core (julia 1, ubuntu-latest, x86)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: |
+          if [ "`git rev-parse --abbrev-ref HEAD`" != master ]; then git fetch origin master:master; fi
+      - name: Install 32-bit runtime libraries (i386)
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libc6:i386 libstdc++6:i386 libgcc-s1:i386 libatomic1:i386
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+          arch: x86
+      - uses: actions/cache@v6
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-x86-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-x86-${{ env.cache-name }}-
+            ${{ runner.os }}-test-x86-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        env:
+          GROUP: Core
+        with:
+          force_latest_compatible_version: 'false'


### PR DESCRIPTION
## Summary
- Add an Ubuntu `arch: x86` Core job with i386 libs installed before `setup-julia`.
- Part of getting 32-bit testing across the SciML / JuliaSymbolics stack (pairs with SymbolicUtils#1060).

## Test plan
- [ ] Existing matrix unchanged / green
- [ ] New Core x86 job runs and reports a clear pass/fail

Made with [Cursor](https://cursor.com)