### PR TITLE
Require SymbolicUtils 4.46.4 (32-bit hasha_seed)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,7 +37,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 SymbolicLimits = "19f23fe9-fdab-4a78-91af-e7b7767979c3"
-SymbolicUtils = "4.46.4"
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 
 [weakdeps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Symbolics"
 uuid = "0c5d862f-8b57-4792-8d23-62f2024744c7"
-version = "7.39.1"
+version = "7.39.2"
 authors = ["Shashi Gowda <gowda@mit.edu>"]
 
 [deps]
@@ -37,7 +37,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 SymbolicLimits = "19f23fe9-fdab-4a78-91af-e7b7767979c3"
-SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
+SymbolicUtils = "4.46.4"
 TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 
 [weakdeps]
@@ -116,7 +116,7 @@ SymPy = "2.2"
 SymPyPythonCall = "0.5"
 SymbolicIndexingInterface = "0.3.14"
 SymbolicLimits = "1.1"
-SymbolicUtils = "4.46.3"
+SymbolicUtils = "4.46.4"
 TermInterface = "2"
 julia = "1.10"
 Libdl = "1"


### PR DESCRIPTION
## Summary
- Bump SymbolicUtils lower bound to **4.46.4**, which truncates `Base.hasha_seed` with `% UInt` so i686 precompile no longer hits `InexactError: trunc(UInt32, …)`.
- Patch version **7.39.2**.

Blocked on [General#167570](https://github.com/JuliaRegistries/General/pull/167570) merging first; do not register until 4.46.4 is in the registry.

## Test plan
- [ ] CI green after 4.46.4 is resolvable
- [ ] Register 7.39.2 after merge

Made with [Cursor](https://cursor.com)