### PR TITLE
ci: use latest QuantumSavory Buildkite plugins

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 steps:
   - label: "Julia 1"
     plugins:
-      - JuliaCI/julia#v1:
+      - QuantumSavory/julia#v1.14:
           version: "1"
       - JuliaCI/julia-test#v1:
            coverage: false # 1000x slowdown


### PR DESCRIPTION
Use [QuantumSavory/julia v1.14](https://github.com/QuantumSavory/julia-buildkite-plugin/tree/v1.14) for all Julia setup steps in Buildkite. This tagged fork includes the Julia prerelease selection, macOS Bash 3.2, and Cygwin fixes.

Validation: parsed all Buildkite YAML files, checked that the parsed pipelines differ only in the selected plugin keys, and ran `git diff --check`. Verified the selected tags against the QuantumSavory fork heads. Julia/package suites and hosted Buildkite jobs were not run locally; this change only updates plugin references.
